### PR TITLE
Optimize MakeAlphaString

### DIFF
--- a/modules/tpcccommon-1.0.tm
+++ b/modules/tpcccommon-1.0.tm
@@ -21,13 +21,40 @@ set name [ concat [ lindex $namearr [ expr {( $num / 100 ) % 10 }] ][ lindex $na
 return $name
 }
 #ALPHA STRING
-proc MakeAlphaString { x y chArray chalen } {
-set len [ RandomNumber $x $y ]
-for {set i 0} {$i < $len } {incr i } {
-append alphastring [lindex $chArray [ expr {int(rand()*$chalen)}]]
+set alphanumArray [ list 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z ]
+set alphanumLength [ llength $alphanumArray ]
+
+proc CreateListProduct2 { chArray chalen } {
+    for {set i 0} {$i < $chalen} {incr i} {
+        set char1 [ lindex $chArray $i]
+        for {set j 0} {$j < $chalen } {incr j } {
+            set char2 [ lindex $chArray $j] 
+            set combined $char1
+            append combined $char2
+            lappend products $combined
+        }
+    }
+    return $products
 }
-return $alphastring
+set alphanum2Array [CreateListProduct2 $alphanumArray $alphanumLength ]
+set alphanum2Length [ llength $alphanum2Array ]
+set alphanum2LengthSquared [ expr { $alphanum2Length * $alphanum2Length } ]
+
+proc MakeAlphaString { x y ignore1 ignore2} {
+    variable alphanum2Array;
+    variable alphanum2Length;
+    variable alphanum2LengthSquared;
+    set len [ RandomNumber $x $y ]
+    for {set i 0} {$i < $len} {incr i 4} {
+        set randnumFull [ expr {int(rand() * $alphanum2LengthSquared)} ]
+        set randnum1 [ expr {$randnumFull / $alphanum2Length} ]
+        set randnum2 [ expr {$randnumFull % $alphanum2Length} ]
+        append alphastring [lindex $alphanum2Array $randnum1 ]
+        append alphastring [lindex $alphanum2Array $randnum2 ]
+    }
+    return [ string range $alphastring 0 $len-1 ]
 }
+
 #ZIP CODE
 proc Makezip { } {
 set zip "000011111"

--- a/modules/tpchcommon-1.0.tm
+++ b/modules/tpchcommon-1.0.tm
@@ -190,7 +190,43 @@ set number [ RandomNumber 1000 9999 ]
 return [ concat $acode-$exchg-$number ]
 }
 #ALPHA STRING
-proc MakeAlphaString { min max chArray chalen } {
+set alphanumArray [ list 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z ]
+set alphanumLength [ llength $alphanumArray ]
+
+proc CreateListProduct2 { chArray chalen } {
+    for {set i 0} {$i < $chalen} {incr i} {
+        set char1 [ lindex $chArray $i]
+        for {set j 0} {$j < $chalen } {incr j } {
+            set char2 [ lindex $chArray $j] 
+            set combined $char1
+            append combined $char2
+            lappend products $combined
+        }
+    }
+    return $products
+}
+set alphanum2Array [CreateListProduct2 $alphanumArray $alphanumLength ]
+set alphanum2Length [ llength $alphanum2Array ]
+set alphanum2LengthSquared [ expr { $alphanum2Length * $alphanum2Length } ]
+
+
+proc MakeAlphaString { x y ignore1 ignore2} {
+    variable alphanum2Array;
+    variable alphanum2Length;
+    variable alphanum2LengthSquared;
+    set len [ RandomNumber $x $y ]
+    for {set i 0} {$i < $len} {incr i 4} {
+        set randnumFull [ expr {int(rand() * $alphanum2LengthSquared)} ]
+        set randnum1 [ expr {$randnumFull / $alphanum2Length} ]
+        set randnum2 [ expr {$randnumFull % $alphanum2Length} ]
+        append alphastring [lindex $alphanum2Array $randnum1 ]
+        append alphastring [lindex $alphanum2Array $randnum2 ]
+    }
+    return [ string range $alphastring 0 $len-1 ]
+}
+
+#RANDOM STRING
+proc MakeRandomString { min max chArray chalen } {
 set len [ RandomNumber [ expr {round($min)} ] [ expr {round($max)} ] ]
 for {set i 0} {$i < $len } {incr i } {
 append alphastring [lindex $chArray [ expr {int(rand()*$chalen)}]]
@@ -299,7 +335,7 @@ return $sentence
 proc V_STR { avg } {
 set globArray [ list , \  0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z ]
 set chalen [ llength $globArray ]
-return [ MakeAlphaString [ expr {$avg * 0.4} ] [ expr {$avg * 1.6} ] $globArray $chalen ] 
+return [ MakeRandomString [ expr {$avg * 0.4} ] [ expr {$avg * 1.6} ] $globArray $chalen ] 
 }
 #TEXT BUILD
 proc TEXT_1 { avg } {


### PR DESCRIPTION
When building the dataset I was able to max out the CPU on the
node that's running HammerDB (as opposed to the database that this node
is connecting to). Since generating data takes a significant amount of
time I took some time trying to find some low hanging fruit for
optimization.

After some profiling, by far the most CPU heavy function turned out to
be `MakeAlphaString`. After digging down even further it turns out that
the thing that makes this function slow is the amount of `rand` calls it
does. Since we cannot completely remove this `rand` call, I investigated
some ways of reducing the number of calls.

The new implementation is able to generate a sequence of 4 random
characters with a single `rand` call. This is done in two ways:
1. Pre-compute an array of all combinations of two alphanumeric characters.
2. Use a single random number to generate two random numbers by creating
   a single random number in the range of 0-N^2. Then two get two
   independent random numbers out of that, you can divide by N. Then use
   the result of this division as the first random number and the remainder
   as the second random number.

The result of these changes is that generating a random string with a
length between 300 and 500 characters now only takes ~43% of the time it
did before (on my machine).

Apart from I tried some more approaches, but this turned out to run the
fastest on my machine. I used the script at the end of this commit
message to compare different approaches (including the simple approach).
Please run the benchmark on your own machine.

One thing to note is that the suggested `MakeAlphaString` implementation
ignores the 3rd and 4th argument, and instead always uses all
alphanumeric ASCII characters. Looking at the existing code there's only
one place where a different character set is used. This is in
`tpchcommon-1.0.tm`, which has its own `MakeAlphaString` implementation.
All other uses use the same alphanumeric ASCII character array. Before
merging this it would be good to remove the `ignored1` and `ignored2`
arguments from the new `MakeAlphaString` implementation and all its 
call sites. I did not do that so far so first there could be some discussion if 
this faster implementation makes sense.

```tcl
package require Tclx
namespace eval benchutils {
    namespace export alphanumArray alphanumLength MakeAlphaString MakeAlphaStringFast MakeAlphaStringFastest
proc RandomNumber {m M} {return [expr {int($m+rand()*($M+1-$m))}]}

set alphanumArray [ list 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z ]
set alphanumLength [ llength $alphanumArray ]

proc MakeAlphaString { x y chArray chalen } {
    set len [ RandomNumber $x $y ]
    for {set i 0} {$i < $len} {incr i} {
        append alphastring [lindex $chArray [ expr {int(rand()*$chalen)}]]
    }
    return $alphastring
}

proc CreateListProduct2 { chArray chalen } {
    for {set i 0} {$i < $chalen} {incr i} {
        set char1 [ lindex $chArray $i]
        for {set j 0} {$j < $chalen } {incr j } {
            set char2 [ lindex $chArray $j]
            set combined $char1
            append combined $char2
            lappend products $combined
        }
    }
    return $products
}
set alphanum2Array [CreateListProduct2 $alphanumArray $alphanumLength ]
set alphanum2Length [ llength $alphanum2Array ]

proc MakeAlphaStringFast { x y ignore1 ignore2 } {
    variable alphanum2Array;
    variable alphanum2Length;
    set len [ RandomNumber $x $y ]
    for {set i 0} {$i < $len} {incr i 2} {
        set randnum [ expr {int(rand() * $alphanum2Length)} ]
        append alphastring [lindex $alphanum2Array $randnum ]
    }
    return [ string range $alphastring 0 $len-1 ]
}

set alphanum2LengthSquared [ expr { $alphanum2Length * $alphanum2Length } ]

proc MakeAlphaStringFastest { x y ignore1 ignore2} {
    variable alphanum2Array;
    variable alphanum2Length;
    variable alphanum2LengthSquared;
    set len [ RandomNumber $x $y ]
    for {set i 0} {$i < $len} {incr i 4} {
        set randnumFull [ expr {int(rand() * $alphanum2LengthSquared)} ]
        set randnum1 [ expr {$randnumFull / $alphanum2Length} ]
        set randnum2 [ expr {$randnumFull % $alphanum2Length} ]
        append alphastring [lindex $alphanum2Array $randnum1 ]
        append alphastring [lindex $alphanum2Array $randnum2 ]
    }
    return [ string range $alphastring 0 $len-1 ]
}

proc CreateListProduct3 { chArray chalen } {
    for {set i 0} {$i < $chalen } {incr i } {
        set char1 [ lindex $chArray $i]
        for {set j 0} {$j < $chalen } {incr j } {
            set char2 [ lindex $chArray $j]
            for {set k 0} {$k < $chalen } {incr k } {
                set char3 [ lindex $chArray $k ]
                set combined $char1
                append combined $char2 $char3
                lappend products $combined
            }
        }
    }
    return $products
}

set alphanum3Array [CreateListProduct3 $alphanumArray $alphanumLength ]
set alphanum3Length [ llength $alphanum3Array ]
set alphanum3LengthSquared [ expr { $alphanum3Length * $alphanum3Length } ]

proc MakeAlphaStringMedium { x y ignore1 ignore2} {
    variable alphanum3Array;
    variable alphanum3Length;
    variable alphanum3LengthSquared;
    set len [ RandomNumber $x $y ]
    for {set i 0} {$i < $len} {incr i 6} {
        set randnumFull [ expr {int(rand() * $alphanum3LengthSquared)} ]
        set randnum1 [ expr {$randnumFull / $alphanum3Length} ]
        set randnum2 [ expr {$randnumFull % $alphanum3Length} ]
        append alphastring [lindex $alphanum3Array $randnum1 ]
        append alphastring [lindex $alphanum3Array $randnum2 ]
    }
    return [ string range $alphastring 0 $len-1 ]
}

proc MakeAlphaStringMedium2 { x y ignore1 ignore2 } {
    variable alphanum3Array;
    variable alphanum3Length;
    set len [ RandomNumber $x $y ]
    for {set i 0} {$i < $len} {incr i 3} {
        set randnum [ expr {int(rand() * $alphanum3Length)} ]
        append alphastring [lindex $alphanum3Array $randnum ]
    }
    return [ string range $alphastring 0 $len-1 ]
}

}
puts [time {benchutils::MakeAlphaString 300 500 $alphanumArray $alphanumLength } 100000]
puts [time {benchutils::MakeAlphaStringFast 300 500 0 0 } 100000]
puts [time {benchutils::MakeAlphaStringFastest 300 500 0 0 } 100000]
puts [time {benchutils::MakeAlphaStringMedium 300 500 0 0 } 100000]
puts [time {benchutils::MakeAlphaStringMedium2 300 500 0 0 } 100000]
```

Timing results of this benchmark script on my machine:
```
72.20168 microseconds per iteration
39.30159 microseconds per iteration
31.65163 microseconds per iteration
51.54411 microseconds per iteration
56.4996 microseconds per iteration
```