### PR TITLE
Update SQL Server library version number for TCL8.6.10

### DIFF
--- a/config/database.xml
+++ b/config/database.xml
@@ -13,7 +13,7 @@
 	<name>MSSQLServer</name>
 	<description>SQL Server</description>
 	<prefix>mssqls</prefix>
-	<library>tdbc::odbc 1.1.0</library>
+	<library>tdbc::odbc 1.1.1</library>
 	<workloads>TPC-C TPC-H</workloads>
 	<commands>odbc execute paramtype prepare connection allrows</commands>
 </mssqlserver>


### PR DESCRIPTION
HammerDB v4.0 moves to TCL 8.6.10. At 8.6.10 the tdbc::odbc library name moves from 1.1.0 to 1.1.1.  The code for tdbc::odbc in HammerDB v3.3 was already at the version as it had been modified to resolve the typo of #if defined (__WIN64) by removing additional underscore that caused SQULEN issues and added the essential evaldirect command.  It has been verified that the code is the same as 8.6.10 is based on. This change updates to the correct library name. 