### PR TITLE
Fix for Issue #242 can't read tc_flog no such variable

### DIFF
--- a/src/generic/gentccmn.tcl
+++ b/src/generic/gentccmn.tcl
@@ -68,6 +68,7 @@ return $tc_flog
 
 proc close_transcount_log { iface } {
 global tc_flog
+if { ![info exists tc_flog] } { set tc_flog "notclog"}
 if { $tc_flog != "notclog" } {
 if { [catch {close $tc_flog} message]} {
 if { $iface eq "cli" } {


### PR DESCRIPTION
Fix for Issue #242 when transaction counter start errors without logging enabled.