### PR TITLE
Reverse print out of metrics to put NOPM ahead of TPM

### DIFF
--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -1345,7 +1345,7 @@ db2_finish $stmnt_handle4
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm Db2 TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Db2 TPM"
 if { $doingmonreport eq "true" } {
 puts "---MONREPORT OUTPUT---"
 puts $monreport
@@ -1709,7 +1709,7 @@ db2_finish $stmnt_handle4
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm Db2 TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Db2 TPM"
 if { $doingmonreport eq "true" } {
 puts "---MONREPORT OUTPUT---"
 puts $monreport

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -2468,7 +2468,7 @@ set tpm 0
 	}
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm SQL Server TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm SQL Server TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 if { $CHECKPOINT } {
@@ -2880,7 +2880,7 @@ set tpm 0
 	}
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm SQL Server TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm SQL Server TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 if { $CHECKPOINT } {

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -1457,7 +1457,7 @@ return
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm MySQL TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm MySQL TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 catch { mysqlclose $mysql_handler }
@@ -1824,7 +1824,7 @@ return
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm MySQL TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm MySQL TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 catch { mysqlclose $mysql_handler }

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -2286,7 +2286,7 @@ set end_nopm [ standsql $curn2 $sql4 ]
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm TimesTen TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm TimesTen TPM"
 	} else {
 puts "Test complete, Taking end AWR snapshot."
 oraparse $curn1 $sql1
@@ -2319,7 +2319,7 @@ set ractpm [ expr $ractpm + [ standsql $curn1 $sqlrac ]]
 set tpm $ractpm
         }
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm Oracle TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Oracle TPM"
 	}
 }
 tsv::set application abort 1
@@ -2691,7 +2691,7 @@ set end_nopm [ standsql $curn2 $sql4 ]
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm TimesTen TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm TimesTen TPM"
 	} else {
 puts "Test complete, Taking end AWR snapshot."
 oraparse $curn1 $sql1
@@ -2724,7 +2724,7 @@ set ractpm [ expr $ractpm + [ standsql $curn1 $sqlrac ]]
 set tpm $ractpm
         }
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm Oracle TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Oracle TPM"
 	}
 }
 tsv::set application abort 1

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2585,7 +2585,7 @@ set end_nopm $o_id_arr(sum)
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm PostgreSQL TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm PostgreSQL TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 if { $VACUUM } {
@@ -3013,7 +3013,7 @@ set end_nopm $o_id_arr(sum)
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm PostgreSQL TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm PostgreSQL TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 if { $VACUUM } {

--- a/src/redis/redisoltp.tcl
+++ b/src/redis/redisoltp.tcl
@@ -814,7 +814,7 @@ incr end_nopm [ $redis HMGET DISTRICT:$w_id:$d_id D_NEXT_O_ID ]
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm Redis TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Redis TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 		} else {
@@ -1210,7 +1210,7 @@ incr end_nopm [ $redis HMGET DISTRICT:$w_id:$d_id D_NEXT_O_ID ]
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] VU \* $async_client AC \= [ expr ($totalvirtualusers - 1) * $async_client ] Active Sessions configured"
-puts "TEST RESULT : System achieved $tpm Redis TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Redis TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 		} else {

--- a/src/trafodion/trafoltp.tcl
+++ b/src/trafodion/trafoltp.tcl
@@ -2254,7 +2254,7 @@ $stmnt close
 set tpm [ expr {($end_trans - $start_trans)/$durmin} ]
 set nopm [ expr {($end_nopm - $start_nopm)/$durmin} ]
 puts "[ expr $totalvirtualusers - 1 ] Active Virtual Users configured"
-puts "TEST RESULT : System achieved $tpm Trafodion TPM at $nopm NOPM"
+puts "TEST RESULT : System achieved $nopm NOPM from $tpm Trafodion TPM"
 tsv::set application abort 1
 if { $mode eq "Master" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
 odbc close


### PR DESCRIPTION
Detailed in Issue #99 - reports test results as NOPM from TPM