### PR TITLE
Allow passing in extra parameters for the user script

### DIFF
--- a/hammerdb
+++ b/hammerdb
@@ -35,7 +35,7 @@ set UserDefaultDir [ file dirname [ info script ] ]
 namespace eval autostart {
     set autostartap "false"
     if {$argc == 0} { ; } else {
-    if {$argc != 2 || [lindex $argv 0] != "auto" } {
+    if {$argc < 2 || [lindex $argv 0] != "auto" } {
 puts {Usage: hammerdb [ auto [ script_to_autoload.tcl  ] ]}
 exit
 	} else {

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -35,7 +35,7 @@ set UserDefaultDir [ file dirname [ info script ] ]
 namespace eval autostart {
     set autostartap "false"
     if {$argc == 0} { ; } else {
-    if {$argc != 2 || [lindex $argv 0] != "auto" } {
+    if {$argc < 2 || [lindex $argv 0] != "auto" } {
 puts {Usage: hammerdbcli [ auto [ script_to_autoload.tcl  ] ]}
 exit
 	} else {

--- a/hammerdbcli.bat
+++ b/hammerdbcli.bat
@@ -1,4 +1,3 @@
 @echo off
 set path=.\bin;%PATH%
-START tclsh86t hammerdbcli %1 %2
-exit
+tclsh86t hammerdbcli %1 %2

--- a/hammerdbws.bat
+++ b/hammerdbws.bat
@@ -1,5 +1,3 @@
 @echo off
 set path=.\bin;%PATH%
-START tclsh86t hammerdbws
-exit
-
+tclsh86t hammerdbws


### PR DESCRIPTION
I changed the command line parameter validation, to allow passing in extra parameters, so in the user script, we can get more flexibility to make use of the extra parameters, instead of changing user script every time.

For example, I can use it like this:
`bin\tclsh86t.exe auto my-script.tcl server=server1 port=5432`
