### PR TITLE
Deprecated Redis

### DIFF
--- a/config/database.xml
+++ b/config/database.xml
@@ -41,6 +41,7 @@
 	<workloads>TPC-C TPC-H</workloads>
 	<commands>pg_conndefaults pg_connect pg_disconnect pg_exec pg_select pg_result pg_execute pg_lo_open pg_lo_close pg_lo_read pg_lo_write pg_lo_lseek pg_lo_creat pg_lo_tell pg_lo_unlink pg_lo_import pg_lo_export pg_listen pg_sendquery pg_sendquery_prepared pg_sendquery_params pg_getresult pg_isbusy pg_blocking pg_cancelrequest pg_on_connection_loss pg_escape_string pg_quote pg_escape_bytea pg_unescape_bytea pg_transaction_status pg_parameter_status pg_exec_prepared pg_exec_params pg_notice_handler pg_result_callback pg_encrypt_password pg_lo_truncate pg_describe_cursor pg_describe_prepared pg_backend_pid pg_server_version</commands>
 </postgresql>
+<!--Redis deprecated, uncomment to enable as unsupported
 <redis>
 	<name>Redis</name>
 	<description>Redis</description>
@@ -49,6 +50,7 @@
 	<workloads>TPC-C</workloads>
 	<commands>redis</commands>
 </redis>
+-->
 <!--Trafodion deprecated, uncomment to enable as unsupported
 <trafodion>
 	<name>Trafodion</name>


### PR DESCRIPTION
Detailed in issue #100 commented out Redis so it doesn't show in the default database list due to single threaded performance bottleneck. User can still uncomment to use unsupported. Will not develop further features such as graphical statistics for unsupported workloads. 