### PR TITLE
Add sslmode support for PostgreSQL database

### DIFF
--- a/config/connectpool/pgcpool.xml
+++ b/config/connectpool/pgcpool.xml
@@ -3,6 +3,7 @@
     <c1>
 	<pg_host>host1</pg_host>
         <pg_port>5432</pg_port>
+	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>
         <pg_dbase>tpcc</pg_dbase>
@@ -10,6 +11,7 @@
     <c2>
 	<pg_host>host2</pg_host>
         <pg_port>5432</pg_port>
+	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>
         <pg_dbase>tpcc</pg_dbase>
@@ -17,6 +19,7 @@
     <c3>
 	<pg_host>host3</pg_host>
         <pg_port>5432</pg_port>
+	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>
         <pg_dbase>tpcc</pg_dbase>

--- a/config/postgresql.xml
+++ b/config/postgresql.xml
@@ -3,6 +3,7 @@
     <connection>
         <pg_host>localhost</pg_host>
         <pg_port>5432</pg_port>
+        <pg_sslmode>prefer</pg_sslmode>
     </connection>
 	<tpcc>
         <schema>

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -947,7 +947,7 @@ pg_result $result -clear
 }
 
 proc do_refresh { host port sslmode db user password scale_factor update_sets trickle_refresh REFRESH_VERBOSE RF_SET } {
-set lda [ ConnectToPostgres $host $sslmode $port $sslmode $user $password $db ]
+set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  	}

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2450,7 +2450,7 @@ set syncdrvi(7a) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#
 set syncdrvi(7b) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards {set mlda [ ConnectToPostgres $host $port $sslmode $user $password $db ]} end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastdelete $syncdrvi(7a) $syncdrvi(7b)+1l
 #Replace individual lines for Asynch
-foreach line {{dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 ] ]} {#puts "sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} asynchline {{dict set connlist $id [ set lda$id [ ConnectToPostgresAsynch $1 $2 $3 $4 $5 $RAISEERROR $clientname $async_verbose ] ]} {#puts "$clientname:sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} {
+foreach line {{dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 $6 ] ]} {#puts "sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} asynchline {{dict set connlist $id [ set lda$id [ ConnectToPostgresAsynch $1 $2 $3 $4 $5 $6 $RAISEERROR $clientname $async_verbose ] ]} {#puts "$clientname:sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} {
 set index [.ed_mainFrame.mainwin.textFrame.left.text search -backwards $line end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastdelete $index "$index lineend + 1 char"
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $index "$asynchline \n"
@@ -3250,6 +3250,7 @@ set ora_compatible \"$pg_oracompat\" ;#Postgres Plus Oracle Compatible Schema
 set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL server
+set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
 set superuser \"$pg_superuser\" ;# Superuser privilege user
 set superuser_password \"$pg_superuserpass\" ;# Password for Superuser
 set default_database \"$pg_defaultdbase\" ;# Default Database for Superuser

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -7,7 +7,7 @@ if {[dict exists $dbdict postgresql library ]} {
 upvar #0 configpostgresql configpostgresql
 #set variables to values in dict
 setlocaltpccvars $configpostgresql
-if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a $pg_count_ware Warehouse PostgreSQL TPROC-C schema\nin host [string toupper $pg_host:$pg_port] under user [ string toupper $pg_user ] in database [ string toupper $pg_dbase ]?" -type yesno ] == yes} { 
+if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a $pg_count_ware Warehouse PostgreSQL TPROC-C schema\nin host [string toupper $pg_host:$pg_port] sslmode [string toupper $pg_sslmode] under user [ string toupper $pg_user ] in database [ string toupper $pg_dbase ]?" -type yesno ] == yes} {
 if { $pg_num_vu eq 1 || $pg_count_ware eq 1 } {
 set maxvuser 1
 } else {
@@ -1577,16 +1577,16 @@ pg_result $result -clear
 return
 }
 
-proc ConnectToPostgres { host port user password dbname } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
 global tcl_platform
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" ; puts $message
 error $message
  } else {
 if {$tcl_platform(platform) == "windows"} {
 #Workaround for Bug #95 where first connection fails on Windows
 catch {pg_disconnect $lda}
-set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]
+set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
         }
 pg_notice_handler $lda puts
 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
@@ -1595,7 +1595,7 @@ pg_result $result -clear
 return $lda
 }
 
-proc CreateUserDatabase { lda host port db tspace superuser superuser_password user password } {
+proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_password user password } {
 set stmnt_count 1
 puts "CREATING DATABASE $db under OWNER $user"
 set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
@@ -1612,7 +1612,7 @@ set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
 if { [pg_result $result -numTuples] == 0} {
 set sql($stmnt_count) "CREATE DATABASE $db OWNER $user"
     } else {
-set existing_db [ ConnectToPostgres $host $port $superuser $superuser_password $db ]
+set existing_db [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $db ]
 if { $existing_db eq "Failed" } {
 error "error, the database connection to $host could not be established"
         } else {
@@ -2064,7 +2064,7 @@ for {set d_id 1} {$d_id <= $DIST_PER_WARE } {incr d_id } {
 	pg_result $result -clear
 	return
 }
-proc do_tpcc { host port count_ware superuser superuser_password defaultdb db tspace user password ora_compatible pg_storedprocs partition num_vu } {
+proc do_tpcc { host port sslmode count_ware superuser superuser_password defaultdb db tspace user password ora_compatible pg_storedprocs partition num_vu } {
 set MAXITEMS 100000
 set CUST_PER_DIST 3000
 set DIST_PER_WARE 10
@@ -2095,15 +2095,15 @@ set num_vu 1
   }
 if { $threaded eq "SINGLE-THREADED" ||  $threaded eq "MULTI-THREADED" && $myposition eq 1 } {
 puts "CREATING [ string toupper $user ] SCHEMA"
-set lda [ ConnectToPostgres $host $port $superuser $superuser_password $defaultdb ]
+set lda [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $defaultdb ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
-CreateUserDatabase $lda $host $port $db $tspace $superuser $superuser_password $user $password
+CreateUserDatabase $lda $host $port $sslmode $db $tspace $superuser $superuser_password $user $password
 set result [ pg_exec $lda "commit" ]
 pg_result $result -clear
 pg_disconnect $lda
-set lda [ ConnectToPostgres $host $port $user $password $db ]
+set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
@@ -2160,7 +2160,7 @@ return
 }
 after 5000 
 }
-set lda [ ConnectToPostgres $host $port $user $password $db ]
+set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  }
@@ -2192,7 +2192,7 @@ return
        }
    }
 }
-.ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_count_ware $pg_superuser $pg_superuserpass $pg_defaultdbase $pg_dbase $pg_tspace $pg_user $pg_pass $pg_oracompat $pg_storedprocs $pg_partition $pg_num_vu"
+.ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_sslmode $pg_count_ware $pg_superuser $pg_superuserpass $pg_defaultdbase $pg_dbase $pg_tspace $pg_user $pg_pass $pg_oracompat $pg_storedprocs $pg_partition $pg_num_vu"
 	} else { return }
 }
 
@@ -2239,13 +2239,13 @@ dict for {id conparams} $connectonly {
 #Set the parameters to variables named from the keys, this allows us to build the connect strings according to the database
 dict with conparams {
 #set PostgreSQL connect string
-set $id [ list $pg_host $pg_port $pg_user $pg_pass $pg_dbase ]
+set $id [ list $pg_host $pg_port $pg_sslmode $pg_user $pg_pass $pg_dbase ]
 	}
     }
 #For the connect keys c1, c2 etc make a connection
 foreach id [ split $conkeys ] {
-    lassign [ set $id ] 1 2 3 4 5
-dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 ] ]
+    lassign [ set $id ] 1 2 3 4 5 6
+dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 $6 ] ]
 if {  [ set lda$id ] eq "Failed" } {
 puts "error, the database connection to $1 could not be established"
  	}
@@ -2284,7 +2284,7 @@ set $cnt 0
 #puts "sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"
     }
 #Open standalone connect to determine highest warehouse id for all connections
-set mlda [ ConnectToPostgres $host $port $user $password $db ]
+set mlda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $mlda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } 
@@ -2375,13 +2375,13 @@ set index [.ed_mainFrame.mainwin.textFrame.left.text search -backwards $line end
 		}
 if { $timedtype eq "async" } {
 set syncdrvt(2) [ subst -nocommands -novariables {#CONNECT ASYNC
-promise::async simulate_client { clientname total_iterations host port user password db ora_compatible pg_storedprocs RAISEERROR KEYANDTHINK async_verbose async_delay } \{
+promise::async simulate_client { clientname total_iterations host port sslmode user password db ora_compatible pg_storedprocs RAISEERROR KEYANDTHINK async_verbose async_delay } \{
 set acno [ expr [ string trimleft [ lindex [ split $clientname ":" ] 1 ] ac ] * $async_delay ]
 if { $async_verbose } { puts "Delaying login of $clientname for $acno ms" }
 async_time $acno
 if {  [ tsv::get application abort ]  } { return "$clientname:abort before login" }
 if { $async_verbose } { puts "Logging in $clientname" }
-set mlda [ ConnectToPostgresAsynch $host $port $user $password $db $RAISEERROR $clientname $async_verbose ]
+set mlda [ ConnectToPostgresAsynch $host $port $sslmode $user $password $db $RAISEERROR $clientname $async_verbose ]
 } ]
 set syncdrvi(2a) [.ed_mainFrame.mainwin.textFrame.left.text search -forwards "#RUN TPC-C" 1.0 ]
 #Insert Asynch connections
@@ -2447,7 +2447,7 @@ set syncdrvi(3b) [ expr $syncdrvi(3b) - 1 ]
 .ed_mainFrame.mainwin.textFrame.left.text fastinsert $syncdrvi(3a) $syncdrvt(3)
 #Remove extra async connection
 set syncdrvi(7a) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards "#Open standalone connect to determine highest warehouse id for all connections" end ]
-set syncdrvi(7b) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards {set mlda [ ConnectToPostgres $host $port $user $password $db ]} end ]
+set syncdrvi(7b) [.ed_mainFrame.mainwin.textFrame.left.text search -backwards {set mlda [ ConnectToPostgres $host $port $sslmode $user $password $db ]} end ]
 .ed_mainFrame.mainwin.textFrame.left.text fastdelete $syncdrvi(7a) $syncdrvi(7b)+1l
 #Replace individual lines for Asynch
 foreach line {{dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 ] ]} {#puts "sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} asynchline {{dict set connlist $id [ set lda$id [ ConnectToPostgresAsynch $1 $2 $3 $4 $5 $RAISEERROR $clientname $async_verbose ] ]} {#puts "$clientname:sproc_cur:$curn_fn connections:[ set $cslist ] cursors:[set $cursor_list] number of cursors:[set $len] execs:[set $cnt]"}} {
@@ -2508,6 +2508,7 @@ set ora_compatible \"$pg_oracompat\" ;#Postgres Plus Oracle Compatible Schema
 set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL Server
+set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
 set user \"$pg_user\" ;# PostgreSQL user
 set password \"$pg_pass\" ;# Password for the PostgreSQL user
 set db \"$pg_dbase\" ;# Database containing the TPC Schema
@@ -2524,16 +2525,16 @@ set tstamp [ clock format [ clock seconds ] -format %Y%m%d%H%M%S ]
 return $tstamp
 }
 #POSTGRES CONNECTION
-proc ConnectToPostgres { host port user password dbname } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
 global tcl_platform
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" ; puts $message
 error $message
  } else {
 if {$tcl_platform(platform) == "windows"} {
 #Workaround for Bug #95 where first connection fails on Windows
 catch {pg_disconnect $lda}
-set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]
+set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
         }
 pg_notice_handler $lda puts
 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
@@ -2732,7 +2733,7 @@ pg_result $result -clear
     }
 }
 #RUN TPC-C
-set lda [ ConnectToPostgres $host $port $user $password $db ]
+set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
@@ -2821,6 +2822,7 @@ set ora_compatible \"$pg_oracompat\" ;#Postgres Plus Oracle Compatible Schema
 set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL server
+set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
 set superuser \"$pg_superuser\" ;# Superuser privilege user
 set superuser_password \"$pg_superuserpass\" ;# Password for Superuser
 set default_database \"$pg_defaultdbase\" ;# Default Database for Superuser
@@ -2838,16 +2840,16 @@ if { [ chk_thread ] eq "FALSE" } {
 error "PostgreSQL Timed Script must be run in Thread Enabled Interpreter"
 }
 
-proc ConnectToPostgres { host port user password dbname } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
 global tcl_platform
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" ; puts $message
 error $message
  } else {
 if {$tcl_platform(platform) == "windows"} {
 #Workaround for Bug #95 where first connection fails on Windows
 catch {pg_disconnect $lda}
-set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]
+set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
         }
 pg_notice_handler $lda puts
 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
@@ -2860,12 +2862,12 @@ switch $myposition {
 1 { 
 if { $mode eq "Local" || $mode eq "Primary" } {
 if { ($DRITA_SNAPSHOTS eq "true") || ($VACUUM eq "true") } {
-set lda [ ConnectToPostgres $host $port $superuser $superuser_password $default_database ]
+set lda [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_database ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  	} 
 }
-set lda1 [ ConnectToPostgres $host $port $user $password $db ]
+set lda1 [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda1 eq "Failed" } {
 error "error, the database connection to $host could not be established"
  	} 
@@ -3176,7 +3178,7 @@ pg_result $result -clear
     }
 }
 #RUN TPC-C
-set lda [ ConnectToPostgres $host $port $user $password $db ]
+set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  } else {
@@ -3269,16 +3271,16 @@ if { [ chk_thread ] eq "FALSE" } {
 error "PostgreSQL Timed Script must be run in Thread Enabled Interpreter"
 }
 
-proc ConnectToPostgres { host port user password dbname } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
 global tcl_platform
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" ; puts $message
 error $message
  } else {
 if {$tcl_platform(platform) == "windows"} {
 #Workaround for Bug #95 where first connection fails on Windows
 catch {pg_disconnect $lda}
-set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]
+set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
         }
 pg_notice_handler $lda puts
 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
@@ -3291,12 +3293,12 @@ switch $myposition {
 1 { 
 if { $mode eq "Local" || $mode eq "Primary" } {
 if { ($DRITA_SNAPSHOTS eq "true") || ($VACUUM eq "true") } {
-set lda [ ConnectToPostgres $host $port $superuser $superuser_password $default_database ]
+set lda [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_database ]
 if { $lda eq "Failed" } {
 error "error, the database connection to $host could not be established"
  	} 
 }
-set lda1 [ ConnectToPostgres $host $port $user $password $db ]
+set lda1 [ ConnectToPostgres $host $port $sslmode $user $password $db ]
 if { $lda1 eq "Failed" } {
 error "error, the database connection to $host could not be established"
  	} 
@@ -3421,10 +3423,10 @@ proc gettimestamp { } {
 set tstamp [ clock format [ clock seconds ] -format %Y%m%d%H%M%S ]
 return $tstamp
 }
-proc ConnectToPostgresAsynch { host port user password dbname RAISEERROR clientname async_verbose } {
+proc ConnectToPostgresAsynch { host port sslmode user password dbname RAISEERROR clientname async_verbose } {
 global tcl_platform
 puts "Connecting to database $dbname"
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" 
 if { $RAISEERROR } {
 puts "$clientname:login failed:$message"
@@ -3434,7 +3436,7 @@ return "$clientname:login failed:$message"
 if {$tcl_platform(platform) == "windows"} {
 #Workaround for Bug #95 where first connection fails on Windows
 catch {pg_disconnect $lda}
-if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port user = $user password = $password dbname = $dbname ]]} message]} {
+if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "Failed" 
 if { $RAISEERROR } {
 puts "$clientname:login failed:$message"
@@ -3636,13 +3638,13 @@ pg_result $result -clear
     }
 }
 #CONNECT ASYNC
-promise::async simulate_client { clientname total_iterations host port user password db ora_compatible pg_storedprocs RAISEERROR KEYANDTHINK async_verbose async_delay } {
+promise::async simulate_client { clientname total_iterations host port sslmode user password db ora_compatible pg_storedprocs RAISEERROR KEYANDTHINK async_verbose async_delay } {
 set acno [ expr [ string trimleft [ lindex [ split $clientname ":" ] 1 ] ac ] * $async_delay ]
 if { $async_verbose } { puts "Delaying login of $clientname for $acno ms" }
 async_time $acno
 if {  [ tsv::get application abort ]  } { return "$clientname:abort before login" }
 if { $async_verbose } { puts "Logging in $clientname" }
-set lda [ ConnectToPostgresAsynch $host $port $user $password $db $RAISEERROR $clientname $async_verbose ]
+set lda [ ConnectToPostgresAsynch $host $port $sslmode $user $password $db $RAISEERROR $clientname $async_verbose ]
 #RUN TPC-C
 if { $ora_compatible eq "true" } {
 set result [ pg_exec $lda "exec dbms_output.disable" ]
@@ -3700,7 +3702,7 @@ return $clientname:complete
 for {set ac 1} {$ac <= $async_client} {incr ac} {
 set clientdesc "vuser$myposition:ac$ac"
 lappend clientlist $clientdesc
-lappend clients [simulate_client $clientdesc $total_iterations $host $port $user $password $db $ora_compatible $pg_storedprocs $RAISEERROR $KEYANDTHINK $async_verbose $async_delay]
+lappend clients [simulate_client $clientdesc $total_iterations $host $port $sslmode $user $password $db $ora_compatible $pg_storedprocs $RAISEERROR $KEYANDTHINK $async_verbose $async_delay]
                 }
 puts "Started asynchronous clients:$clientlist"
 set acprom [ promise::eventloop [ promise::all $clients ] ]

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -17,9 +17,9 @@ variable pg_oracompat
 if {[dict exists configpostgresql tpcc pg_oracompat ]} {
 set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
 	}
-set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get}} tpcc {pg_superuser {.countopt.f1.e3 get} pg_superuserpass {.countopt.f1.e4 get} pg_defaultdbase {.countopt.f1.e5 get}} ]
+set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.countopt.f1.e3 get} pg_superuserpass {.countopt.f1.e4 get} pg_defaultdbase {.countopt.f1.e5 get}} ]
 } else {
-set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get}} tpch {pg_tpch_superuser {.countopt.f1.e3 get} pg_tpch_superuserpass {.countopt.f1.e4 get} pg_tpch_defaultdbase {.countopt.f1.e5 get}} ]
+set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.countopt.f1.e3 get} pg_tpch_superuserpass {.countopt.f1.e4 get} pg_tpch_defaultdbase {.countopt.f1.e5 get}} ]
 }
 if { [ info exists afval ] } {
         after cancel $afval
@@ -103,9 +103,16 @@ set Name $Parent.f1.e6
    grid $Prompt -column 0 -row 6 -sticky e
    grid $Name -column 1 -row 6 -sticky ew
 
+set Prompt $Parent.f1.p6a
+ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
+set Name $Parent.f1.e6a
+ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
+   grid $Prompt -column 0 -row 7 -sticky e
+   grid $Name -column 1 -row 7 -sticky w
+
   set Name $Parent.f1.e7
 ttk::checkbutton $Name -text "Log Output to Temp" -variable tclog -onvalue 1 -offvalue 0
-   grid $Name -column 1 -row 7 -sticky w
+   grid $Name -column 1 -row 8 -sticky w
 bind .countopt.f1.e7 <Button> {
 set opst [ .countopt.f1.e7 cget -state ]
 if {$opst != "disabled" && $tclog == 0} {
@@ -120,14 +127,14 @@ set tcstamp 0
                 }
   set Name $Parent.f1.e8
 ttk::checkbutton $Name -text "Use Unique Log Name" -variable uniquelog -onvalue 1 -offvalue 0
-   grid $Name -column 1 -row 8 -sticky w
+   grid $Name -column 1 -row 9 -sticky w
         if {$tclog == 0} {
         $Name configure -state disabled
         }
 
    set Name $Parent.f1.e9
 ttk::checkbutton $Name -text "Log Timestamps" -variable tcstamp -onvalue 1 -offvalue 0
-   grid $Name -column 1 -row 9 -sticky w
+   grid $Name -column 1 -row 10 -sticky w
         if {$tclog == 0} {
         $Name configure -state disabled
         }
@@ -198,7 +205,7 @@ upvar #0 configpostgresql configpostgresql
 setlocaltpccvars $configpostgresql
 #set matching fields in dialog to temporary dict
 variable pgfields
-set pgfields [ dict create connection {pg_host {.tpc.f1.e1 get} pg_port {.tpc.f1.e2 get}} tpcc {pg_superuser {.tpc.f1.e3 get} pg_superuserpass {.tpc.f1.e4 get} pg_defaultdbase {.tpc.f1.e5 get} pg_user {.tpc.f1.e6 get} pg_pass {.tpc.f1.e7 get} pg_dbase {.tpc.f1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
+set pgfields [ dict create connection {pg_host {.tpc.f1.e1 get} pg_port {.tpc.f1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.tpc.f1.e3 get} pg_superuserpass {.tpc.f1.e4 get} pg_defaultdbase {.tpc.f1.e5 get} pg_user {.tpc.f1.e6 get} pg_pass {.tpc.f1.e7 get} pg_dbase {.tpc.f1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
 set whlist [ get_warehouse_list_for_spinbox ]
 if { $pg_oracompat eq "true" } {
 if { $pg_port eq "5432" } { set pg_port "5444" }
@@ -323,6 +330,12 @@ if {$pg_oracompat == "true" } {
 	}
    grid $Prompt -column 0 -row 11 -sticky e
    grid $Name -column 1 -row 11 -sticky w
+set Prompt $Parent.f1.p9b
+ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
+set Name $Parent.f1.e9b
+ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
+   grid $Prompt -column 0 -row 12 -sticky e
+   grid $Name -column 1 -row 12 -sticky w
 if { $option eq "all" || $option eq "build" } {
 set Prompt $Parent.f1.p10
 ttk::label $Prompt -text "Number of Warehouses :"
@@ -339,8 +352,8 @@ set pg_partition "false"
 .tpc.f1.e11a configure -state enabled
         }
 }
-	grid $Prompt -column 0 -row 12 -sticky e
-	grid $Name -column 1 -row 12 -sticky ew
+	grid $Prompt -column 0 -row 13 -sticky e
+	grid $Name -column 1 -row 13 -sticky ew
 set Prompt $Parent.f1.p11
 ttk::label $Prompt -text "Virtual Users to Build Schema :"
 set Name $Parent.f1.e11
@@ -352,14 +365,14 @@ set pg_num_vu $pg_count_ware
         }
 event add <<Any-Button-Any-Key>> <Any-ButtonRelease>
 event add <<Any-Button-Any-Key>> <KeyRelease>
-grid $Prompt -column 0 -row 13 -sticky e
-grid $Name -column 1 -row 13 -sticky ew
+grid $Prompt -column 0 -row 14 -sticky e
+grid $Name -column 1 -row 14 -sticky ew
 set Prompt $Parent.f1.p11a
 ttk::label $Prompt -text "Partition Order Line Table :"
 set Name $Parent.f1.e11a
 ttk::checkbutton $Name -text "" -variable pg_partition -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 14 -sticky e
-   grid $Name -column 1 -row 14 -sticky w
+   grid $Prompt -column 0 -row 15 -sticky e
+   grid $Name -column 1 -row 15 -sticky w
 if {$pg_count_ware < 200 } {
         $Name configure -state disabled
         }
@@ -368,17 +381,17 @@ if { $option eq "all" || $option eq "drive" } {
 if { $option eq "all" } {
 set Prompt $Parent.f1.h3
 ttk::label $Prompt -image [ create_image driveroptlo icons ]
-grid $Prompt -column 0 -row 15 -sticky e
+grid $Prompt -column 0 -row 16 -sticky e
 set Prompt $Parent.f1.h4
 ttk::label $Prompt -text "Driver Options"
-grid $Prompt -column 1 -row 15 -sticky w
+grid $Prompt -column 1 -row 16 -sticky w
 	}
 set Prompt $Parent.f1.p14
 ttk::label $Prompt -text "TPROC-C Driver Script :" -image [ create_image hdbicon icons ] -compound left
-grid $Prompt -column 0 -row 16 -sticky e
+grid $Prompt -column 0 -row 17 -sticky e
 set Name $Parent.f1.r1
 ttk::radiobutton $Name -value "test" -text "Test Driver Script" -variable pg_driver
-grid $Name -column 1 -row 16 -sticky w
+grid $Name -column 1 -row 17 -sticky w
 bind .tpc.f1.r1 <ButtonPress-1> {
 set pg_vacuum "false"
 set pg_dritasnap "false"
@@ -399,7 +412,7 @@ set pg_async_verbose "false"
 }
 set Name $Parent.f1.r2
 ttk::radiobutton $Name -value "timed" -text "Timed Driver Script" -variable pg_driver
-grid $Name -column 1 -row 17 -sticky w
+grid $Name -column 1 -row 18 -sticky w
 bind .tpc.f1.r2 <ButtonPress-1> {
 .tpc.f1.e19 configure -state normal
 .tpc.f1.e20 configure -state normal
@@ -418,14 +431,14 @@ set Name $Parent.f1.e15
    set Prompt $Parent.f1.p15
    ttk::label $Prompt -text "Total Transactions per User :"
    ttk::entry $Name -width 30 -textvariable pg_total_iterations
-   grid $Prompt -column 0 -row 18 -sticky e
-   grid $Name -column 1 -row 18 -sticky ew
+   grid $Prompt -column 0 -row 19 -sticky e
+   grid $Name -column 1 -row 19 -sticky ew
  set Prompt $Parent.f1.p16
 ttk::label $Prompt -text "Exit on PostgreSQL Error :"
   set Name $Parent.f1.e16
 ttk::checkbutton $Name -text "" -variable pg_raiseerror -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 19 -sticky e
-   grid $Name -column 1 -row 19 -sticky w
+   grid $Prompt -column 0 -row 20 -sticky e
+   grid $Name -column 1 -row 20 -sticky w
  set Prompt $Parent.f1.p17
 ttk::label $Prompt -text "Keying and Thinking Time :"
   set Name $Parent.f1.e17
@@ -441,14 +454,14 @@ set pg_async_verbose "false"
         }
     }
 }
-   grid $Prompt -column 0 -row 20 -sticky e
-   grid $Name -column 1 -row 20 -sticky w
+   grid $Prompt -column 0 -row 21 -sticky e
+   grid $Name -column 1 -row 21 -sticky w
 set Prompt $Parent.f1.p19
 ttk::label $Prompt -text "Vacuum when complete :"
 set Name $Parent.f1.e19
 ttk::checkbutton $Name -text "" -variable pg_vacuum -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 21 -sticky e
-   grid $Name -column 1 -row 21 -sticky w
+   grid $Prompt -column 0 -row 22 -sticky e
+   grid $Name -column 1 -row 22 -sticky w
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -456,8 +469,8 @@ set Prompt $Parent.f1.p20
 ttk::label $Prompt -text "EnterpriseDB DRITA Snapshots :"
 set Name $Parent.f1.e20
 ttk::checkbutton $Name -text "" -variable pg_dritasnap -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 22 -sticky e
-   grid $Name -column 1 -row 22 -sticky w
+   grid $Prompt -column 0 -row 23 -sticky e
+   grid $Name -column 1 -row 23 -sticky w
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -465,8 +478,8 @@ set Name $Parent.f1.e21
    set Prompt $Parent.f1.p21
    ttk::label $Prompt -text "Minutes of Rampup Time :"
    ttk::entry $Name -width 30 -textvariable pg_rampup
-   grid $Prompt -column 0 -row 23 -sticky e
-   grid $Name -column 1 -row 23 -sticky ew
+   grid $Prompt -column 0 -row 24 -sticky e
+   grid $Name -column 1 -row 24 -sticky ew
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -474,8 +487,8 @@ set Name $Parent.f1.e22
    set Prompt $Parent.f1.p22
    ttk::label $Prompt -text "Minutes for Test Duration :"
    ttk::entry $Name -width 30 -textvariable pg_duration
-   grid $Prompt -column 0 -row 24 -sticky e
-   grid $Name -column 1 -row 24 -sticky ew
+   grid $Prompt -column 0 -row 25 -sticky e
+   grid $Name -column 1 -row 25 -sticky ew
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -483,8 +496,8 @@ set Name $Parent.f1.e23
    set Prompt $Parent.f1.p23
    ttk::label $Prompt -text "Use All Warehouses :"
    ttk::checkbutton $Name -text "" -variable pg_allwarehouse -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 25 -sticky e
-   grid $Name -column 1 -row 25 -sticky ew
+   grid $Prompt -column 0 -row 26 -sticky e
+   grid $Name -column 1 -row 26 -sticky ew
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -492,8 +505,8 @@ set Name $Parent.f1.e24
    set Prompt $Parent.f1.p24
    ttk::label $Prompt -text "Time Profile :"
    ttk::checkbutton $Name -text "" -variable pg_timeprofile -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 26 -sticky e
-   grid $Name -column 1 -row 26 -sticky ew
+   grid $Prompt -column 0 -row 27 -sticky e
+   grid $Name -column 1 -row 27 -sticky ew
 if {$pg_driver == "test" } {
 	$Name configure -state disabled
 	}
@@ -501,8 +514,8 @@ if {$pg_driver == "test" } {
    set Prompt $Parent.f1.p25
    ttk::label $Prompt -text "Asynchronous Scaling :"
 ttk::checkbutton $Name -text "" -variable pg_async_scale -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 27 -sticky e
-   grid $Name -column 1 -row 27 -sticky ew
+   grid $Prompt -column 0 -row 28 -sticky e
+   grid $Name -column 1 -row 28 -sticky ew
 if {$pg_driver == "test" } {
         set pg_async_scale "false"
         $Name configure -state disabled
@@ -526,8 +539,8 @@ set Name $Parent.f1.e26
    set Prompt $Parent.f1.p26
    ttk::label $Prompt -text "Asynch Clients per Virtual User :"
    ttk::entry $Name -width 30 -textvariable pg_async_client
-   grid $Prompt -column 0 -row 28 -sticky e
-   grid $Name -column 1 -row 28 -sticky ew
+   grid $Prompt -column 0 -row 29 -sticky e
+   grid $Name -column 1 -row 29 -sticky ew
 if {$pg_driver == "test" || $pg_async_scale == "false" } {
         $Name configure -state disabled
         }
@@ -535,8 +548,8 @@ set Name $Parent.f1.e27
    set Prompt $Parent.f1.p27
    ttk::label $Prompt -text "Asynch Client Login Delay :"
    ttk::entry $Name -width 30 -textvariable pg_async_delay
-   grid $Prompt -column 0 -row 29 -sticky e
-   grid $Name -column 1 -row 29 -sticky ew
+   grid $Prompt -column 0 -row 30 -sticky e
+   grid $Name -column 1 -row 30 -sticky ew
 if {$pg_driver == "test" || $pg_async_scale == "false" } {
         $Name configure -state disabled
         }
@@ -544,8 +557,8 @@ if {$pg_driver == "test" || $pg_async_scale == "false" } {
    set Prompt $Parent.f1.p28
    ttk::label $Prompt -text "Asynchronous Verbose :"
 ttk::checkbutton $Name -text "" -variable pg_async_verbose -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 30 -sticky e
-   grid $Name -column 1 -row 30 -sticky ew
+   grid $Prompt -column 0 -row 31 -sticky e
+   grid $Name -column 1 -row 31 -sticky ew
 if {$pg_driver == "test" || $pg_async_scale == "false" } {
         set pg_async_verbose "false"
         $Name configure -state disabled
@@ -554,8 +567,8 @@ if {$pg_driver == "test" || $pg_async_scale == "false" } {
    set Prompt $Parent.f1.p29
    ttk::label $Prompt -text "XML Connect Pool :"
 ttk::checkbutton $Name -text "" -variable pg_connect_pool -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 31 -sticky e
-   grid $Name -column 1 -row 31 -sticky ew
+   grid $Prompt -column 0 -row 32 -sticky e
+   grid $Name -column 1 -row 32 -sticky ew
 }
 #This is the Cancel button variables stay as before
 set Name $Parent.b2
@@ -599,7 +612,7 @@ upvar #0 configpostgresql configpostgresql
 setlocaltpchvars $configpostgresql
 #set matching fields in dialog to temporary dict
 variable pgfields
-set pgfields [ dict create connection {pg_host {.pgtpch.f1.e1 get} pg_port {.pgtpch.f1.e2 get}} tpch {pg_tpch_superuser {.pgtpch.f1.e3 get} pg_tpch_superuserpass {.pgtpch.f1.e4 get} pg_tpch_defaultdbase {.pgtpch.f1.e5 get} pg_tpch_user {.pgtpch.f1.e6 get} pg_tpch_pass {.pgtpch.f1.e7 get} pg_tpch_dbase {.pgtpch.f1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
+set pgfields [ dict create connection {pg_host {.pgtpch.f1.e1 get} pg_port {.pgtpch.f1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.pgtpch.f1.e3 get} pg_tpch_superuserpass {.pgtpch.f1.e4 get} pg_tpch_defaultdbase {.pgtpch.f1.e5 get} pg_tpch_user {.pgtpch.f1.e6 get} pg_tpch_pass {.pgtpch.f1.e7 get} pg_tpch_dbase {.pgtpch.f1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
    catch "destroy .pgtpch"
    ttk::toplevel .pgtpch
    wm transient .pgtpch .ed_mainFrame
@@ -678,6 +691,12 @@ set Name $Parent.f1.e8
    ttk::entry $Name -width 30 -textvariable pg_tpch_dbase
    grid $Prompt -column 0 -row 8 -sticky e
    grid $Name -column 1 -row 8 -sticky ew
+set Prompt $Parent.f1.p8b
+ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
+set Name $Parent.f1.e8b
+ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
+   grid $Prompt -column 0 -row 10 -sticky e
+   grid $Name -column 1 -row 10 -sticky w
 if { $option eq "all" || $option eq "build" } {
 set Name $Parent.f1.e8a
    set Prompt $Parent.f1.p8a
@@ -697,24 +716,24 @@ set pg_tpch_gpcompress "false"
 .pgtpch.f1.e10 configure -state normal
                 }
 	}
-   grid $Prompt -column 0 -row 10 -sticky e
-   grid $Name -column 1 -row 10 -sticky w
+   grid $Prompt -column 0 -row 11 -sticky e
+   grid $Name -column 1 -row 11 -sticky w
 set Prompt $Parent.f1.p10
 ttk::label $Prompt -text "Greenplum Compressed Columns :"
 set Name $Parent.f1.e10
 ttk::checkbutton $Name -text "" -variable pg_tpch_gpcompress -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 11 -sticky e
-   grid $Name -column 1 -row 11 -sticky w
+   grid $Prompt -column 0 -row 12 -sticky e
+   grid $Name -column 1 -row 12 -sticky w
 if {$pg_tpch_gpcompat == "false" } {
 	$Name configure -state disabled
 	}
 set Name $Parent.f1.e11
    set Prompt $Parent.f1.p11
    ttk::label $Prompt -text "Scale Factor :"
-   grid $Prompt -column 0 -row 12 -sticky e
+   grid $Prompt -column 0 -row 13 -sticky e
    set Name $Parent.f1.f2
    ttk::frame $Name -width 30
-   grid $Name -column 1 -row 12 -sticky ew
+   grid $Name -column 1 -row 13 -sticky ew
 	set rcnt 1
 	foreach item {1} {
 	set Name $Parent.f1.f2.r$rcnt
@@ -747,48 +766,48 @@ set Prompt $Parent.f1.p12
 ttk::label $Prompt -text "Virtual Users to Build Schema :"
 set Name $Parent.f1.e12
 ttk::spinbox $Name -from 1 -to 512 -textvariable pg_num_tpch_threads
-	grid $Prompt -column 0 -row 13 -sticky e
-	grid $Name -column 1 -row 13 -sticky ew
+	grid $Prompt -column 0 -row 14 -sticky e
+	grid $Name -column 1 -row 14 -sticky ew
 	}
 if { $option eq "all" || $option eq "drive" } {
 if { $option eq "all" } {
 set Prompt $Parent.f1.h3
 ttk::label $Prompt -image [ create_image driveroptlo icons ]
-grid $Prompt -column 0 -row 14 -sticky e
+grid $Prompt -column 0 -row 15 -sticky e
 set Prompt $Parent.f1.h4
 ttk::label $Prompt -text "Driver Options"
-grid $Prompt -column 1 -row 14 -sticky w
+grid $Prompt -column 1 -row 15 -sticky w
 	}
    set Name $Parent.f1.e14
    set Prompt $Parent.f1.p14
    ttk::label $Prompt -text "Total Query Sets per User :"
    ttk::entry $Name -width 30 -textvariable pg_total_querysets
-   grid $Prompt -column 0 -row 15 -sticky e
-   grid $Name -column 1 -row 15  -columnspan 4 -sticky ew
+   grid $Prompt -column 0 -row 16 -sticky e
+   grid $Name -column 1 -row 16  -columnspan 4 -sticky ew
  set Prompt $Parent.f1.p15
 ttk::label $Prompt -text "Exit on PostgreSQL Error :"
   set Name $Parent.f1.e15
 ttk::checkbutton $Name -text "" -variable pg_raise_query_error -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 16 -sticky e
-   grid $Name -column 1 -row 16 -sticky w
+   grid $Prompt -column 0 -row 17 -sticky e
+   grid $Name -column 1 -row 17 -sticky w
  set Prompt $Parent.f1.p16
 ttk::label $Prompt -text "Verbose Output :"
   set Name $Parent.f1.e16
 ttk::checkbutton $Name -text "" -variable pg_verbose -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 17 -sticky e
-   grid $Name -column 1 -row 17 -sticky w
+   grid $Prompt -column 0 -row 18 -sticky e
+   grid $Name -column 1 -row 18 -sticky w
 set Name $Parent.f1.e16a
    set Prompt $Parent.f1.p16a
    ttk::label $Prompt -text "Degree of Parallelism :"
    ttk::entry $Name  -width 30 -textvariable pg_degree_of_parallel
-   grid $Prompt -column 0 -row 18 -sticky e
-   grid $Name -column 1 -row 18 -sticky ew
+   grid $Prompt -column 0 -row 19 -sticky e
+   grid $Name -column 1 -row 19 -sticky ew
  set Prompt $Parent.f1.p17
 ttk::label $Prompt -text "Refresh Function :"
   set Name $Parent.f1.e17
 ttk::checkbutton $Name -text "" -variable pg_refresh_on -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 19 -sticky e
-   grid $Name -column 1 -row 19 -sticky w
+   grid $Prompt -column 0 -row 20 -sticky e
+   grid $Name -column 1 -row 20 -sticky w
 bind $Parent.f1.e17 <Button> {
 if {$pg_refresh_on eq "true"} { 
 set pg_refresh_verbose "false"
@@ -805,8 +824,8 @@ foreach field {e18 e19 e20} {
    set Prompt $Parent.f1.p18
    ttk::label $Prompt -text "Number of Update Sets :"
    ttk::entry $Name -width 30 -textvariable pg_update_sets
-   grid $Prompt -column 0 -row 20 -sticky e
-   grid $Name -column 1 -row 20  -columnspan 4 -sticky ew
+   grid $Prompt -column 0 -row 21 -sticky e
+   grid $Name -column 1 -row 21  -columnspan 4 -sticky ew
 if {$pg_refresh_on == "false" } {
 	$Name configure -state disabled
 	}
@@ -814,8 +833,8 @@ if {$pg_refresh_on == "false" } {
    set Prompt $Parent.f1.p19
    ttk::label $Prompt -text "Trickle Refresh Delay(ms) :"
    ttk::entry $Name -width 30 -textvariable pg_trickle_refresh
-   grid $Prompt -column 0 -row 21 -sticky e
-   grid $Name -column 1 -row 21  -columnspan 4 -sticky ew
+   grid $Prompt -column 0 -row 22 -sticky e
+   grid $Name -column 1 -row 22  -columnspan 4 -sticky ew
 if {$pg_refresh_on == "false" } {
 	$Name configure -state disabled
 	}
@@ -823,8 +842,8 @@ if {$pg_refresh_on == "false" } {
 ttk::label $Prompt -text "Refresh Verbose :"
   set Name $Parent.f1.e20
 ttk::checkbutton $Name -text "" -variable pg_refresh_verbose -onvalue "true" -offvalue "false"
-   grid $Prompt -column 0 -row 22 -sticky e
-   grid $Name -column 1 -row 22 -sticky w
+   grid $Prompt -column 0 -row 23 -sticky e
+   grid $Name -column 1 -row 23 -sticky w
 if {$pg_refresh_on == "false" } {
 	$Name configure -state disabled
 	}
@@ -840,8 +859,8 @@ set pg_rs_compat "false"
 .pgtpch.f1.e22 configure -state normal
                 }
 	}
-   grid $Prompt -column 0 -row 23 -sticky e
-   grid $Name -column 1 -row 23 -sticky w
+   grid $Prompt -column 0 -row 24 -sticky e
+   grid $Name -column 1 -row 24 -sticky w
 set Prompt $Parent.f1.p22
 ttk::label $Prompt -text "Redshift Compatible :"
 set Name $Parent.f1.e22
@@ -849,8 +868,8 @@ ttk::checkbutton $Name -text "" -variable pg_rs_compat -onvalue "true" -offvalue
 if {$pg_cloud_query == "false" } {
 	$Name configure -state disabled
 	}
-grid $Prompt -column 0 -row 24 -sticky e
-grid $Name -column 1 -row 24 -sticky w
+grid $Prompt -column 0 -row 25 -sticky e
+grid $Name -column 1 -row 25 -sticky w
 }
    set Name $Parent.b2
  ttk::button $Name -command {

--- a/src/postgresql/pgotc.tcl
+++ b/src/postgresql/pgotc.tcl
@@ -6,7 +6,7 @@ if {[dict exists $dbdict postgresql library ]} {
 } else { set library "Pgtcl" }
 #Setup Transaction Counter Thread
 set tc_threadID [thread::create {
-proc ConnectToPostgres { host port user sslmode password dbname } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
 global tcl_platform
 if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
 set lda "connection failed:$message"


### PR DESCRIPTION
Allow pg_sslmode argument to be passed into the postgres driver. Keep default argument value to prefer to make it compatible with default postgres value (refer to https://www.postgresql.org/docs/13/libpq-ssl.html)

pg_sslmode can be changed as follows:

    hammerdb>dbset db pg
    Database set to PostgreSQL

    hammerdb>print dict
    Dictionary Settings for PostgreSQL
    connection {
     pg_host    = localhost
     pg_port    = 5432
     pg_sslmode = prefer
    }
    ...

    hammerdb>diset connection pg_sslmode disable
    Changed connection:pg_sslmode from prefer to disable for PostgreSQL

    hammerdb>print dict
    Dictionary Settings for PostgreSQL
    connection {
     pg_host    = localhost
     pg_port    = 5432
     pg_sslmode = disable
    }
    ...

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.