### PR TITLE
Fix for Xtprof can retain old data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -964,6 +964,7 @@ Version 4.2 June 2021
 
 Pull Requests & Issues
 
+Xtprof timer can retain old data #253 (#254)
 Update to increase TPROC-C Schema Size Limits for Issue #250 (#251)
 Fix for Timing Data Times Out (#248)
 Fix for Issue #242 can't read tc_flog no such variable #242 (#243)

--- a/modules/xtprof-1.0.tm
+++ b/modules/xtprof-1.0.tm
@@ -13,6 +13,12 @@ set TimeProfilerMode 0
 if [catch {package require xml} ] { error "Failed to load XML functions into Time Profile Package" } 
 if { [info exists TimeProfilerMode] } {
 puts "Initializing xtprof time profiler"
+if {[ tsv::exists allvutimings 2 ]} { 
+tsv::unset allvutimings
+	}
+if {[ tsv::exists allclicktimings 2 ]} { 
+tsv::unset allclicktimings
+	}
     proc xttimeprofiler {args} {
         global ProfilerArray
         


### PR DESCRIPTION
Reinitialize xtprof thread shared variables on module load.