### PR TITLE
set MariaDB autocommit to 1 for Monitor VU

### DIFF
--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -1756,6 +1756,7 @@ switch $myposition {
     1 { 
         if { $mode eq "Local" || $mode eq "Primary" } {
 	set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password $db ]
+        maria::autocommit $maria_handler 1
             set ramptime 0
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
@@ -2185,6 +2186,7 @@ switch $myposition {
     1 { 
         if { $mode eq "Local" || $mode eq "Primary" } {
 	set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password $db ]
+        maria::autocommit $maria_handler 1
             set ramptime 0
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]


### PR DESCRIPTION
Minor fix for bug introduced by modifying MariaDB connect procedure for SSL. By default autocommit is set to 0. Monitor VU needs value set to 1 otherwise querying of NOPM value returns 0. 
PR sets autocommit to 1 for the monitor VU to prestore previous behaviour. 