### PR TITLE
fix issue 309 both mysql/postgresql lost connection

### DIFF
--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -955,6 +955,7 @@ proc do_tpcc { host port socket count_ware user password db mysql_storage_engine
                 set num_part 0
             }
             CreateTables $mysql_handler $mysql_storage_engine $num_part
+            CreateStoredProcs $mysql_handler
         } else {
             error $mysqlstatus(message)
             return
@@ -1037,7 +1038,6 @@ proc do_tpcc { host port socket count_ware user password db mysql_storage_engine
         }
     }
     if { $threaded eq "SINGLE-THREADED" || $threaded eq "MULTI-THREADED" && $myposition eq 1 } {
-        CreateStoredProcs $mysql_handler
         GatherStatistics $mysql_handler
         puts "[ string toupper $db ] SCHEMA COMPLETE"
         mysqlclose $mysql_handler

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2127,6 +2127,8 @@ proc do_tpcc { host port sslmode count_ware superuser superuser_password default
                     set num_part 0
                 }
                 CreateTables $lda $ora_compatible $citus_compatible $num_part
+                CreateIndexes $lda
+                CreateStoredProcs $lda $ora_compatible $citus_compatible $pg_storedprocs
                 set result [ pg_exec $lda "commit" ]
                 pg_result $result -clear
             }
@@ -2195,8 +2197,6 @@ proc do_tpcc { host port sslmode count_ware superuser superuser_password default
         }
     }
     if { $threaded eq "SINGLE-THREADED" || $threaded eq "MULTI-THREADED" && $myposition eq 1 } {
-        CreateIndexes $lda
-        CreateStoredProcs $lda $ora_compatible $citus_compatible $pg_storedprocs
         GatherStatistics $lda 
         puts "[ string toupper $user ] SCHEMA COMPLETE"
         pg_disconnect $lda


### PR DESCRIPTION
When I use HammerDB to run a TPC-C benchmarking on mysql and postgresql database, I suffered the db lost connection issue  both on AWS Cloud and on Prem. With a loop investigating in HammerDB's source code, I addressed the root cause that

1. The TPC-C will run 2 stage, the 1st stage is to build schema, while the 2nd is to really run hammer stressing.
2. The db lost connection always occurs at the 1st stage, looking into the code, HammerDB will multiple thread to load the data, suppose you specify N virtual users to build the schema, HammerDb will use 1+N threads to build the schema, the `1` thread will be responsible for create database/tables...then the N threads will go to load table datas, finally back to `1` thread to create stored procedure(Where the issue occurs), since to load a large warehouse(800) table data will cost a long time(1h),  the db connection the '1' thread hold will be timeout, so the step to create stored procedure will fail and always fails here.  per my understanding HammerDB should have introduce a db connection retry method for each db operation. Here my fix is just an workaround.

BTW, to config any timeout parameters it didn't work fine, but to specify a minor warehouse number, the issue not found. However since it is to run performance test, the warehouse cannot be decreased. 