### PR TITLE
Fix getcols can return zero, resulting in divide-by-zero

### DIFF
--- a/modules/tclreadline-1.2.tm
+++ b/modules/tclreadline-1.2.tm
@@ -8,7 +8,7 @@ namespace eval TclReadLine {
     # Initialise our own env variables:
     variable PROMPT "hammerdb>"
     variable COMPLETION_MATCH ""
-    
+
     # Support extensions to the completion handling
     # which will be called in list order.
     # Initialize with the "open sourced" TCL base handler
@@ -20,17 +20,17 @@ namespace eval TclReadLine {
     #  a cygwin over ssh. 
     #
     variable READLINE_LATENCY 10 ;# in ms
-    
+
     variable CMDLINE ""
     variable CMDLINE_CURSOR 0
     variable CMDLINE_LINES 0
     variable CMDLINE_PARTIAL
-    
+
     variable ALIASES
     array set ALIASES {}
-    
+
     variable forever 0
-    
+
     # Resource and history files:
     variable HISTORY_SIZE 100
     variable HISTORY_LEVEL 0
@@ -39,30 +39,30 @@ namespace eval TclReadLine {
 }
 
 proc TclReadLine::setup_prompt_requirements {} {
-if {[string match windows $::tcl_platform(platform)]} {
-   package require twapi
-   package require twapi_input
-   twapi::set_console_title "HammerDB Command Line Interface"
-   proc enableRaw {{channel stdin}} {
-   set console_handle [twapi::GetStdHandle -10]
-   set oldmode [twapi::GetConsoleMode $console_handle]
-   set newmode [expr {$oldmode & ~6}] ;# Turn off the echo and line-editing bits
-   twapi::SetConsoleMode $console_handle $newmode
-}
-   proc disableRaw {{channel stdin}} {
-   set console_handle [twapi::GetStdHandle -10]
-   set oldmode [twapi::GetConsoleMode $console_handle]
-   set newmode [expr {$oldmode | 6}] ;# Turn on the echo and line-editing bits
-   twapi::SetConsoleMode $console_handle $newmode
-}
-	} else {
-    package require Expect
-    interp alias {} stty {} exp_stty
-    # Prevent sigint from killing our shell:
-    exp_trap SIG_IGN SIGINT
-    # Handle terminal resize events:
-    exp_trap ::TclReadLine::getColumns SIGWINCH
-	}
+    if {[string match windows $::tcl_platform(platform)]} {
+        package require twapi
+        package require twapi_input
+        twapi::set_console_title "HammerDB Command Line Interface"
+        proc enableRaw {{channel stdin}} {
+            set console_handle [twapi::GetStdHandle -10]
+            set oldmode [twapi::GetConsoleMode $console_handle]
+            set newmode [expr {$oldmode & ~6}] ;# Turn off the echo and line-editing bits
+            twapi::SetConsoleMode $console_handle $newmode
+        }
+        proc disableRaw {{channel stdin}} {
+            set console_handle [twapi::GetStdHandle -10]
+            set oldmode [twapi::GetConsoleMode $console_handle]
+            set newmode [expr {$oldmode | 6}] ;# Turn on the echo and line-editing bits
+            twapi::SetConsoleMode $console_handle $newmode
+        }
+    } else {
+        package require Expect
+        interp alias {} stty {} exp_stty
+        # Prevent sigint from killing our shell:
+        exp_trap SIG_IGN SIGINT
+        # Handle terminal resize events:
+        exp_trap ::TclReadLine::getColumns SIGWINCH
+    }
 }
 
 
@@ -79,7 +79,7 @@ proc TclReadLine::shift {ls} {
 
 proc TclReadLine::readbuf {txt} {
     upvar 1 $txt STRING
-    
+
     set ret [string index $STRING 0]
     set STRING [string range $STRING 1 end]
     return $ret
@@ -89,70 +89,78 @@ proc TclReadLine::goto {row {col 1}} {
     switch -- $row {
         "home" {set row 1}
     }
-if {[string match windows $::tcl_platform(platform)]} { ; } else {
-    print "[ESC]\[${row};${col}H" nowait
-	}
+    if {[string match windows $::tcl_platform(platform)]} { ; } else {
+        print "[ESC]\[${row};${col}H" nowait
+    }
 }
 
 proc TclReadLine::gotocol {col} {
     print "\r" nowait
     if {$col > 0} {
-if {[string match windows $::tcl_platform(platform)]} {
-set handle [ twapi::get_console_handle stdout ]
-set current [ twapi::get_console_cursor_position $handle ]
-set new [ lreplace $current 0 0 $col ]
-set current [ twapi::set_console_cursor_position $handle $new ]
-	} else {
-print "[ESC]\[${col}C" nowait
-	}
+        if {[string match windows $::tcl_platform(platform)]} {
+            set handle [ twapi::get_console_handle stdout ]
+            set current [ twapi::get_console_cursor_position $handle ]
+            set new [ lreplace $current 0 0 $col ]
+            set current [ twapi::set_console_cursor_position $handle $new ]
+        } else {
+            print "[ESC]\[${col}C" nowait
+        }
     }
 }
 
 proc TclReadLine::clear {} {
-if {[string match windows $::tcl_platform(platform)]} { 
-set handle [ twapi::get_console_handle stdout ]
-twapi::clear_console
- } else {
-    print "[ESC]\[2J" nowait
-	}
+    if {[string match windows $::tcl_platform(platform)]} { 
+        set handle [ twapi::get_console_handle stdout ]
+        twapi::clear_console
+    } else {
+        print "[ESC]\[2J" nowait
+    }
     goto home
 }
 
 proc TclReadLine::clearline {} {
-variable CMDLINE_CURSOR
-if {[string match windows $::tcl_platform(platform)]} { 
-set handle [twapi::get_standard_handle stdout]
-lassign [ split [ join [ lreplace [ twapi::get_console_screen_buffer_info $handle -cursorpos ] 0 0 ] ] ] col row
-#col always 9 as length of hammerdb> prompt
-twapi::fill_console $handle -numlines 1 -position "9,$row"
-	 } else {
-    print "[ESC]\[2K\r" nowait
-	}
+    variable CMDLINE_CURSOR
+    if {[string match windows $::tcl_platform(platform)]} { 
+        set handle [twapi::get_standard_handle stdout]
+        lassign [ split [ join [ lreplace [ twapi::get_console_screen_buffer_info $handle -cursorpos ] 0 0 ] ] ] col row
+        #col always 9 as length of hammerdb> prompt
+        twapi::fill_console $handle -numlines 1 -position "9,$row"
+    } else {
+        print "[ESC]\[2K\r" nowait
+    }
+}
+
+proc TclReadLine::checkColumns {cols} {
+    set defaultcols 80
+    if { [ string is entier $cols ] && $cols != 0 }  {
+        return $cols 
+    } else {
+        return $defaultcols
+    }
 }
 
 proc TclReadLine::getColumns {} {
     variable COLUMNS
-if {[string match windows $::tcl_platform(platform)]} {
-set cols 0
-set handle [twapi::get_standard_handle stdout]
-set cols [ lindex [ join [twapi::_get_console_screen_buffer_info $handle -size ] ] 1 ]
-   return [set COLUMNS $cols]
-	} else {
     set cols 0
-    if {![catch {stty size} size]} {
-        lassign $size rows cols
-    } elseif {![catch {stty -a} err]} {
-        # check for Linux stlye stty output
-        if {[regexp {rows (= )?(\d+); columns (= )?(\d+)} $err - i1 rows i2 cols]} {
-            return [set COLUMNS $cols]
-        }
-        # check for BSD style stty output
-        if {[regexp { (\d+) rows; (\d+) columns;} $err - rows cols]} {
-            return [set COLUMNS $cols]
+    if {[string match windows $::tcl_platform(platform)]} {
+        set handle [twapi::get_standard_handle stdout]
+        set cols [ lindex [ join [twapi::_get_console_screen_buffer_info $handle -size ] ] 1 ]
+        return [set COLUMNS [ checkColumns $cols ]]
+    } else {
+        if {![catch {stty size} size]} {
+            lassign $size rows cols
+        } elseif {![catch {stty -a} err]} {
+            # check for Linux stlye stty output
+            if {[regexp {rows (= )?(\d+); columns (= )?(\d+)} $err - i1 rows i2 cols]} {
+                return [set COLUMNS [ checkColumns $cols ]]
+            }
+            # check for BSD style stty output
+            if {[regexp { (\d+) rows; (\d+) columns;} $err - rows cols]} {
+                return [set COLUMNS [ checkColumns $cols ]]
+            }
         }
     }
-}
-    set COLUMNS $cols
+    set COLUMNS [ checkColumns $cols ]
 }
 
 proc TclReadLine::localInfo {args} {
@@ -170,7 +178,7 @@ proc TclReadLine::localPuts {args} {
     if { 3 < $l } {
         return -code error "Error: wrong \# args"
     }
-    
+
     if { 1 < $l } {
         if { [string equal "-nonewline" [lindex $args 0]] } {
             if { 2 < $l } {
@@ -208,7 +216,7 @@ proc TclReadLine::prompt {{txt ""}} {
     variable CMDLINE_CURSOR
     variable COLUMNS
     foreach {end mid} $CMDLINE_LINES break
-    
+
     # Calculate how many extra lines we need to display.
     # Also calculate cursor position:
     set n -1
@@ -217,7 +225,7 @@ proc TclReadLine::prompt {{txt ""}} {
     set cursorLen [expr {$CMDLINE_CURSOR+[string length $visprompt]}]
     set row 0
     set col 0
-    
+
     # Render output line-by-line to $out then copy back to $txt:
     set found 0
     set out [list]
@@ -228,7 +236,7 @@ proc TclReadLine::prompt {{txt ""}} {
             set cursorLen [expr {$cursorLen - ($totalLen - $len)}]
             set col [expr {$cursorLen % $COLUMNS}]
             set row [expr {$n + ($cursorLen / $COLUMNS) + 1}]
-            
+
             if {$cursorLen >= $len} {
                 set col 0
                 incr row
@@ -244,7 +252,7 @@ proc TclReadLine::prompt {{txt ""}} {
     }
     set txt [join $out "\n"]
     set row [expr {$n-$row}]
-    
+
     # Reserve spaces for display:
     if {$end} {
         if {$mid} {
@@ -257,10 +265,10 @@ proc TclReadLine::prompt {{txt ""}} {
     }
     clearline
     set CMDLINE_LINES $n
-    
+
     # Output line(s):
     print "\r$txt"
-    
+
     if {$row} {
         print "[ESC]\[${row}A" nowait
     }
@@ -282,14 +290,14 @@ proc TclReadLine::print {txt {wait wait}} {
 }
 
 proc TclReadLine::unknown {args} {
-    
+
     set name [lindex $args 0]
     set cmdline $TclReadLine::CMDLINE
     set cmd [string trim [regexp -inline {^\s*[^\s]+} $cmdline]]
     if {[info exists TclReadLine::ALIASES($cmd)]} {
         set cmd [regexp -inline {^\s*[^\s]+} $TclReadLine::ALIASES($cmd)]
     }
-    
+
     set new [auto_execok $name]
     if {$new != ""} {
         set redir ""
@@ -297,16 +305,16 @@ proc TclReadLine::unknown {args} {
             set redir ">&@ stdout <@ stdin"
         }
         if {[catch {
-           uplevel 1 exec $redir $new [lrange $args 1 end]} ret]
+            uplevel 1 exec $redir $new [lrange $args 1 end]} ret]
         } {
             return
         }
         return $ret
     } else {
-if { [catch {uplevel _unknown $args} message]} {
-puts "Error: $message"
-	}
-	}
+        if { [catch {uplevel _unknown $args} message]} {
+            puts "Error: $message"
+        }
+    }
 }
 
 proc TclReadLine::alias {word command} {
@@ -321,10 +329,10 @@ proc TclReadLine::unalias {word} {
 
 # Key bindings
 proc TclReadLine::handleEscapes {} {
-    
+
     variable CMDLINE
     variable CMDLINE_CURSOR
-    
+
     upvar 1 keybuffer keybuffer
     set seq ""
     set found 0
@@ -382,13 +390,13 @@ proc TclReadLine::handleEscapes {} {
 }
 
 proc TclReadLine::handleControls {} {
-    
+
     variable CMDLINE
     variable CMDLINE_CURSOR
-    
+
     upvar 1 char char
     upvar 1 keybuffer keybuffer
-    
+
     # Control chars start at a == \u0001 and count up.
     switch -exact -- $char {
         \u0001 { ;# ^a
@@ -447,14 +455,14 @@ proc TclReadLine::handleControls {} {
         \u007f { ;# ^h && backspace ?
             if {$CMDLINE_CURSOR > 0} {
                 incr CMDLINE_CURSOR -1
-if {[string match windows $::tcl_platform(platform)]} {
-		set pos $CMDLINE_CURSOR
-		set pos2 [ expr $CMDLINE_CURSOR + 2 ]
-                set CMDLINE [string replace $CMDLINE $pos $pos2 " " ]
-	} else {
-                set CMDLINE [string replace $CMDLINE \
+                if {[string match windows $::tcl_platform(platform)]} {
+                    set pos $CMDLINE_CURSOR
+                    set pos2 [ expr $CMDLINE_CURSOR + 2 ]
+                    set CMDLINE [string replace $CMDLINE $pos $pos2 " " ]
+                } else {
+                    set CMDLINE [string replace $CMDLINE \
                                  $CMDLINE_CURSOR $CMDLINE_CURSOR]
-		}
+                }
             }
         }
         \u001b { ;# ESC - handle escape sequences
@@ -505,12 +513,12 @@ proc TclReadLine::handleCompletion {} {
 proc TclReadLine::handleCompletionBase {} {
     variable CMDLINE
     variable CMDLINE_CURSOR
-    
+
     set vars ""
     set cmds ""
     set execs ""
     set files ""
-    
+
     # First find out what kind of word we need to complete:
     set wordstart [string last " " $CMDLINE [expr {$CMDLINE_CURSOR-1}]]
     incr wordstart
@@ -521,18 +529,18 @@ proc TclReadLine::handleCompletionBase {} {
         incr wordend -1
     }
     set word [string range $CMDLINE $wordstart $wordend]
-    
+
     if {[string trim $word] == ""} return
-    
+
     set firstchar [string index $word 0]
-    
+
     # Check if word is a variable:
     if {$firstchar == "\$"} {
         set word [string range $word 1 end]
         incr wordstart
-        
+
         # Check if it is an array key:proc
-        
+
         set x [string first "(" $word]
         if {$x != -1} {
             set v [string range $word 0 [expr {$x-1}]]
@@ -566,7 +574,7 @@ proc TclReadLine::handleCompletionBase {} {
                     foreach f [glob -nocomplain -directory $dir -- $word*] {
                         set exe [string trimleft [string range $f \
                                                       [string length $dir] end] "/"]
-                        
+
                         if {[lsearch -exact $execs $exe] == -1} {
                             lappend execs $exe
                         }
@@ -607,7 +615,7 @@ proc TclReadLine::handleCompletionBase {} {
             }
         }
     }
-    
+
     variable COMPLETION_MATCH
     set maybe [concat $vars $cmds $execs $files]
     set shortest [shortMatch $maybe]
@@ -634,7 +642,7 @@ proc TclReadLine::handleCompletionBase {} {
         }
     } else {
         if {[file isdirectory $shortest] &&
-            [string index $shortest end] != "/"} {
+        [string index $shortest end] != "/"} {
             append shortest "/"
         }
         if {$shortest != ""} {
@@ -655,7 +663,7 @@ proc TclReadLine::handleHistory {x} {
     variable CMDLINE
     variable CMDLINE_CURSOR
     variable CMDLINE_PARTIAL
-    
+
     set maxid [expr {[history nextid] - 1}]
     if {$maxid > 0} {
         #
@@ -699,7 +707,7 @@ proc TclReadLine::handleHistory {x} {
 
 proc TclReadLine::getHistory {} {
     variable HISTORY_SIZE
-    
+
     set l [list]
     set e [history nextid]
     set i [expr {$e - $HISTORY_SIZE}]
@@ -723,21 +731,21 @@ proc TclReadLine::setHistory {hlist} {
 proc TclReadLine::rawInput {} {
     fconfigure stdin -buffering none -blocking 0
     fconfigure stdout -buffering none -translation auto
-if {[string match windows $::tcl_platform(platform)]} {
-enableRaw
-	} else {
-    stty raw -echo
-	}
+    if {[string match windows $::tcl_platform(platform)]} {
+        enableRaw
+    } else {
+        stty raw -echo
+    }
 }
 
 proc TclReadLine::lineInput {} {
     fconfigure stdin -buffering line -blocking 1
     fconfigure stdout -buffering line
-if {[string match windows $::tcl_platform(platform)]} {
-disableRaw
-	} else {
-    stty -raw echo
-	}
+    if {[string match windows $::tcl_platform(platform)]} {
+        disableRaw
+    } else {
+        stty -raw echo
+    }
 }
 
 proc TclReadLine::doExit {{code 0}} {
@@ -746,10 +754,10 @@ proc TclReadLine::doExit {{code 0}} {
 
     # Reset terminal:
     #print "[ESC]c[ESC]\[2J" nowait
-    
+
     restore ;# restore "info' command -
     lineInput
-    
+
     set hlist [getHistory]
     #
     # Get rid of the TclReadLine::doExit, shouldn't be more than one
@@ -770,7 +778,7 @@ proc TclReadLine::doExit {{code 0}} {
         }
         close $f
     }
-    
+
     exit $code
 }
 
@@ -799,7 +807,7 @@ proc TclReadLine::interact {} {
     variable HISTFILE
     variable HISTORY_SIZE
     history keep $HISTORY_SIZE
-    
+
     if {[file exists $HISTFILE]} {
         set f [open $HISTFILE r]
         set hlist [list]
@@ -817,20 +825,20 @@ proc TclReadLine::interact {} {
         unset hlist
         close $f
     }
-    
+
     rawInput
-    
+
     # This is to restore the environment on exit:
     # Do not unalias this!
     alias exit TclReadLine::doExit
-    
+
     variable ThisScript [info script]
-    
+
     tclline ;# emit the first prompt
     fileevent stdin readable TclReadLine::tclline
     variable forever
     vwait TclReadLine::forever
-    
+
     restore
 }
 
@@ -857,13 +865,13 @@ proc TclReadLine::tclline {} {
     variable COLUMNS
     variable CMDLINE_CURSOR
     variable CMDLINE
-    
+
     set char ""
     set keybuffer [read stdin]
     set COLUMNS [getColumns]
-    
+
     check_partial_keyseq keybuffer
-    
+
     while {$keybuffer != ""} {
         if {[eof stdin]} return
         set char [readbuf keybuffer]
@@ -872,12 +880,12 @@ proc TclReadLine::tclline {} {
             after 40
             continue
         }
-        
+
         if {[string is print $char]} {
             set x $CMDLINE_CURSOR
-            
+
             if {$x < 1 && [string trim $char] == ""} continue
-            
+
             set trailing [string range $CMDLINE $x end]
             set CMDLINE [string replace $CMDLINE $x end]
             append CMDLINE $char
@@ -891,7 +899,7 @@ proc TclReadLine::tclline {} {
                 lineInput
                 print "\n" nowait
                 uplevel \#0 {
-                    
+
                     # Handle aliases:
                     set cmdline $TclReadLine::CMDLINE
                     #
@@ -902,7 +910,7 @@ proc TclReadLine::tclline {} {
                     if {[info exists TclReadLine::ALIASES($cmd)]} {
                         regsub -- "(?q)$cmd" $cmdline $TclReadLine::ALIASES($cmd) cmdline
                     }
-                    
+
                     # Perform glob substitutions:
                     set cmdline [string map {
                         "\\*" \0
@@ -923,7 +931,7 @@ proc TclReadLine::tclline {} {
                         foreach {i n} $x break
                         set s [string range $cmdline $i $n]
                         set x [glob -nocomplain -- $s]
-                        
+
                         # If glob can't find anything then don't do
                         # glob substitution, pass * or ~ as literals:
                         if {$x == ""} {
@@ -938,7 +946,7 @@ proc TclReadLine::tclline {} {
                         \0 "*"
                         \1 "~"
                     } $cmdline]
-                    
+
                     rename ::info ::_info
                     rename TclReadLine::localInfo ::info
 
@@ -947,7 +955,7 @@ proc TclReadLine::tclline {} {
                     if {[info exists TclReadLine::CMDLINE_PARTIAL]} {
                         unset TclReadLine::CMDLINE_PARTIAL
                     }
-                    
+
                     # Run the command:
                     set code [catch $cmdline res]
                     rename ::info TclReadLine::localInfo
@@ -957,7 +965,7 @@ proc TclReadLine::tclline {} {
                     } else {
                         TclReadLine::print "$res\n"
                     }
-                    
+
                     set TclReadLine::CMDLINE ""
                     set TclReadLine::CMDLINE_CURSOR 0
                     set TclReadLine::CMDLINE_LINES {0 0}
@@ -965,9 +973,9 @@ proc TclReadLine::tclline {} {
                 rawInput
             } else {
                 set x $CMDLINE_CURSOR
-                
+
                 if {$x < 1 && [string trim $char] == ""} continue
-                
+
                 set trailing [string range $CMDLINE $x end]
                 set CMDLINE [string replace $CMDLINE $x end]
                 append CMDLINE $char


### PR DESCRIPTION
Fix for Issue #289, when run in Kubernetes interactive mode, getcols can return a terminal width of zero. This checks if the columns value is detected, if not it will set a default value of 80. 