### PR TITLE
Fix for Timing Data Times Out

### DIFF
--- a/config/generic.xml
+++ b/config/generic.xml
@@ -63,5 +63,6 @@
     <timeprofile>
            <profiler>xtprof</profiler>
            <xt_unique_log_name>0</xt_unique_log_name>
+           <xt_gather_timeout>10</xt_gather_timeout>
     </timeprofile>
 </hammerdb>


### PR DESCRIPTION
Fix for Issue #247 where timing data times out when using a large number of virtual users with event driven scaling. Solution is to make timeout value user configurable and if timeout reached when no data reported to error but when some data reported to continue and calculate timings for those Virtual Users that did.