### PR TITLE
Escape username and database name in PostgreSQL procedures

### DIFF
--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -74,17 +74,17 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
     puts "CREATING DATABASE $db under OWNER $user"
     set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
     if { [pg_result $result -numTuples] == 0 } {
-        set sql($stmnt_count) "CREATE USER $user PASSWORD '$password'"
+        set sql($stmnt_count) "CREATE USER \"$user\" PASSWORD '$password'"
         incr stmnt_count;
-        set sql($stmnt_count) "GRANT $user to $superuser"
+        set sql($stmnt_count) "GRANT \"$user\" to \"$superuser\""
     } else {
         puts "Using existing User $user for Schema build"
-        set sql($stmnt_count) "ALTER USER $user PASSWORD '$password'"
+        set sql($stmnt_count) "ALTER USER \"$user\" PASSWORD '$password'"
     }
     incr stmnt_count;
     set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
     if { [pg_result $result -numTuples] == 0} {
-        set sql($stmnt_count) "CREATE DATABASE $db OWNER $user"
+        set sql($stmnt_count) "CREATE DATABASE \"$db\" OWNER \"$user\""
     } else {
         set existing_db [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $db ]
         if { $existing_db eq "Failed" } {
@@ -93,7 +93,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
             set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
             if { [pg_result $result -numTuples] == 0 } {
                 puts "Using existing empty Database $db for Schema build"
-                set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+                set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
             } else {
                 puts "Database with tables $db exists"
                 error "Database $db exists but is not empty, specify a new or empty database name"

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -1608,17 +1608,17 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
     puts "CREATING DATABASE $db under OWNER $user"
     set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
     if { [pg_result $result -numTuples] == 0 } {
-        set sql($stmnt_count) "CREATE USER $user PASSWORD '$password'"
+        set sql($stmnt_count) "CREATE USER \"$user\" PASSWORD '$password'"
         incr stmnt_count;
-        set sql($stmnt_count) "GRANT $user to $superuser"
+        set sql($stmnt_count) "GRANT \"$user\" to \"$superuser\""
     } else {
         puts "Using existing User $user for Schema build"
-        set sql($stmnt_count) "ALTER USER $user PASSWORD '$password'"
+        set sql($stmnt_count) "ALTER USER \"$user\" PASSWORD '$password'"
     }
     incr stmnt_count;
     set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
     if { [pg_result $result -numTuples] == 0} {
-        set sql($stmnt_count) "CREATE DATABASE $db OWNER $user"
+        set sql($stmnt_count) "CREATE DATABASE \"$db\" OWNER \"$user\""
     } else {
         set existing_db [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $db ]
         if { $existing_db eq "Failed" } {
@@ -1627,7 +1627,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
             set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
             if { [pg_result $result -numTuples] == 0 } {
                 puts "Using existing empty Database $db for Schema build"
-                set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+                set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
             } else {
                 puts "Database with tables $db exists"
                 error "Database $db exists but is not empty, specify a new or empty database name"


### PR DESCRIPTION
Valid database names and usernames might have upper case characters. However, if
they are passed without proper escaping PostgreSQL will end up referencing the
name using wrong case and later the procedure will error on not finding the
correct username or database name.

Fix this by using double quotes when passing usernames or database names.

All new code of the whole pull request, including one or several files that are
either new files or modified ones, are contributed under the BSD-new license. I
am contributing on behalf of my employer Amazon Web Services, Inc.