### PR TITLE
Refactor Postgres procedural code for performance

### DIFF
--- a/src/generic/gentpcc.tcl
+++ b/src/generic/gentpcc.tcl
@@ -15,7 +15,7 @@ set wh [expr ((($myposition - 2) + ($addMore * $loadUserCount))%$w_id_input)+1]
 if {$addMore >= $whRequiredCount} {
 set addMore -1
 } else {
-puts "VU $myposition : Assigning WID=$wh based on VU count $loadUserCount, Warehouses = $w_id_input ($addMore out of $whRequiredCount)"
+puts "VU $myposition : Assigning WID=$wh based on VU count $loadUserCount, Warehouses = $w_id_input ([expr $addMore + 1] out of [ expr int($whRequiredCount)])"
 lappend myWarehouses $wh
 set addMore [expr $addMore + 1]
 }

--- a/src/generic/gentpcc.tcl
+++ b/src/generic/gentpcc.tcl
@@ -4,26 +4,22 @@ allwarehouse {
 #set additional text for all warehouses
 set allwt(1) {set allwarehouses "true";# Use all warehouses to increase I/O
 }
-set allwt(2) {#2.4.1.1 does not apply when allwarehouses is true 
+set allwt(2) {#2.4.1.1 does not apply when allwarehouses is true
 if { $allwarehouses == "true" } {
-set mypos [ expr $myposition -1 ]
-if { $mypos > $w_id_input  } { 
-set mymod [expr ($mypos % $w_id_input) ]
-if { $mymod eq 0 }  { set mymod $w_id_input } 
-lappend myWarehouses $mymod
-} else {
 set loadUserCount [expr $totalvirtualusers - 1]
 set myWarehouses {}
-lappend myWarehouses [expr $myposition - 1]
-set addMore 1
-while {$addMore > 0} {
-set wh [expr ($myposition - 1) + ($addMore * $loadUserCount)]
-if {$wh > $w_id_input || $wh eq 1} {
 set addMore 0
+set whRequiredCount [expr ceil(double($w_id_input)/double($loadUserCount))]
+while {$addMore >= 0} {
+set wh [expr ((($myposition - 2) + ($addMore * $loadUserCount))%$w_id_input)+1]
+if {$addMore >= $whRequiredCount} {
+set addMore -1
 } else {
+puts "VU $myposition : Assigning WID=$wh based on VU count $loadUserCount, Warehouses = $w_id_input ($addMore out of $whRequiredCount)"
 lappend myWarehouses $wh
 set addMore [expr $addMore + 1]
-}}}
+}
+}
 set myWhCount [llength $myWarehouses]
 }
 }
@@ -34,16 +30,16 @@ set w_id [lindex $myWarehouses [expr [RandomNumber 1 $myWhCount] -1]]
 set allwt(4) {global allwarehouses myposition totalvirtualusers
 }
 #search for insert points and insert functions
-set allwi(1) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#EDITABLE OPTIONS##################################################" end ] 
+set allwi(1) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#EDITABLE OPTIONS##################################################" end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $allwi(1) $allwt(1)
-set allwi(2) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "#2.4.1.1" $allwi(1) ] 
+set allwi(2) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "#2.4.1.1" $allwi(1) ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $allwi(2) $allwt(2)
 set allwi(3) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "set choice" $allwi(2) ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $allwi(3) $allwt(3)
 if { $db_async_scale } {
-set allwi(4) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "#EDITABLE OPTIONS##################################################" end ] 
+set allwi(4) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "#EDITABLE OPTIONS##################################################" end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $allwi(4)+1l $allwt(4)
-set allwi(5) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "promise::async" end ] 
+set allwi(5) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "promise::async" end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $allwi(5)+1l $allwt(4)
 	}
    }
@@ -56,9 +52,9 @@ set timept(2) {if {$timeprofile eq "true" && $myposition eq 2} {package require 
 set timept(3) {if {$timeprofile eq "true" && $myposition eq 2} {::etprof::printLiveInfo}
 }
 #search for insert points and insert functions
-set timepi(1) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#EDITABLE OPTIONS##################################################" end ] 
+set timepi(1) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#EDITABLE OPTIONS##################################################" end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $timepi(1) $timept(1)
-set timepi(2) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "default \{" end ] 
+set timepi(2) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "default \{" end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $timepi(2)+1l $timept(2)
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert end-2l $timept(3)
   }

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -475,196 +475,316 @@ no_w_id         IN INTEGER,
 no_max_w_id     IN INTEGER,
 no_d_id         IN INTEGER,
 no_c_id         IN INTEGER,
-no_o_ol_cnt             IN INTEGER,
-no_c_discount           INOUT NUMERIC,
-no_c_last               INOUT VARCHAR,
-no_c_credit             INOUT VARCHAR,
-no_d_tax                INOUT NUMERIC,
-no_w_tax                INOUT NUMERIC,
-no_d_next_o_id          INOUT INTEGER,
+no_o_ol_cnt     IN INTEGER,
+no_c_discount   INOUT NUMERIC,
+no_c_last       INOUT VARCHAR,
+no_c_credit     INOUT VARCHAR,
+no_d_tax        INOUT NUMERIC,
+no_w_tax        INOUT NUMERIC,
+no_d_next_o_id  INOUT INTEGER,
 tstamp          IN TIMESTAMP )
 AS $$
 DECLARE
-no_ol_supply_w_id       INTEGER;
-no_ol_i_id              NUMERIC;
-no_ol_quantity          NUMERIC;
-no_o_all_local          INTEGER;
-o_id                    INTEGER;
-no_i_name               VARCHAR(24);
-no_i_price              NUMERIC(5,2);
-no_i_data               VARCHAR(50);
-no_s_quantity           NUMERIC(6);
-no_ol_amount            NUMERIC(6,2);
-no_s_dist_01            CHAR(24);
-no_s_dist_02            CHAR(24);
-no_s_dist_03            CHAR(24);
-no_s_dist_04            CHAR(24);
-no_s_dist_05            CHAR(24);
-no_s_dist_06            CHAR(24);
-no_s_dist_07            CHAR(24);
-no_s_dist_08            CHAR(24);
-no_s_dist_09            CHAR(24);
-no_s_dist_10            CHAR(24);
-no_ol_dist_info         CHAR(24);
-no_s_data               VARCHAR(50);
-x                       NUMERIC;
-rbk                     NUMERIC;
+    no_s_quantity		NUMERIC;
+    no_o_all_local		SMALLINT;
+    rbk					SMALLINT;
+    item_id_array 		INT[];
+    supply_wid_array	SMALLINT[];
+    quantity_array		SMALLINT[];
+    order_line_array	SMALLINT[];
+    stock_dist_array	CHAR(24)[];
+    s_quantity_array	SMALLINT[];
+    price_array			NUMERIC(5,2)[];
+    amount_array		NUMERIC(5,2)[];
 BEGIN
---assignment below added due to error in appendix code
-no_o_all_local := 0;
-SELECT c_discount, c_last, c_credit, w_tax
-INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
-FROM customer, warehouse
-WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND
-customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
-UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
-o_id := no_d_next_o_id;
-INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
-INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
---#2.4.1.4
-rbk := round(DBMS_RANDOM(1,100));
---#2.4.1.5
-FOR loop_counter IN 1 .. no_o_ol_cnt
-LOOP
-IF ((loop_counter = no_o_ol_cnt) AND (rbk = 1))
-THEN
-no_ol_i_id := 100001;
-ELSE
-no_ol_i_id := round(DBMS_RANDOM(1,100000));
-END IF;
---#2.4.1.5.2
-x := round(DBMS_RANDOM(1,100));
-IF ( x > 1 )
-THEN
-no_ol_supply_w_id := no_w_id;
-ELSE
-no_ol_supply_w_id := no_w_id;
---no_all_local is actually used before this point so following not beneficial
-no_o_all_local := 0;
-WHILE ((no_ol_supply_w_id = no_w_id) AND (no_max_w_id != 1))
-LOOP
-no_ol_supply_w_id := round(DBMS_RANDOM(1,no_max_w_id));
-END LOOP;
-END IF;
---#2.4.1.5.3
-no_ol_quantity := round(DBMS_RANDOM(1,10));
-SELECT i_price, i_name, i_data INTO no_i_price, no_i_name, no_i_data
-FROM item WHERE i_id = no_ol_i_id;
-SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
-INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-IF ( no_s_quantity > no_ol_quantity )
-THEN
-no_s_quantity := ( no_s_quantity - no_ol_quantity );
-ELSE
-no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
-END IF;
-UPDATE stock SET s_quantity = no_s_quantity
-WHERE s_i_id = no_ol_i_id
-AND s_w_id = no_ol_supply_w_id;
+	no_o_all_local := 1;
+	SELECT c_discount, c_last, c_credit, w_tax
+	INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
+	FROM customer, warehouse
+	WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
 
-no_ol_amount := (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+	--#2.4.1.4
+	rbk := round(DBMS_RANDOM(1,100));
+	--#2.4.1.5
+	FOR loop_counter IN 1 .. no_o_ol_cnt
+	LOOP
+		IF ((loop_counter = no_o_ol_cnt) AND (rbk = 1))
+		THEN
+			item_id_array[loop_counter] := 100001;
+		ELSE
+			item_id_array[loop_counter] := round(DBMS_RANDOM(1,100000));
+		END IF;
 
-IF no_d_id = 1
-THEN
-no_ol_dist_info := no_s_dist_01;
+		--#2.4.1.5.2
+		IF ( round(DBMS_RANDOM(1,100)) > 1 )
+		THEN
+			supply_wid_array[loop_counter] := no_w_id;
+		ELSE
+			no_o_all_local := 0;
+			supply_wid_array[loop_counter] := 1 + MOD(CAST (no_w_id + round(DBMS_RANDOM(0,no_max_w_id-1)) AS INT), no_max_w_id);
+		END IF;
 
-ELSIF no_d_id = 2
-THEN
-no_ol_dist_info := no_s_dist_02;
+		--#2.4.1.5.3
+		quantity_array[loop_counter] := round(DBMS_RANDOM(1,10));
+		order_line_array[loop_counter] := loop_counter;
+	END LOOP;
 
-ELSIF no_d_id = 3
-THEN
-no_ol_dist_info := no_s_dist_03;
+	UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
 
-ELSIF no_d_id = 4
-THEN
-no_ol_dist_info := no_s_dist_04;
+	INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
+	INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);
 
-ELSIF no_d_id = 5
-THEN
-no_ol_dist_info := no_s_dist_05;
+	SELECT array_agg ( i_price )
+	INTO price_array
+	FROM UNNEST(item_id_array) item_id
+	LEFT JOIN item ON i_id = item_id;
 
-ELSIF no_d_id = 6
-THEN
-no_ol_dist_info := no_s_dist_06;
+	IF no_d_id = 1
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 2
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 3
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 4
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 5
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 6
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 7
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 8
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 9
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 10
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	END IF;
 
-ELSIF no_d_id = 7
-THEN
-no_ol_dist_info := no_s_dist_07;
+	INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+	SELECT no_d_next_o_id,
+		   no_d_id,
+		   no_w_id,
+		   data.line_number,
+		   data.item_id,
+		   data.supply_wid,
+		   data.quantity,
+		   data.amount,
+		   data.stock_dist
+	  FROM UNNEST(order_line_array,
+				   item_id_array,
+				   supply_wid_array,
+				   quantity_array,
+				   amount_array,
+				   stock_dist_array)
+		   AS data( line_number, item_id, supply_wid, quantity, amount, stock_dist);
 
-ELSIF no_d_id = 8
-THEN
-no_ol_dist_info := no_s_dist_08;
+	no_s_quantity := 0;
+	FOR loop_counter IN 1 .. no_o_ol_cnt
+	LOOP
+		no_s_quantity := no_s_quantity + CAST( amount_array[loop_counter] AS NUMERIC);
+	END LOOP;
 
-ELSIF no_d_id = 9
-THEN
-no_ol_dist_info := no_s_dist_09;
-
-ELSIF no_d_id = 10
-THEN
-no_ol_dist_info := no_s_dist_10;
-END IF;
-
-INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-VALUES (o_id, no_d_id, no_w_id, loop_counter, no_ol_i_id, no_ol_supply_w_id, no_ol_quantity, no_ol_amount, no_ol_dist_info);
-
-END LOOP;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
---Cannot commit before exception handler
-COMMIT;
+    EXCEPTION
+        WHEN serialization_failure OR deadlock_detected OR no_data_found
+            THEN ROLLBACK;
 END;
 $$
 LANGUAGE 'plpgsql';}
 set sql(3) {CREATE OR REPLACE PROCEDURE DELIVERY (
-d_w_id                IN INTEGER,
-d_o_carrier_id        IN  INTEGER,
+d_w_id          IN INTEGER,
+d_o_carrier_id  IN  INTEGER,
 tstamp          IN TIMESTAMP )
 AS $$
 DECLARE
-d_no_o_id               INTEGER;
-d_d_id                  INTEGER;
-d_c_id                  NUMERIC;
-d_ol_total              NUMERIC;
-loop_counter            INTEGER;
+loop_counter	SMALLINT;
+d_id_in_array	SMALLINT[] := ARRAY[1,2,3,4,5,6,7,8,9,10];
+d_id_array		SMALLINT[];
+o_id_array 		INT[];
+c_id_array 		INT[];
+order_count		SMALLINT;
+sum_amounts     NUMERIC[];
+
+customer_count INT;
 BEGIN
-FOR loop_counter IN 1 .. 10
-LOOP
-d_d_id := loop_counter;
-SELECT no_o_id INTO d_no_o_id FROM new_order WHERE no_w_id = d_w_id AND no_d_id = d_d_id ORDER BY no_o_id ASC LIMIT 1;
-DELETE FROM new_order WHERE no_w_id = d_w_id AND no_d_id = d_d_id AND no_o_id = d_no_o_id;
-SELECT o_c_id INTO d_c_id FROM orders
-WHERE o_id = d_no_o_id AND o_d_id = d_d_id AND
-o_w_id = d_w_id;
- UPDATE orders SET o_carrier_id = d_o_carrier_id
-WHERE o_id = d_no_o_id AND o_d_id = d_d_id AND
-o_w_id = d_w_id;
-UPDATE order_line SET ol_delivery_d = current_timestamp
-WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id AND
-ol_w_id = d_w_id;
-SELECT SUM(ol_amount) INTO d_ol_total
-FROM order_line
-WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
-AND ol_w_id = d_w_id;
-UPDATE customer SET c_balance = c_balance + d_ol_total
-WHERE c_id = d_c_id AND c_d_id = d_d_id AND
-c_w_id = d_w_id;
-RAISE NOTICE 'D: % O: % time %', d_d_id, d_no_o_id, tstamp;
-END LOOP;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
---Cannot commit before exception handler
-COMMIT;
-END; 
+	WITH new_order_delete AS (
+		DELETE
+		 FROM new_order as del_new_order
+		USING UNNEST(d_id_in_array) AS d_ids
+		WHERE no_d_id = d_ids
+		  AND no_w_id = d_w_id
+		  AND del_new_order.no_o_id = (select min (select_new_order.no_o_id)
+						   from new_order as select_new_order
+						  where no_d_id = d_ids
+							and no_w_id = d_w_id)
+		RETURNING del_new_order.no_o_id, del_new_order.no_d_id
+		)
+	SELECT array_agg(no_o_id), array_agg(no_d_id)
+	  FROM new_order_delete
+	  INTO o_id_array, d_id_array;
+
+	UPDATE orders
+	   SET o_carrier_id = d_o_carrier_id
+	  FROM UNNEST(o_id_array, d_id_array) AS ids(o_id, d_id)
+	 WHERE orders.o_id = ids.o_id
+	   AND o_d_id = ids.d_id
+	   AND o_w_id = d_w_id;
+
+	WITH order_line_update AS (
+        UPDATE order_line
+           SET ol_delivery_d = current_timestamp
+		  FROM UNNEST(o_id_array, d_id_array) AS ids(o_id, d_id)
+		 WHERE ol_o_id = ids.o_id
+           AND ol_d_id = ids.d_id
+           AND ol_w_id = d_w_id
+		RETURNING ol_d_id, ol_o_id, ol_amount
+		)
+	SELECT array_agg(ol_d_id), array_agg(c_id), array_agg(sum_amount)
+	  FROM ( SELECT ol_d_id,
+			       ( SELECT DISTINCT o_c_id FROM orders WHERE o_id = ol_o_id AND o_d_id = ol_d_id AND o_w_id = d_w_id) AS c_id,
+			        sum(ol_amount) AS sum_amount
+			   FROM order_line_update
+			  GROUP BY ol_d_id, ol_o_id ) AS inner_sum
+	  INTO d_id_array, c_id_array, sum_amounts;
+
+	UPDATE customer
+	   SET c_balance = COALESCE(c_balance,0) + ids_and_sums.sum_amounts
+	  FROM UNNEST(d_id_array, c_id_array, sum_amounts) AS ids_and_sums(d_id, c_id, sum_amounts)
+	 WHERE customer.c_id = ids_and_sums.c_id
+	   AND c_d_id = ids_and_sums.d_id
+	   AND c_w_id = d_w_id;
+
+    EXCEPTION
+		WHEN serialization_failure OR deadlock_detected OR no_data_found
+	        THEN ROLLBACK;
+END;
 $$
 LANGUAGE 'plpgsql';}
 set sql(4) {CREATE OR REPLACE PROCEDURE PAYMENT (
 p_w_id			IN INTEGER,
-p_d_id			IN INTEGER,	
-p_c_w_id		IN INTEGER,	
-p_c_d_id		IN INTEGER,	
+p_d_id			IN INTEGER,
+p_c_w_id		IN INTEGER,
+p_c_d_id		IN INTEGER,
 byname			IN INTEGER,
 p_h_amount		IN NUMERIC,
 p_c_credit              INOUT CHAR(2),
@@ -696,173 +816,156 @@ p_c_data                INOUT VARCHAR(500),
 tstamp			IN TIMESTAMP)
 AS $$
 DECLARE
-namecnt			INTEGER;
+name_count		SMALLINT;
 p_d_name		VARCHAR(11);
 p_w_name		VARCHAR(11);
-p_c_new_data		VARCHAR(500);
 h_data			VARCHAR(30);
-c_byname CURSOR FOR
-SELECT c_first, c_middle, c_id,
-c_street_1, c_street_2, c_city, c_state, c_zip,
-c_phone, c_credit, c_credit_lim,
-c_discount, c_balance, c_since
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_last = p_c_last
-ORDER BY c_first;
+	c_byname CURSOR FOR
+		SELECT c_first, c_middle, c_id,
+				c_street_1, c_street_2, c_city, c_state, c_zip,
+				c_phone, c_credit, c_credit_lim,
+				c_discount, c_balance, c_since
+		  FROM customer
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_last = p_c_last
+		ORDER BY c_first;
 BEGIN
-UPDATE warehouse SET w_ytd = w_ytd + p_h_amount
-WHERE w_id = p_w_id;
-SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name
-INTO p_w_street_1, p_w_street_2, p_w_city, p_w_state, p_w_zip, p_w_name
-FROM warehouse
-WHERE w_id = p_w_id;
-UPDATE district SET d_ytd = d_ytd + p_h_amount
-WHERE d_w_id = p_w_id AND d_id = p_d_id;
-SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name
-INTO p_d_street_1, p_d_street_2, p_d_city, p_d_state, p_d_zip, p_d_name
-FROM district
-WHERE d_w_id = p_w_id AND d_id = p_d_id;
-IF ( byname = 1 )
-THEN
-SELECT count(c_id) INTO namecnt
-FROM customer
-WHERE c_last = p_c_last AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id;
-OPEN c_byname;
-IF ( MOD (namecnt, 2) = 1 )
-THEN
-namecnt := (namecnt + 1);
-END IF;
-FOR loop_counter IN 0 .. cast((namecnt/2) AS INTEGER)
-LOOP
-FETCH c_byname
-INTO p_c_first, p_c_middle, p_c_id, p_c_street_1, p_c_street_2, p_c_city,
-p_c_state, p_c_zip, p_c_phone, p_c_credit, p_c_credit_lim, p_c_discount, p_c_balance, p_c_since;
-END LOOP;
-CLOSE c_byname;
-ELSE
-SELECT c_first, c_middle, c_last,
-c_street_1, c_street_2, c_city, c_state, c_zip,
-c_phone, c_credit, c_credit_lim,
-c_discount, c_balance, c_since
-INTO p_c_first, p_c_middle, p_c_last,
-p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip,
-p_c_phone, p_c_credit, p_c_credit_lim,
-p_c_discount, p_c_balance, p_c_since
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
-END IF;
-p_c_balance := ( p_c_balance + p_h_amount );
-IF p_c_credit = 'BC' 
-THEN
- SELECT c_data INTO p_c_data
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
-h_data := p_w_name || ' ' || p_d_name;
-p_c_new_data := (p_c_id || ' ' || p_c_d_id || ' ' || p_c_w_id || ' ' || p_d_id || ' ' || p_w_id || ' ' || TO_CHAR(p_h_amount,'9999.99') || TO_CHAR(tstamp,'YYYYMMDDHH24MISS') || h_data);
-p_c_new_data := substr(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
-UPDATE customer
-SET c_balance = p_c_balance, c_data = p_c_new_data
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
-c_id = p_c_id;
-ELSE
-UPDATE customer SET c_balance = p_c_balance
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
-c_id = p_c_id;
-END IF;
-h_data := p_w_name || ' ' || p_d_name;
-INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id,
-h_w_id, h_date, h_amount, h_data)
-VALUES (p_c_d_id, p_c_w_id, p_c_id, p_d_id,
-p_w_id, tstamp, p_h_amount, h_data);
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
---Cannot commit before exception handler
-COMMIT;
-END; 
+	UPDATE warehouse
+	   SET w_ytd = w_ytd + p_h_amount
+	 WHERE w_id = p_w_id
+	 RETURNING w_street_1, w_street_2, w_city, w_state, w_zip, w_name
+	 INTO p_w_street_1, p_w_street_2, p_w_city, p_w_state, p_w_zip, p_w_name;
+
+	UPDATE district
+	   SET d_ytd = d_ytd + p_h_amount
+	 WHERE d_w_id = p_w_id AND d_id = p_d_id
+	 RETURNING d_street_1, d_street_2, d_city, d_state, d_zip, d_name
+	 INTO p_d_street_1, p_d_street_2, p_d_city, p_d_state, p_d_zip, p_d_name;
+
+	IF ( byname = 1 )
+	THEN
+		SELECT count(c_last) INTO name_count
+		FROM customer
+		WHERE c_last = p_c_last AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id;
+		OPEN c_byname;
+		FOR loop_counter IN 1 .. cast( name_count/2 AS INT)
+		LOOP
+			FETCH c_byname
+			INTO p_c_first, p_c_middle, p_c_id, p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip, p_c_phone, p_c_credit, p_c_credit_lim, p_c_discount, p_c_balance, p_c_since;
+		END LOOP;
+		CLOSE c_byname;
+	ELSE
+		SELECT c_first, c_middle, c_last,
+		c_street_1, c_street_2, c_city, c_state, c_zip,
+		c_phone, c_credit, c_credit_lim,
+		c_discount, c_balance, c_since
+		INTO p_c_first, p_c_middle, p_c_last,
+		p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip,
+		p_c_phone, p_c_credit, p_c_credit_lim,
+		p_c_discount, p_c_balance, p_c_since
+		FROM customer
+		WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
+	END IF;
+
+    h_data := p_w_name || ' ' || p_d_name;
+
+	IF p_c_credit = 'BC'
+	THEN
+		UPDATE customer
+		   SET c_balance = p_c_balance - p_h_amount,
+		       c_data = substr ((p_c_id || ' ' ||
+                                 p_c_d_id || ' ' ||
+                                 p_c_w_id || ' ' ||
+                                 p_d_id || ' ' ||
+                                 p_w_id || ' ' ||
+                                 to_char (p_h_amount, '9999.99') || ' ' ||
+                                 TO_CHAR(tstamp,'YYYYMMDDHH24MISS') || ' ' ||
+                                 h_data || ' | ') || c_data, 1, 500)
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
+		RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
+	ELSE
+		UPDATE customer
+		   SET c_balance = p_c_balance - p_h_amount
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
+		RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
+	END IF;
+
+	INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id,h_w_id, h_date, h_amount, h_data)
+	VALUES (p_c_d_id, p_c_w_id, p_c_id, p_d_id,	p_w_id, tstamp, p_h_amount, h_data);
+
+    EXCEPTION
+		WHEN serialization_failure OR deadlock_detected OR no_data_found
+			THEN ROLLBACK;
+END;
 $$
 LANGUAGE 'plpgsql';}
 set sql(5) {CREATE OR REPLACE PROCEDURE OSTAT (
-os_w_id			IN INTEGER,
-os_d_id			IN INTEGER,
-os_c_id			INOUT INTEGER,
-byname			IN INTEGER,
-os_c_last		INOUT VARCHAR,
-os_c_first		INOUT VARCHAR,
-os_c_middle		INOUT VARCHAR,
-os_c_balance		INOUT NUMERIC,
-os_o_id			INOUT INTEGER,
-os_entdate		INOUT TIMESTAMP,
-os_o_carrier_id		INOUT INTEGER, 
-os_c_line		INOUT TEXT DEFAULT '')
+    os_w_id			IN INTEGER,
+    os_d_id			IN INTEGER,
+    os_c_id			INOUT INTEGER,
+    byname			IN INTEGER,
+    os_c_last		INOUT VARCHAR,
+    os_c_first		INOUT VARCHAR,
+    os_c_middle		INOUT VARCHAR,
+    os_c_balance	INOUT NUMERIC,
+    os_o_id			INOUT INTEGER,
+    os_entdate		INOUT TIMESTAMP,
+    os_o_carrier_id	INOUT INTEGER,
+    os_c_line		INOUT TEXT DEFAULT '')
 AS $$
 DECLARE
-out_os_c_id	INTEGER;
-out_os_c_last	VARCHAR;
-os_c_first	VARCHAR;
-os_c_middle	VARCHAR;
-os_c_balance	NUMERIC;
-os_o_id		INTEGER;
-os_entdate	TIMESTAMP;
-os_o_carrier_id	INTEGER;
-os_ol		RECORD;
-namecnt		INTEGER;
-c_name CURSOR FOR
-SELECT c_balance, c_first, c_middle, c_id
-FROM customer
-WHERE c_last = os_c_last AND c_d_id = os_d_id AND c_w_id = os_w_id
-ORDER BY c_first;
-c_line CURSOR FOR
-SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
-FROM order_line
-WHERE ol_o_id = os_o_id AND ol_d_id = os_d_id AND ol_w_id = os_w_id;
+    out_os_c_id	    INTEGER;
+    out_os_c_last	VARCHAR;
+    os_ol		    RECORD;
+    namecnt		    INTEGER;
+    c_name CURSOR FOR
+    SELECT c_balance, c_first, c_middle, c_id
+      FROM customer
+     WHERE c_last = os_c_last AND c_d_id = os_d_id AND c_w_id = os_w_id
+    ORDER BY c_first;
 BEGIN
-IF ( byname = 1 )
-THEN
-SELECT count(c_id) INTO namecnt
-FROM customer
-WHERE c_last = os_c_last AND c_d_id = os_d_id AND c_w_id = os_w_id;
-IF ( MOD (namecnt, 2) = 1 )
-THEN
-namecnt := (namecnt + 1);
-END IF;
-OPEN c_name;
-FOR loop_counter IN 0 .. cast((namecnt/2) AS INTEGER)
-LOOP
-FETCH c_name  
-INTO os_c_balance, os_c_first, os_c_middle, os_c_id;
-END LOOP;
-close c_name;
-ELSE
-SELECT c_balance, c_first, c_middle, c_last
-INTO os_c_balance, os_c_first, os_c_middle, os_c_last
-FROM customer
-WHERE c_id = os_c_id AND c_d_id = os_d_id AND c_w_id = os_w_id;
-END IF;
-SELECT o_id, o_carrier_id, o_entry_d 
-INTO os_o_id, os_o_carrier_id, os_entdate
-FROM
-(SELECT o_id, o_carrier_id, o_entry_d
-FROM orders where o_d_id = os_d_id AND o_w_id = os_w_id and o_c_id=os_c_id
-ORDER BY o_id DESC) AS SUBQUERY
-LIMIT 1;
-IF NOT FOUND THEN
-RAISE NOTICE 'No orders for customer';
-RETURN;
-END IF;
-OPEN c_line;
-LOOP
-FETCH c_line INTO os_ol;
-EXIT WHEN NOT FOUND;
-os_c_line := os_c_line || ',' || os_ol.ol_i_id || ',' || os_ol.ol_supply_w_id || ',' || os_ol.ol_quantity || ',' || os_ol.ol_amount || ',' || os_ol.ol_delivery_d;
-END LOOP;
-close c_line;
+    IF ( byname = 1 )
+    THEN
+        SELECT count(c_id) INTO namecnt
+        FROM customer
+        WHERE c_last = os_c_last AND c_d_id = os_d_id AND c_w_id = os_w_id;
+
+        IF ( MOD (namecnt, 2) = 1 )
+        THEN
+            namecnt := (namecnt + 1);
+        END IF;
+
+        OPEN c_name;
+        FOR loop_counter IN 0 .. cast((namecnt/2) AS INTEGER)
+        LOOP
+            FETCH c_name
+            INTO os_c_balance, os_c_first, os_c_middle, os_c_id;
+        END LOOP;
+        CLOSE c_name;
+    ELSE
+        SELECT c_balance, c_first, c_middle, c_last
+        INTO os_c_balance, os_c_first, os_c_middle, os_c_last
+        FROM customer
+        WHERE c_id = os_c_id AND c_d_id = os_d_id AND c_w_id = os_w_id;
+    END IF;
+
+    SELECT o_id, o_carrier_id, o_entry_d
+      INTO os_o_id, os_o_carrier_id, os_entdate
+      FROM (SELECT o_id, o_carrier_id, o_entry_d
+              FROM orders where o_d_id = os_d_id AND o_w_id = os_w_id and o_c_id=os_c_id
+            ORDER BY o_id DESC) AS SUBQUERY
+    LIMIT 1;
+
+    FOR os_ol IN
+    SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d, out_os_c_id, out_os_c_last, os_c_first, os_c_middle, os_c_balance, os_o_id, os_entdate, os_o_carrier_id
+      FROM order_line
+     WHERE ol_o_id = os_o_id AND ol_d_id = os_d_id AND ol_w_id = os_w_id
+    LOOP
+        os_c_line := os_c_line || ',' || os_ol.ol_i_id || ',' || os_ol.ol_supply_w_id || ',' || os_ol.ol_quantity || ',' || os_ol.ol_amount || ',' || os_ol.ol_delivery_d;
+    END LOOP;
 EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
---Cannot commit before exception handler
-COMMIT;
-END; 
+    WHEN serialization_failure OR deadlock_detected OR no_data_found
+        THEN ROLLBACK;
+END;
 $$
 LANGUAGE 'plpgsql';}
 set sql(6) {CREATE OR REPLACE PROCEDURE SLEV (
@@ -871,24 +974,19 @@ st_d_id			IN INTEGER,
 threshold		IN INTEGER,
 stock_count		INOUT INTEGER )
 AS $$
-DECLARE
-st_o_id			NUMERIC;	
 BEGIN
-SELECT d_next_o_id INTO st_o_id
-FROM district
-WHERE d_w_id=st_w_id AND d_id=st_d_id;
-SELECT COUNT(DISTINCT (s_i_id)) INTO stock_count
-FROM order_line, stock
-WHERE ol_w_id = st_w_id AND
-ol_d_id = st_d_id AND (ol_o_id < st_o_id) AND
-ol_o_id >= (st_o_id - 20) AND s_w_id = st_w_id AND
-s_i_id = ol_i_id AND s_quantity < threshold;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
---Cannot commit before exception handler
-COMMIT;
-END; 
+	SELECT COUNT(DISTINCT (s_i_id)) INTO stock_count
+	  FROM order_line, stock, district
+	 WHERE ol_w_id = st_w_id
+	   AND ol_d_id = st_d_id
+	   AND d_w_id=st_w_id
+	   AND d_id=st_d_id
+	   AND (ol_o_id < d_next_o_id)
+	   AND ol_o_id >= (d_next_o_id - 20)
+	   AND s_w_id = st_w_id
+	   AND s_i_id = ol_i_id
+	   AND s_quantity < threshold;
+END;
 $$
 LANGUAGE 'plpgsql';}
 	} else {
@@ -903,323 +1001,446 @@ $$ LANGUAGE 'plpgsql' STRICT;
 }
 set sql(2) { CREATE OR REPLACE FUNCTION NEWORD (INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER) RETURNS NUMERIC AS '
 DECLARE
-no_w_id		ALIAS FOR $1;	
-no_max_w_id	ALIAS FOR $2;
-no_d_id		ALIAS FOR $3;
-no_c_id		ALIAS FOR $4;
-no_o_ol_cnt	ALIAS FOR $5;
-no_d_next_o_id	ALIAS FOR $6;
-no_c_discount	NUMERIC;
-no_c_last	VARCHAR;
-no_c_credit	VARCHAR;
-no_d_tax	NUMERIC;
-no_w_tax	NUMERIC;
-tstamp		TIMESTAMP;
-no_ol_supply_w_id	INTEGER;
-no_ol_i_id		NUMERIC;
-no_ol_quantity		NUMERIC;
-no_o_all_local		INTEGER;
-o_id			INTEGER;
-no_i_name		VARCHAR(24);
-no_i_price		NUMERIC(5,2);
-no_i_data		VARCHAR(50);
-no_s_quantity		NUMERIC(6);
-no_ol_amount		NUMERIC(6,2);
-no_s_dist_01		CHAR(24);
-no_s_dist_02		CHAR(24);
-no_s_dist_03		CHAR(24);
-no_s_dist_04		CHAR(24);
-no_s_dist_05		CHAR(24);
-no_s_dist_06		CHAR(24);
-no_s_dist_07		CHAR(24);
-no_s_dist_08		CHAR(24);
-no_s_dist_09		CHAR(24);
-no_s_dist_10		CHAR(24);
-no_ol_dist_info		CHAR(24);
-no_s_data		VARCHAR(50);
-x			NUMERIC;
-rbk			NUMERIC;
+    no_w_id		        ALIAS FOR $1;
+    no_max_w_id	        ALIAS FOR $2;
+    no_d_id		        ALIAS FOR $3;
+    no_c_id		        ALIAS FOR $4;
+    no_o_ol_cnt	        ALIAS FOR $5;
+    no_d_next_o_id	    ALIAS FOR $6;
+    no_c_discount	    NUMERIC;
+    no_c_last			VARCHAR;
+    no_c_credit			VARCHAR;
+    no_d_tax			NUMERIC;
+    no_w_tax			NUMERIC;
+    no_s_quantity		NUMERIC;
+    no_o_all_local		SMALLINT;
+    rbk					SMALLINT;
+    item_id_array 		INT[];
+    supply_wid_array	SMALLINT[];
+    quantity_array		SMALLINT[];
+    order_line_array	SMALLINT[];
+    stock_dist_array	CHAR(24)[];
+    s_quantity_array	SMALLINT[];
+    price_array			NUMERIC(5,2)[];
+    amount_array		NUMERIC(5,2)[];
 BEGIN
---assignment below added due to error in appendix code
-no_o_all_local := 0;
-SELECT c_discount, c_last, c_credit, w_tax
-INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
-FROM customer, warehouse
-WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND
-customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
-UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
-o_id := no_d_next_o_id;
-INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
-INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
---#2.4.1.4
-rbk := round(DBMS_RANDOM(1,100));
---#2.4.1.5
-FOR loop_counter IN 1 .. no_o_ol_cnt
-LOOP
-IF ((loop_counter = no_o_ol_cnt) AND (rbk = 1))
-THEN
-no_ol_i_id := 100001;
-ELSE
-no_ol_i_id := round(DBMS_RANDOM(1,100000));
-END IF;
---#2.4.1.5.2
-x := round(DBMS_RANDOM(1,100));
-IF ( x > 1 )
-THEN
-no_ol_supply_w_id := no_w_id;
-ELSE
-no_ol_supply_w_id := no_w_id;
---no_all_local is actually used before this point so following not beneficial
-no_o_all_local := 0;
-WHILE ((no_ol_supply_w_id = no_w_id) AND (no_max_w_id != 1))
-LOOP
-no_ol_supply_w_id := round(DBMS_RANDOM(1,no_max_w_id));
-END LOOP;
-END IF;
---#2.4.1.5.3
-no_ol_quantity := round(DBMS_RANDOM(1,10));
-SELECT i_price, i_name, i_data INTO no_i_price, no_i_name, no_i_data
-FROM item WHERE i_id = no_ol_i_id;
-SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
-INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-IF ( no_s_quantity > no_ol_quantity )
-THEN
-no_s_quantity := ( no_s_quantity - no_ol_quantity );
-ELSE
-no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
-END IF;
-UPDATE stock SET s_quantity = no_s_quantity
-WHERE s_i_id = no_ol_i_id
-AND s_w_id = no_ol_supply_w_id;
+	no_o_all_local := 1;
+	SELECT c_discount, c_last, c_credit, w_tax
+	INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
+	FROM customer, warehouse
+	WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
 
-no_ol_amount := (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+	--#2.4.1.4
+	rbk := round(DBMS_RANDOM(1,100));
+	--#2.4.1.5
+	FOR loop_counter IN 1 .. no_o_ol_cnt
+	LOOP
+		IF ((loop_counter = no_o_ol_cnt) AND (rbk = 1))
+		THEN
+			item_id_array[loop_counter] := 100001;
+		ELSE
+			item_id_array[loop_counter] := round(DBMS_RANDOM(1,100000));
+		END IF;
 
-IF no_d_id = 1
-THEN 
-no_ol_dist_info := no_s_dist_01; 
+		--#2.4.1.5.2
+		IF ( round(DBMS_RANDOM(1,100)) > 1 )
+		THEN
+			supply_wid_array[loop_counter] := no_w_id;
+		ELSE
+			no_o_all_local := 0;
+			supply_wid_array[loop_counter] := 1 + MOD(CAST (no_w_id + round(DBMS_RANDOM(0,no_max_w_id-1)) AS INT), no_max_w_id);
+		END IF;
 
-ELSIF no_d_id = 2
-THEN
-no_ol_dist_info := no_s_dist_02;
+		--#2.4.1.5.3
+		quantity_array[loop_counter] := round(DBMS_RANDOM(1,10));
+		order_line_array[loop_counter] := loop_counter;
+	END LOOP;
 
-ELSIF no_d_id = 3
-THEN
-no_ol_dist_info := no_s_dist_03;
+	UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
 
-ELSIF no_d_id = 4
-THEN
-no_ol_dist_info := no_s_dist_04;
+	INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
+	INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);
 
-ELSIF no_d_id = 5
-THEN
-no_ol_dist_info := no_s_dist_05;
+	SELECT array_agg ( i_price )
+	INTO price_array
+	FROM UNNEST(item_id_array) item_id
+	LEFT JOIN item ON i_id = item_id;
 
-ELSIF no_d_id = 6
-THEN
-no_ol_dist_info := no_s_dist_06;
+	IF no_d_id = 1
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 2
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 3
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 4
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 5
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 6
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 7
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 8
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 9
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	ELSIF no_d_id = 10
+	THEN
+		WITH stock_update AS (
+	        UPDATE stock
+    	       SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+			  FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
+				   AS item_stock (item_id, supply_wid, quantity, price)
+			 WHERE stock.s_i_id = item_stock.item_id
+			   AND stock.s_w_id = item_stock.supply_wid
+			RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+    	)
+		SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
+		FROM stock_update
+		INTO stock_dist_array, s_quantity_array, amount_array;
+	END IF;
 
-ELSIF no_d_id = 7
-THEN
-no_ol_dist_info := no_s_dist_07;
+	INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+	SELECT no_d_next_o_id,
+		   no_d_id,
+		   no_w_id,
+		   data.line_number,
+		   data.item_id,
+		   data.supply_wid,
+		   data.quantity,
+		   data.amount,
+		   data.stock_dist
+	  FROM UNNEST(order_line_array,
+				   item_id_array,
+				   supply_wid_array,
+				   quantity_array,
+				   amount_array,
+				   stock_dist_array)
+		   AS data( line_number, item_id, supply_wid, quantity, amount, stock_dist);
 
-ELSIF no_d_id = 8
-THEN
-no_ol_dist_info := no_s_dist_08;
+	no_s_quantity := 0;
+	FOR loop_counter IN 1 .. no_o_ol_cnt
+	LOOP
+		no_s_quantity := no_s_quantity + CAST( amount_array[loop_counter] AS NUMERIC);
+	END LOOP;
 
-ELSIF no_d_id = 9
-THEN
-no_ol_dist_info := no_s_dist_09;
+    RETURN no_s_quantity;
 
-ELSIF no_d_id = 10
-THEN
-no_ol_dist_info := no_s_dist_10;
-END IF;
-
-INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-VALUES (o_id, no_d_id, no_w_id, loop_counter, no_ol_i_id, no_ol_supply_w_id, no_ol_quantity, no_ol_amount, no_ol_dist_info);
-
-END LOOP;
-RETURN no_s_quantity;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
-END; 
+    EXCEPTION
+        WHEN serialization_failure OR deadlock_detected OR no_data_found
+            THEN ROLLBACK;
+END;
 ' LANGUAGE 'plpgsql';
 	}
 set sql(3) { CREATE OR REPLACE FUNCTION DELIVERY (INTEGER, INTEGER) RETURNS INTEGER AS '
 DECLARE
-d_w_id		ALIAS FOR $1;	
-d_o_carrier_id  ALIAS FOR $2;	
-d_d_id	       	INTEGER;
-d_c_id	       	NUMERIC;
-d_no_o_id		INTEGER;
-d_ol_total		NUMERIC;
-loop_counter		INTEGER;
+    d_w_id		ALIAS FOR $1;
+    d_o_carrier_id  ALIAS FOR $2;
+    loop_counter	SMALLINT;
+    d_id_in_array	SMALLINT[] := ARRAY[1,2,3,4,5,6,7,8,9,10];
+    d_id_array		SMALLINT[];
+    o_id_array 		INT[];
+    c_id_array 		INT[];
+    order_count		SMALLINT;
+    sum_amounts     NUMERIC[];
+
+    customer_count INT;
 BEGIN
-FOR loop_counter IN 1 .. 10
-LOOP
-d_d_id := loop_counter;
-SELECT no_o_id INTO d_no_o_id FROM new_order WHERE no_w_id = d_w_id AND no_d_id = d_d_id ORDER BY no_o_id ASC LIMIT 1;
-DELETE FROM new_order WHERE no_w_id = d_w_id AND no_d_id = d_d_id AND no_o_id = d_no_o_id;
-SELECT o_c_id INTO d_c_id FROM orders
-WHERE o_id = d_no_o_id AND o_d_id = d_d_id AND
-o_w_id = d_w_id;
- UPDATE orders SET o_carrier_id = d_o_carrier_id
-WHERE o_id = d_no_o_id AND o_d_id = d_d_id AND
-o_w_id = d_w_id;
-UPDATE order_line SET ol_delivery_d = current_timestamp
-WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id AND
-ol_w_id = d_w_id;
-SELECT SUM(ol_amount) INTO d_ol_total
-FROM order_line
-WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
-AND ol_w_id = d_w_id;
-UPDATE customer SET c_balance = c_balance + d_ol_total
-WHERE c_id = d_c_id AND c_d_id = d_d_id AND
-c_w_id = d_w_id;
-END LOOP;
-RETURN 1;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
-END; 
+	WITH new_order_delete AS (
+		DELETE
+		 FROM new_order as del_new_order
+		USING UNNEST(d_id_in_array) AS d_ids
+		WHERE no_d_id = d_ids
+		  AND no_w_id = d_w_id
+		  AND del_new_order.no_o_id = (select min (select_new_order.no_o_id)
+						   from new_order as select_new_order
+						  where no_d_id = d_ids
+							and no_w_id = d_w_id)
+		RETURNING del_new_order.no_o_id, del_new_order.no_d_id
+		)
+	SELECT array_agg(no_o_id), array_agg(no_d_id)
+	  FROM new_order_delete
+	  INTO o_id_array, d_id_array;
+
+	UPDATE orders
+	   SET o_carrier_id = d_o_carrier_id
+	  FROM UNNEST(o_id_array, d_id_array) AS ids(o_id, d_id)
+	 WHERE orders.o_id = ids.o_id
+	   AND o_d_id = ids.d_id
+	   AND o_w_id = d_w_id;
+
+	WITH order_line_update AS (
+        UPDATE order_line
+           SET ol_delivery_d = current_timestamp
+		  FROM UNNEST(o_id_array, d_id_array) AS ids(o_id, d_id)
+		 WHERE ol_o_id = ids.o_id
+           AND ol_d_id = ids.d_id
+           AND ol_w_id = d_w_id
+		RETURNING ol_d_id, ol_o_id, ol_amount
+		)
+	SELECT array_agg(ol_d_id), array_agg(c_id), array_agg(sum_amount)
+	  FROM ( SELECT ol_d_id,
+			       ( SELECT DISTINCT o_c_id FROM orders WHERE o_id = ol_o_id AND o_d_id = ol_d_id AND o_w_id = d_w_id) AS c_id,
+			        sum(ol_amount) AS sum_amount
+			   FROM order_line_update
+			  GROUP BY ol_d_id, ol_o_id ) AS inner_sum
+	  INTO d_id_array, c_id_array, sum_amounts;
+
+	UPDATE customer
+	   SET c_balance = COALESCE(c_balance,0) + ids_and_sums.sum_amounts
+	  FROM UNNEST(d_id_array, c_id_array, sum_amounts) AS ids_and_sums(d_id, c_id, sum_amounts)
+	 WHERE customer.c_id = ids_and_sums.c_id
+	   AND c_d_id = ids_and_sums.d_id
+	   AND c_w_id = d_w_id;
+
+    RETURN 1;
+
+	EXCEPTION
+		WHEN serialization_failure OR deadlock_detected OR no_data_found
+	        THEN ROLLBACK;
+END;
 ' LANGUAGE 'plpgsql';
 }
 set sql(4) { CREATE OR REPLACE FUNCTION PAYMENT (INTEGER, INTEGER, INTEGER, INTEGER, NUMERIC, INTEGER, NUMERIC, VARCHAR, VARCHAR, NUMERIC ) RETURNS INTEGER AS '
 DECLARE
-p_w_id			ALIAS FOR $1;
-p_d_id			ALIAS FOR $2;
-p_c_w_id		ALIAS FOR $3;
-p_c_d_id		ALIAS FOR $4;
-p_c_id_in		ALIAS FOR $5;
-byname			ALIAS FOR $6;
-p_h_amount		ALIAS FOR $7;
-p_c_last_in		ALIAS FOR $8;
-p_c_credit_in		ALIAS FOR $9;
-p_c_balance_in		ALIAS FOR $10;
-p_c_balance             NUMERIC(12, 2);
-p_c_credit              CHAR(2);
-p_c_last		VARCHAR(16);
-p_c_id			NUMERIC(5,0);
-p_w_street_1            VARCHAR(20);
-p_w_street_2            VARCHAR(20);
-p_w_city                VARCHAR(20);
-p_w_state               CHAR(2);
-p_w_zip                 CHAR(9);
-p_d_street_1            VARCHAR(20);
-p_d_street_2            VARCHAR(20);
-p_d_city                VARCHAR(20);
-p_d_state               CHAR(2);
-p_d_zip                 CHAR(9);
-p_c_first               VARCHAR(16);
-p_c_middle              CHAR(2);
-p_c_street_1            VARCHAR(20);
-p_c_street_2            VARCHAR(20);
-p_c_city                VARCHAR(20);
-p_c_state               CHAR(2);
-p_c_zip                 CHAR(9);
-p_c_phone               CHAR(16);
-p_c_since		TIMESTAMP;
-p_c_credit_lim          NUMERIC(12, 2);
-p_c_discount            NUMERIC(4, 4);
-p_c_data                VARCHAR(500);
-tstamp			TIMESTAMP;
-namecnt			INTEGER;
-p_d_name		VARCHAR(11);
-p_w_name		VARCHAR(11);
-p_c_new_data		VARCHAR(500);
-h_data			VARCHAR(30);
-c_byname CURSOR FOR
-SELECT c_first, c_middle, c_id,
-c_street_1, c_street_2, c_city, c_state, c_zip,
-c_phone, c_credit, c_credit_lim,
-c_discount, c_balance, c_since
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_last = p_c_last
-ORDER BY c_first;
+    p_w_id			ALIAS FOR $1;
+    p_d_id			ALIAS FOR $2;
+    p_c_w_id		ALIAS FOR $3;
+    p_c_d_id		ALIAS FOR $4;
+    p_c_id_in		ALIAS FOR $5;
+    byname			ALIAS FOR $6;
+    p_h_amount		ALIAS FOR $7;
+    p_c_last_in		ALIAS FOR $8;
+    p_c_credit_in	ALIAS FOR $9;
+    p_c_balance_in	ALIAS FOR $10;
+	p_c_balance     NUMERIC(12, 2);
+	p_c_credit      CHAR(2);
+    p_c_last		VARCHAR(16);
+	p_c_id					INT;
+	p_w_street_1            VARCHAR(20);
+	p_w_street_2            VARCHAR(20);
+	p_w_city                VARCHAR(20);
+	p_w_state               CHAR(2);
+	p_w_zip                 CHAR(9);
+	p_d_street_1            VARCHAR(20);
+	p_d_street_2            VARCHAR(20);
+	p_d_city                VARCHAR(20);
+	p_d_state               CHAR(2);
+	p_d_zip                 CHAR(9);
+	p_c_first               VARCHAR(16);
+	p_c_middle              CHAR(2);
+	p_c_street_1            VARCHAR(20);
+	p_c_street_2            VARCHAR(20);
+	p_c_city                VARCHAR(20);
+	p_c_state               CHAR(2);
+	p_c_zip                 CHAR(9);
+	p_c_phone               CHAR(16);
+	p_c_since				TIMESTAMP;
+	p_c_credit_lim          NUMERIC(12, 2);
+	p_c_discount            NUMERIC(4, 4);
+	tstamp					TIMESTAMP;
+	p_d_name				VARCHAR(11);
+	p_w_name				VARCHAR(11);
+	p_c_new_data			VARCHAR(500);
+
+	name_count SMALLINT;
+
+	c_byname CURSOR FOR
+		SELECT c_first, c_middle, c_id,
+				c_street_1, c_street_2, c_city, c_state, c_zip,
+				c_phone, c_credit, c_credit_lim,
+				c_discount, c_balance, c_since
+		  FROM customer
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_last = p_c_last
+		ORDER BY c_first;
 BEGIN
-p_c_balance := p_c_balance_in;
-p_c_id := p_c_id_in;
-p_c_last := p_c_last_in;
-p_c_credit := p_c_credit_in;
-tstamp := current_timestamp;
-UPDATE warehouse SET w_ytd = w_ytd + p_h_amount
-WHERE w_id = p_w_id;
-SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name
-INTO p_w_street_1, p_w_street_2, p_w_city, p_w_state, p_w_zip, p_w_name
-FROM warehouse
-WHERE w_id = p_w_id;
-UPDATE district SET d_ytd = d_ytd + p_h_amount
-WHERE d_w_id = p_w_id AND d_id = p_d_id;
-SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name
-INTO p_d_street_1, p_d_street_2, p_d_city, p_d_state, p_d_zip, p_d_name
-FROM district
-WHERE d_w_id = p_w_id AND d_id = p_d_id;
-IF ( byname = 1 )
-THEN
-SELECT count(c_id) INTO namecnt
-FROM customer
-WHERE c_last = p_c_last AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id;
-OPEN c_byname;
-IF ( MOD (namecnt, 2) = 1 )
-THEN
-namecnt := (namecnt + 1);
-END IF;
-FOR loop_counter IN 0 .. cast((namecnt/2) AS INTEGER)
-LOOP
-FETCH c_byname
-INTO p_c_first, p_c_middle, p_c_id, p_c_street_1, p_c_street_2, p_c_city,
-p_c_state, p_c_zip, p_c_phone, p_c_credit, p_c_credit_lim, p_c_discount, p_c_balance, p_c_since;
-END LOOP;
-CLOSE c_byname;
-ELSE
-SELECT c_first, c_middle, c_last,
-c_street_1, c_street_2, c_city, c_state, c_zip,
-c_phone, c_credit, c_credit_lim,
-c_discount, c_balance, c_since
-INTO p_c_first, p_c_middle, p_c_last,
-p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip,
-p_c_phone, p_c_credit, p_c_credit_lim,
-p_c_discount, p_c_balance, p_c_since
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
-END IF;
-p_c_balance := ( p_c_balance + p_h_amount );
-IF p_c_credit = ''BC'' 
-THEN
- SELECT c_data INTO p_c_data
-FROM customer
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
-h_data := p_w_name || '' '' || p_d_name;
-p_c_new_data := (p_c_id || '' '' || p_c_d_id || '' '' || p_c_w_id || '' '' || p_d_id || '' '' || p_w_id || '' '' || TO_CHAR(p_h_amount,''9999.99'') || TO_CHAR(tstamp,''YYYYMMDDHH24MISS'') || h_data);
-p_c_new_data := substr(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
-UPDATE customer
-SET c_balance = p_c_balance, c_data = p_c_new_data
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
-c_id = p_c_id;
-ELSE
-UPDATE customer SET c_balance = p_c_balance
-WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
-c_id = p_c_id;
-END IF;
-h_data := p_w_name || '' '' || p_d_name;
-INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id,
-h_w_id, h_date, h_amount, h_data)
-VALUES (p_c_d_id, p_c_w_id, p_c_id, p_d_id,
-p_w_id, tstamp, p_h_amount, h_data);
-RETURN p_c_id;
-EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
-END; 
+	tstamp := current_timestamp;
+	p_c_id := p_c_id_in;
+    p_c_balance := p_c_balance_in;
+    p_c_last := p_c_last_in;
+    p_c_credit := p_c_credit_in;
+
+	UPDATE warehouse
+	   SET w_ytd = w_ytd + p_h_amount
+	 WHERE w_id = p_w_id
+	 RETURNING w_street_1, w_street_2, w_city, w_state, w_zip, w_name
+	 INTO p_w_street_1, p_w_street_2, p_w_city, p_w_state, p_w_zip, p_w_name;
+
+	UPDATE district
+	   SET d_ytd = d_ytd + p_h_amount
+	 WHERE d_w_id = p_w_id AND d_id = p_d_id
+	 RETURNING d_street_1, d_street_2, d_city, d_state, d_zip, d_name
+	 INTO p_d_street_1, p_d_street_2, p_d_city, p_d_state, p_d_zip, p_d_name;
+
+	IF ( byname = 1 )
+	THEN
+		SELECT count(c_last) INTO name_count
+		FROM customer
+		WHERE c_last = p_c_last AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id;
+		OPEN c_byname;
+		FOR loop_counter IN 1 .. cast( name_count/2 AS INT)
+		LOOP
+			FETCH c_byname
+			INTO p_c_first, p_c_middle, p_c_id, p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip, p_c_phone, p_c_credit, p_c_credit_lim, p_c_discount, p_c_balance, p_c_since;
+		END LOOP;
+		CLOSE c_byname;
+	ELSE
+		SELECT c_first, c_middle, c_last,
+		c_street_1, c_street_2, c_city, c_state, c_zip,
+		c_phone, c_credit, c_credit_lim,
+		c_discount, c_balance, c_since
+		INTO p_c_first, p_c_middle, p_c_last,
+		p_c_street_1, p_c_street_2, p_c_city, p_c_state, p_c_zip,
+		p_c_phone, p_c_credit, p_c_credit_lim,
+		p_c_discount, p_c_balance, p_c_since
+		FROM customer
+		WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id;
+	END IF;
+
+	IF p_c_credit = ''BC''
+	THEN
+		UPDATE customer
+		   SET c_balance = p_c_balance - p_h_amount,
+		       c_data = substr ((p_c_id || '' '' ||
+                                 p_c_d_id || '' '' ||
+                                 p_c_w_id || '' '' ||
+                                 p_d_id || '' '' ||
+                                 p_w_id || '' '' ||
+                                 to_char (p_h_amount, ''9999.99'') || '' | '') || c_data, 1, 500)
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
+		RETURNING c_balance, c_data INTO p_c_balance, p_c_new_data;
+	ELSE
+		UPDATE customer
+		   SET c_balance = p_c_balance - p_h_amount
+		 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
+		RETURNING c_balance, '' '' INTO p_c_balance, p_c_new_data;
+	END IF;
+
+	INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id,h_w_id, h_date, h_amount, h_data)
+	VALUES (p_c_d_id, p_c_w_id, p_c_id, p_d_id,	p_w_id, tstamp, p_h_amount, p_w_name || '' '' || p_d_name);
+
+	RETURN p_c_id;
+
+	EXCEPTION
+		WHEN serialization_failure OR deadlock_detected OR no_data_found
+			THEN ROLLBACK;
+END;
 ' LANGUAGE 'plpgsql';
 	}
 set sql(5) { CREATE OR REPLACE FUNCTION OSTAT (INTEGER, INTEGER, INTEGER, INTEGER, VARCHAR) RETURNS SETOF record AS '
 DECLARE
 os_w_id		ALIAS FOR $1;
-os_d_id		ALIAS FOR $2;		
+os_d_id		ALIAS FOR $2;
 os_c_id	 	ALIAS FOR $3;
-byname		ALIAS FOR $4;	
+byname		ALIAS FOR $4;
 os_c_last	ALIAS FOR $5;
 out_os_c_id	INTEGER;
 out_os_c_last	VARCHAR;
@@ -1249,7 +1470,7 @@ END IF;
 OPEN c_name;
 FOR loop_counter IN 0 .. cast((namecnt/2) AS INTEGER)
 LOOP
-FETCH c_name  
+FETCH c_name
 INTO os_c_balance, os_c_first, os_c_middle, os_c_id;
 END LOOP;
 close c_name;
@@ -1259,7 +1480,7 @@ INTO os_c_balance, os_c_first, os_c_middle, os_c_last
 FROM customer
 WHERE c_id = os_c_id AND c_d_id = os_d_id AND c_w_id = os_w_id;
 END IF;
-SELECT o_id, o_carrier_id, o_entry_d 
+SELECT o_id, o_carrier_id, o_entry_d
 INTO os_o_id, os_o_carrier_id, os_entdate
 FROM
 (SELECT o_id, o_carrier_id, o_entry_d
@@ -1267,7 +1488,7 @@ FROM orders where o_d_id = os_d_id AND o_w_id = os_w_id and o_c_id=os_c_id
 ORDER BY o_id DESC) AS SUBQUERY
 LIMIT 1;
 FOR os_ol IN
-SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d, out_os_c_id, out_os_c_last, os_c_first, os_c_middle, os_c_balance, os_o_id, os_entdate, os_o_carrier_id	
+SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d, out_os_c_id, out_os_c_last, os_c_first, os_c_middle, os_c_balance, os_o_id, os_entdate, os_o_carrier_id
 FROM order_line
 WHERE ol_o_id = os_o_id AND ol_d_id = os_d_id AND ol_w_id = os_w_id
 LOOP
@@ -1276,33 +1497,33 @@ END LOOP;
 EXCEPTION
 WHEN serialization_failure OR deadlock_detected OR no_data_found
 THEN ROLLBACK;
-END; 
+END;
 ' LANGUAGE 'plpgsql';
 }
 set sql(6) { CREATE OR REPLACE FUNCTION SLEV (INTEGER, INTEGER, INTEGER) RETURNS INTEGER AS '
 DECLARE
 st_w_id			ALIAS FOR $1;
 st_d_id			ALIAS FOR $2;
-threshold		ALIAS FOR $3; 
-
-st_o_id			NUMERIC;	
+threshold		ALIAS FOR $3;
 stock_count		INTEGER;
 BEGIN
-SELECT d_next_o_id INTO st_o_id
-FROM district
-WHERE d_w_id=st_w_id AND d_id=st_d_id;
+	SELECT COUNT(DISTINCT (s_i_id)) INTO stock_count
+	  FROM order_line, stock, district
+	 WHERE ol_w_id = st_w_id
+	   AND ol_d_id = st_d_id
+	   AND d_w_id=st_w_id
+	   AND d_id=st_d_id
+	   AND (ol_o_id < d_next_o_id)
+	   AND ol_o_id >= (d_next_o_id - 20)
+	   AND s_w_id = st_w_id
+	   AND s_i_id = ol_i_id
+	   AND s_quantity < threshold;
 
-SELECT COUNT(DISTINCT (s_i_id)) INTO stock_count
-FROM order_line, stock
-WHERE ol_w_id = st_w_id AND
-ol_d_id = st_d_id AND (ol_o_id < st_o_id) AND
-ol_o_id >= (st_o_id - 20) AND s_w_id = st_w_id AND
-s_i_id = ol_i_id AND s_quantity < threshold;
-RETURN stock_count;
+	RETURN stock_count;
 EXCEPTION
-WHEN serialization_failure OR deadlock_detected OR no_data_found
-THEN ROLLBACK;
-END; 
+	WHEN serialization_failure OR deadlock_detected OR no_data_found
+		THEN ROLLBACK;
+END;
 ' LANGUAGE 'plpgsql';
 	}
     }
@@ -1351,7 +1572,7 @@ return $lda
 }
 
 proc CreateUserDatabase { lda db superuser user password } {
-puts "CREATING DATABASE $db under OWNER $user"  
+puts "CREATING DATABASE $db under OWNER $user"
 set sql(1) "CREATE USER $user PASSWORD '$password'"
 set sql(2) "GRANT $user to $superuser"
 set sql(3) "CREATE DATABASE $db OWNER $user"


### PR DESCRIPTION
Rewrite of the functions and stored procedures using bulk processing and more RETURNING functionality.  The approach taken is based on that the in Oracle TPC-C Full Disclosure report: http://c970058.r58.cf2.rackcdn.com/fdr/tpcc/Cisco-Oracle%20C240%20TPC-C%20FDR.pdf

On a CPU bound system, testing reveals increase in NOPM:
PG10: 51753 to 69200 (34%)
PG11: 62131 to 74166 (19%)

Whilst every effort has been made to verify no regression in performance, the lack of full regression pack makes it hard to be certain but the workload appears to be equivalent.

Note that one issue was "fixed" i.e. non local order distribution.  I don't believe this has any impact of workload but does adhere to the TPC-C specification.


