### PR TITLE
Added Dockerfile to build a HammerDB container and TPROC_C sample scripts to build schema and run tests

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,78 @@
+FROM       ubuntu:20.04
+LABEL maintainer="Pooja Jain"
+
+# For apt install without question
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Enable apt sources
+RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
+
+# Set working directory
+WORKDIR /home/hammerdb
+
+# Update & upgrade apt and download basic utilities
+RUN apt update && \
+    apt -y upgrade && \
+    apt -y install -q \
+    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat
+
+# Install and configure Microsoft SQLServer client libraries
+RUN apt -y install -q \ 
+    apt -y curl gcc make && \
+    curl https://packages.microsoft.com/keys/microsoft.asc |  apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get -yq install mssql-tools  && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile && \
+    wget http://www.unixodbc.org/unixODBC-2.3.9.tar.gz && tar -xzvf unixODBC-2.3.9.tar.gz && cd unixODBC-2.3.9 && \ 
+    ./configure --prefix=/usr/local/unixODBC --enable-gui=no --enable-drivers=no --enable-iconv --with-iconv-char-enc=UTF8 \
+    --with-iconv-ucode-enc=UTF16LE --enable-threads=yes --enable-fastvalidate && make && make install && cd .. && \ 
+    echo 'export PATH="$PATH:/opt/mssql-tools/bin:/usr/local/unixODBC/bin"' >> ~/.bashrc && \
+    echo 'export ODBCINI="/usr/local/unixODBC/etc/odbc.ini"'  >> ~/.bashrc && \
+    echo 'export ODBCSYSINI="/usr/local/unixODBC/etc"'  >> ~/.bashrc && \
+    echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/unixODBC/lib"'  >> ~/.bashrc && \
+    rm -rf *.tar.gz *.zip unixODBC-2.3.9 
+   
+# Install and configure Oracle client libraries
+RUN wget https://download.oracle.com/otn_software/linux/instantclient/215000/instantclient-basic-linux.x64-21.5.0.0.0dbru.zip && \
+    unzip *.zip && \
+    echo 'export LD_LIBRARY_PATH=/home/hammerdb/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
+    echo 'export ORACLE_LIBRARY=/home/hammerdb/instantclient_21_5/libclntsh.so'  >> ~/.bashrc
+  
+# Install and configure IBM Db2 client libraries, 
+# You will need to pre-download IDB Db2 client libraries and place in the local folder
+ RUN mkdir -p db2_cli_odbc_driver/odbc_cli
+ ADD odbc_cli db2_cli_odbc_driver/odbc_cli/
+ RUN apt update && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt -y install libxml2 && \
+    echo 'export DB2_CLI_DRIVER_INSTALL_PATH="/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver"' >> ~/.bashrc && \
+    echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
+    echo 'export LIBPATH="/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
+    echo 'export PATH="$PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/bin"' >> ~/.bashrc && \
+    echo 'export PATH="$PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/adm"' >>  ~/.bashrc
+
+# Install and Configure MariaDB client libraries
+RUN apt install -y libmariadb3
+
+# Install and configure PostgreSQL client libraries
+RUN apt install -y libpq-dev 
+
+# Install and configuring MySQL client libraries
+RUN apt install -y libmysqlclient21
+
+# Install configure HammerDB-v4.4
+RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.4/HammerDB-4.4-Linux.tar.gz && \
+    tar -xvzf HammerDB-4.4-Linux.tar.gz && ls && \
+    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
+    rm -rf *.tar.gz *.zip unixODBC-2.3.9    
+WORKDIR /home/hammerdb/HammerDB-4.4
+
+# Adding some sample scripts to be used with HammerDB command line interface
+ADD sample_scripts /home/hammerdb/HammerDB-4.4/sample_scripts
+
+CMD "bash"
+
+#To create an image: Go to the folder containing the Dockerfile 
+#     docker build -t hammerdb-v4.4 .
+#To start a container with that image
+#     docker run -it -name hammerdb hammerdb-v4.4 bash

--- a/Docker/Readme
+++ b/Docker/Readme
@@ -1,0 +1,12 @@
+
+This folder provides a Dockerfile for building a HammerDb-v4.4 client container that supports all the databases HammerDB is enabled for, i.e. Oracle, Microsoft SQL Server, IBM Db2, MySQL, PostgreSQL and MariaDB. However for enabling client libraries for IBM Db2, you will need to download the client libraries from IBM web portal. For seamless build from Dockerfile, you can place the downloaded IBM Db2 client libraries,  "odbc_cli" alongside Dockerfile in the same folder where you plan to build the HammerD container. For someone who doesn't need IBM DB2 client, they can create a empty folder as "odbc_cli".
+
+To create an image: Go to the folder containing the Dockerfile
+	docker build -t hammerdb-v4.4 .
+
+To start a container named "hammerdb" with the image, "hammerdb-v4.4" built from from Dockerfile
+	docker run -it --name hammerdb hammerdb-v4.4 bash
+
+You will need to add networking to communicate with a remote database when starting the container
+For example, adding host network to the container.
+	docker run --network=host -it --name hammerdb hammerdb-v4.4 bash

--- a/Docker/odbc_cli/Readme
+++ b/Docker/odbc_cli/Readme
@@ -1,0 +1,1 @@
+Please download IBM Db2 client libraries and place them under this folder.

--- a/Docker/sample_scripts/tprocc/db2_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/db2_tprocc_build.tcl
@@ -1,0 +1,32 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db db2
+dbset bm TPC-C
+
+diset connection db2_def_user db2inst1
+diset connection db2_def_pass ibmdb2
+diset connection db2_def_dbase db2
+
+diset tpcc db2_count_ware 1
+diset tpcc db2_num_vu 1
+diset tpcc db2_user db2inst1
+diset tpcc db2_pass ibmdb2
+diset tpcc db2_dbase tpcc
+diset tpcc db2_def_tab USERSPACE1
+diset tpcc db2_partition true
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/db2_tprocc_build.tcl
+

--- a/Docker/sample_scripts/tprocc/db2_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/db2_tprocc_run.tcl
@@ -1,0 +1,43 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db db2
+dbset bm TPC-C
+
+diset connection db2_def_user db2inst1
+diset connection db2_def_pass ibmdb2
+
+diset tpcc db2_user ibmdb2
+diset tpcc db2_pass db2
+diset tpcc db2_dbase tpcc
+diset tpcc db2_total_iterations 10000000
+diset tpcc db2_driver timed
+diset tpcc db2_rampup 2
+diset tpcc db2_duration 5
+diset tpcc db2_monreport 0
+diset tpcc db2_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/db2_tprocc_run.tcl
+

--- a/Docker/sample_scripts/tprocc/maria_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/maria_tprocc_build.tcl
@@ -10,7 +10,7 @@ dbset bm TPC-C
 
 diset connection maria_host localhost
 diset connection maria_port 3306
-diset connection maria_host /tmp/mariadb.sock
+diset connection maria_sock /tmp/mariadb.sock
 
 diset tpcc maria_count_ware 1
 diset tpcc maria_num_vu 1

--- a/Docker/sample_scripts/tprocc/maria_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/maria_tprocc_build.tcl
@@ -1,0 +1,31 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db maria
+dbset bm TPC-C
+
+diset connection maria_host localhost
+diset connection maria_port 3306
+diset connection maria_host /tmp/mariadb.sock
+
+diset tpcc maria_count_ware 1
+diset tpcc maria_num_vu 1
+diset tpcc maria_pass maria
+diset tpcc maria_dbase tpcc
+diset tpcc maria_storage_engine innodb
+diset tpcc maria_partition false 
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/maria_tprocc_build.tcl
+

--- a/Docker/sample_scripts/tprocc/maria_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/maria_tprocc_run.tcl
@@ -1,0 +1,43 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db maria
+dbset bm TPC-C
+
+diset connection maria_host localhost
+diset connection maria_port 3306
+diset connection maria_host /tmp/mariadb.sock
+
+diset tpcc maria_user root
+diset tpcc maria_pass maria
+diset tpcc maria_dbase tpcc
+diset tpcc maria_driver timed
+diset tpcc maria_rampup 2
+diset tpcc maria_duration 5
+diset tpcc maria_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/maria_tprocc_run.tcl
+
+
+

--- a/Docker/sample_scripts/tprocc/maria_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/maria_tprocc_run.tcl
@@ -10,7 +10,7 @@ dbset bm TPC-C
 
 diset connection maria_host localhost
 diset connection maria_port 3306
-diset connection maria_host /tmp/mariadb.sock
+diset connection maria_sock /tmp/mariadb.sock
 
 diset tpcc maria_user root
 diset tpcc maria_pass maria

--- a/Docker/sample_scripts/tprocc/mssqls_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/mssqls_tprocc_build.tcl
@@ -1,0 +1,29 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path where you want to log results.
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-C
+
+diset connection mssqls_host localhost
+diset connection mssqls_authentication windows
+diset connection mssqls_odbc_driver "ODBC Driver 17 for SQL Server"
+
+diset tpcc mssqls_count_ware 1
+diset tpcc mssqls_num_vu 1
+diset tpcc mssqls_pass mssqls
+diset tpcc mssqls_dbase tpcc
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/mssqls_tprocc_build.tcl
+

--- a/Docker/sample_scripts/tprocc/mssqls_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/mssqls_tprocc_run.tcl
@@ -1,0 +1,45 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-C
+
+diset connection mssqls_host localhost
+diset connection mssqls_authentication windows
+#How to specify the ODBC driver here, it has spaces, in double quotes?
+diset connection mssqls_odbc_driver "ODBC Driver 17 for SQL Server"
+
+diset tpcc mssqls_user root
+diset tpcc mssqls_pass mssqls
+diset tpcc mssqls_dbase tpcc
+diset tpcc mssqls_driver timed
+diset tpcc mssqls_total_iterations 10000000
+diset tpcc mssqls_checkpoint true
+diset tpcc mssqls_rampup 2
+diset tpcc mssqls_duration 5
+diset tpcc mssqls_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/mssqls_tprocc_run.tcl
+
+

--- a/Docker/sample_scripts/tprocc/mysql_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/mysql_tprocc_build.tcl
@@ -10,7 +10,7 @@ dbset bm TPC-C
 
 diset connection mysql_host localhost
 diset connection mysql_port 3306
-diset connection mysql_host /tmp/mysql.sock
+diset connection mysql_sock /tmp/mysql.sock
 
 diset tpcc mysql_count_ware 1
 diset tpcc mysql_num_vu 1

--- a/Docker/sample_scripts/tprocc/mysql_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/mysql_tprocc_build.tcl
@@ -1,0 +1,31 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db mysql
+dbset bm TPC-C
+
+diset connection mysql_host localhost
+diset connection mysql_port 3306
+diset connection mysql_host /tmp/mysql.sock
+
+diset tpcc mysql_count_ware 1
+diset tpcc mysql_num_vu 1
+diset tpcc mysql_pass mysql
+diset tpcc mysql_dbase tpcc
+diset tpcc mysql_storage_engine innodb
+diset tpcc mysql_partition false 
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/mysql_tprocc_build.tcl
+

--- a/Docker/sample_scripts/tprocc/mysql_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/mysql_tprocc_run.tcl
@@ -1,0 +1,43 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db mysql
+dbset bm TPC-C
+
+diset connection mysql_host localhost
+diset connection mysql_port 3306
+diset connection mysql_host /tmp/mysql.sock
+
+diset tpcc mysql_user root
+diset tpcc mysql_pass mysql
+diset tpcc mysql_dbase tpcc
+diset tpcc mysql_driver timed
+diset tpcc mysql_rampup 2
+diset tpcc mysql_duration 5
+diset tpcc mysql_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/mysql_tprocc_run.tcl
+
+
+

--- a/Docker/sample_scripts/tprocc/mysql_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/mysql_tprocc_run.tcl
@@ -10,7 +10,7 @@ dbset bm TPC-C
 
 diset connection mysql_host localhost
 diset connection mysql_port 3306
-diset connection mysql_host /tmp/mysql.sock
+diset connection mysql_sock /tmp/mysql.sock
 
 diset tpcc mysql_user root
 diset tpcc mysql_pass mysql

--- a/Docker/sample_scripts/tprocc/ora_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/ora_tprocc_build.tcl
@@ -1,0 +1,35 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-C
+
+diset connection system_user system
+diset connection system_password manager
+diset connection instance oracle
+
+diset tpcc count_ware 1
+diset tpcc num_vu 1
+diset tpcc tpcc_user tpcc        
+diset tpcc tpcc_pass tpcc      
+diset tpcc tpcc_def_tab tpcctab  
+diset tpcc tpcc_ol_tab tpcctab
+diset tpcc tpcc_def_temp temp
+diset tpcc partition false
+diset tpcc hash_clusters false
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/ora_tprocc_build.tcl
+~
+

--- a/Docker/sample_scripts/tprocc/ora_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/ora_tprocc_run.tcl
@@ -1,0 +1,42 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-C
+
+diset connection system_user system
+diset connection system_password manager
+diset connection instance oracle
+
+diset tpcc tpcc_user tpcc        
+diset tpcc tpcc_pass tpcc      
+diset tpcc ora_driver timed
+diset tpcc total_iterations 1000000
+diset tpcc checkpoint true
+diset tpcc rampup 2 
+diset tpcc duration 5        
+diset tpcc ora_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/ora_tprocc_run.tcl

--- a/Docker/sample_scripts/tprocc/pg_tprocc_build.tcl
+++ b/Docker/sample_scripts/tprocc/pg_tprocc_build.tcl
@@ -1,0 +1,34 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db pg
+dbset bm TPC-C
+
+diset connection pg_host localhost
+diset connection pg_port 5432
+diset connection pg_sslmode prefer
+
+diset tpcc pg_count_ware 1
+diset tpcc pg_num_vu 1
+diset tpcc pg_superuser postgres
+diset tpcc pg_superuserpass postgres
+diset tpcc pg_defaultdbase postgres
+diset tpcc pg_user tpcc
+diset tpcc pg_pass tpcc
+diset tpcc pg_tspace tpcc
+diset tpcc pg_storedprocs true
+diset tpcc pg_partition false
+
+print dict
+vuset logtotemp 1
+buildschema
+waittocomplete
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/pg_tprocc_build.tcl

--- a/Docker/sample_scripts/tprocc/pg_tprocc_run.tcl
+++ b/Docker/sample_scripts/tprocc/pg_tprocc_run.tcl
@@ -1,0 +1,47 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+
+#Set the path for logs directory. By Default logs are logged in /tmp
+export TMP="/tmp"
+
+puts "SETTING CONFIGURATION"
+dbset db pg
+dbset bm TPC-C
+
+diset connection pg_host localhost
+diset connection pg_port 5432
+diset connection pg_sslmode prefer
+
+diset tpcc pg_superuser postgres
+diset tpcc pg_superuserpass postgres
+diset tpcc pg_defaultdbase postgres
+diset tpcc pg_user tpcc
+diset tpcc pg_pass tpcc
+diset tpcc pg_dbase tpcc
+diset tpcc pg_driver timed
+diset tpcc pg_total_iterations 10000000
+diset tpcc pg_rampup 2
+diset tpcc pg_duration 5
+diset tpcc pg_vaccum true
+diset tpcc pg_timeprofile false
+
+print dict
+vuset logtotemp 1
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+tcstart
+tcstatus
+vurun
+runtimer 500
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+
+
+#For Advanced configuration changes, check configuration parameters using command "print dict" in ./hammerdbcli
+
+#Command to run the script
+# ./hammerdbcli auto sample_scripts/tprocc/pg_tprocc_run.tcl
+


### PR DESCRIPTION
Dockerfile builds a ubuntu 20.04 HammerDB container that installs all the client libraries for databases supported by HammerDB. 
Adding some sample scripts for all databases to build schema and do a test run for TPROC-C workload. 