### PR TITLE
Make Linux hammerdb executable work with spaces in PATH

### DIFF
--- a/hammerdb
+++ b/hammerdb
@@ -1,9 +1,9 @@
 #!/bin/sh
 ########################################################################
 # \
-export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="./lib:$LD_LIBRARY_PATH"
 # \
-export PATH=./bin:$PATH
+export PATH="./bin:$PATH"
 # \
 exec wish8.6 -file $0 ${1+"$@"}
 # \

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -1,9 +1,9 @@
 #!/bin/sh
 #########################################################################
 ## \
-export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="./lib:$LD_LIBRARY_PATH"
 ## \
-export PATH=./bin:$PATH
+export PATH="./bin:$PATH"
 ## \
 exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 ########################################################################

--- a/hammerdbws
+++ b/hammerdbws
@@ -1,9 +1,9 @@
 #!/bin/sh
 #########################################################################
 ## \
-export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="./lib:$LD_LIBRARY_PATH"
 ## \
-export PATH=./bin:$PATH
+export PATH="./bin:$PATH"
 ## \
 exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 ########################################################################


### PR DESCRIPTION
If the $PATH variable contained spaces then it would result in an error
like this:

```
./hammerdb: 6: export: (x86)/Microsoft: bad variable name
```

By double quoting the usage of the existing $PATH variable bash handles
this correctly.