### PR TITLE
Fixed statistics updates failure on AWS

### DIFF
--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -41,7 +41,12 @@ if [catch {package require tpchcommon} ] { error "Failed to load tpch common fun
 proc UpdateStatistics { odbc db azure } {
 puts "UPDATING SCHEMA STATISTICS"
 if {!$azure} {
-$odbc evaldirect "EXEC sp_updatestats"
+$odbc evaldirect "CREATE OR ALTER PROCEDURE dbo.sp_updstats
+with execute as 'dbo'
+as
+exec sp_updatestats
+"
+$odbc evaldirect "EXEC dbo.sp_updstats"
 } else {
 set sql(1) "USE $db"
 set sql(2) "EXEC sp_updatestats"

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -1448,7 +1448,12 @@ return
 proc UpdateStatistics { odbc db azure } {
 puts "UPDATING SCHEMA STATISTICS"
 if {!$azure} {
-$odbc evaldirect "EXEC sp_updatestats"
+$odbc evaldirect "CREATE OR ALTER PROCEDURE dbo.sp_updstats
+with execute as 'dbo'
+as
+exec sp_updatestats
+"
+$odbc evaldirect "EXEC dbo.sp_updstats"
 } else {
 set sql(1) "USE $db"
 set sql(2) "EXEC sp_updatestats"


### PR DESCRIPTION
For sql server on aws-rds, sp_updatestats fails due to permission error. Here is an article discussing this issue. https://yatb.mitza.net/2017/03/running-spupdatestats-on-aws-rds.html

The error message looks like this when I run tpch or tpcc on aws-rds
```
Vuser 1:UPDATING SCHEMA STATISTICS

Error in Virtual User 1: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]User does not have permission to perform this action.
(executing the statement)

Vuser 1:FINISHED FAILED

ALL VIRTUAL USERS COMPLETE
```

The work around is to create a stored procedure which wraps sp_updatestats and run it under a different user.