### PR TITLE
Add hammerdbrun to run command line scripts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -860,3 +860,9 @@ Bug fixes
 [#131] Duplicate Files with incorrect prefix in MySQL and Redis Directories
 
 Added Oracle Database Metrics based on Ashmon by Kyle Hailey, used with permission to add as GPLv3
+
+---------------------------------------------------------------------
+
+Version 3.1a Jul 2019
+
+Add command line tool hammerdbrun to run command line scripts

--- a/hammerdbrun
+++ b/hammerdbrun
@@ -1,0 +1,67 @@
+#!/bin/sh
+#########################################################################
+## \
+export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH
+## \
+export PATH=./bin:$PATH
+## \
+exec ./bin/tclsh8.6 "$0" ${1+"$@"}
+########################################################################
+# HammerDB
+# Copyright (C) 2003-2018 Steve Shaw
+# Author contact information at: http://www.hammerdb.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public
+# License along with this program; If not, see <https://www.gnu.org/licenses/>
+########################################################################
+global hdb_version
+set hdb_version "v3.1"
+puts "HammerDB CLI $hdb_version"
+puts "Copyright (C) 2003-2018 Steve Shaw"
+puts "Type \"help\" for a list of commands"
+set UserDefaultDir [ file dirname [ info script ] ]
+::tcl::tm::path add "$UserDefaultDir/modules"
+
+append modulelist { Thread msgcat xml tclreadline }
+for { set modcount 0 } { $modcount < [llength $modulelist] } { incr modcount } {
+    set m [lindex $modulelist $modcount]
+		set loadtext $m
+	if [catch { package require $m }] {
+                puts stderr "While loading module\
+                        \"$m\"...\n$errorInfo"
+                exit 1
+        }
+    }
+
+append loadlist { gendict.tcl genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl geninitcli.tcl gencli.tcl }
+for { set loadcount 0 } { $loadcount < [llength $loadlist] } { incr loadcount } {
+    set f [lindex $loadlist $loadcount]
+		set loadtext $f
+	if [catch {source [ file join $UserDefaultDir src generic $f ]}] {
+                puts stderr "While loading component file\
+                        \"$f\"...\n$errorInfo"
+                exit 1
+        }
+    }
+
+for { set dbsrccount 0 } { $dbsrccount < [llength $dbsrclist] } { incr dbsrccount } {
+    set f [lindex $dbsrclist $dbsrccount]
+		set loadtext $f
+	if [catch {source [ file join $UserDefaultDir src $f ]}] {
+                puts stderr "Error loading database source files/$f"
+        }
+    }
+
+for { set paramcount 0 } { $paramcount < $argc} { incr paramcount } {
+    source [ lindex $argv $paramcount ]
+}

--- a/hammerdbrun.bat
+++ b/hammerdbrun.bat
@@ -1,0 +1,2 @@
+@echo off
+.\bin\tclsh86t hammerdbcli


### PR DESCRIPTION
Add command line tool to run command line scripts directly instead of typing commands by hand.
This is mainly for Windows, as using pipe for standard input does not work on Windows.