### PR TITLE
Dependency build automation for Windows

### DIFF
--- a/Build/Bawt-2.1.0/Build-Windows.bat
+++ b/Build/Bawt-2.1.0/Build-Windows.bat
@@ -45,6 +45,8 @@ set BAWTOPTS=--rootdir %OUTROOTDIR% ^
              --architecture %ARCH% ^
              --compiler %COMPILER% ^
              --numjobs %NUMJOBS% ^
+             --url http://www.hammerdb.com/build ^
+	     --finalizefile Setup\HammerDBFinalize.bawt ^
              --logviewer
 
 rem Build all libraries as listed in Setup file.

--- a/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
@@ -4,20 +4,20 @@
 # Setup LibName         ZipFile                        BuildFile           BuildOptions
 
 # Tcl/Tk, stubs and manual.
-Setup Tcl               Tcl-[GetTclVersion].7z         Tcl.bawt
-Setup Tk                Tk-[GetTkVersion].7z           Tk.bawt
+Setup Tcl               Tcl-[GetTclVersion].7z         Tcl.bawt		
+Setup Tk                Tk-[GetTkVersion].7z           Tk.bawt		
 # Compiled Tcl packages.
-Setup expect            expect-5.45.4.7z               expect.bawt
+Setup expect            expect-5.45.4.7z               expect.bawt	
+Setup libressl          libressl-2.6.4.7z              libressl.bawt	
+Setup tcltls            tcltls-1.7.22.7z               tcltls.bawt	
 Setup tksvg             tksvg-0.5.7z                   tksvg.bawt
 Setup tkblt             tkblt-3.2.23.7z                tkblt.bawt
-Setup libressl          libressl-2.6.4.7z              libressl.bawt
-Setup tcltls            tcltls-1.7.22.7z               tcltls.bawt
 # Compiled Tcl Database interface packages.
-Setup oratcl            oratcl-4.6.7z                  oratcl.bawt
-Setup mariatcl          mariatcl-0.1.7z                mariatcl.bawt
-Setup mysqltcl          mysqltcl-3.052.7z              mysqltcl.bawt
-Setup db2tcl            db2tcl-2.0.1.7z                db2tcl.bawt
-Setup pgtcl             pgtcl-2.1.1.7z                 pgtcl.bawt
+Setup oratcl            oratcl-4.6.7z                  oratcl.bawt	
+Setup mariatcl          mariatcl-0.1.7z                mariatcl.bawt	
+Setup mysqltcl          mysqltcl-3.052.7z              mysqltcl.bawt	
+Setup db2tcl            db2tcl-2.0.1.7z                db2tcl.bawt	
+Setup pgtcl             pgtcl-2.1.1.7z                 pgtcl.bawt	
 # Pure Tcl/Tk packages.
 Setup awthemes          awthemes-9.3.1.7z              awthemes.bawt
 Setup clearlooks        clearlooks-1.0.7z              clearlooks.bawt

--- a/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
@@ -1,0 +1,26 @@
+# Builds Tcl, Tk, Starkit and Tcl/Tk packages, which do not depend on 3rd party libraries.
+# On Windows all libraries can be compiled with MSys/MinGW.
+
+# Setup LibName         ZipFile                        BuildFile           BuildOptions
+
+# Tcl/Tk, stubs and manual.
+Setup Tcl	        Tcl-[GetTclVersion].7z         Tcl_NMake.bawt
+Setup Tcl_gcc           Tcl-[GetTclVersion].7z         Tcl_Gcc.bawt
+Setup TclStubs          Tcl-[GetTclVersion].7z         TclStubs.bawt
+Setup Tk		Tk-[GetTkVersion].7z           Tk_NMake.bawt
+Setup Tk_gcc            Tk-[GetTkVersion].7z           Tk_Gcc.bawt
+Setup TkStubs           Tk-[GetTkVersion].7z           TkStubs.bawt
+# Compiled Tcl packages.
+Setup twapi		twapi-4.6.0.7z		       twapi.bawt
+Setup tksvg             tksvg-0.5.7z                   tksvg.bawt
+Setup tkblt             tkblt-3.2.23.7z                tkblt.bawt
+# Compiled Tcl Database interface packages.
+Setup oratcl            oratcl-4.6.7z                  oratcl_NMake.bawt	
+Setup mariatcl          mariatcl-0.1.7z                mariatcl_NMake.bawt
+Setup mysqltcl          mysqltcl-3.052.7z              mysqltcl_NMake.bawt
+Setup pgtcl             pgtcl-2.1.1.7z                 pgtcl_NMake.bawt	
+Setup db2tcl            db2tcl-2.0.1.7z                db2tcl_NMake.bawt
+# Pure Tcl/Tk packages.
+Setup awthemes          awthemes-9.3.1.7z              awthemes.bawt
+Setup clearlooks        clearlooks-1.0.7z              clearlooks.bawt
+Setup redis             redis-0.1.7z                   redis.bawt

--- a/Build/Bawt-2.1.0/Setup/HammerDBFinalize.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDBFinalize.bawt
@@ -54,7 +54,8 @@ if { $HammerDBsrcDirIn != $HammerDBsrcDirOut } {
 if { [ file isdirectory [ file join [file nativename [GetOutputDistDir]] HammerDB bin ]] && [ file isdirectory [ file join [file nativename [GetOutputDistDir]] HammerDB lib ]] && [ file isdirectory [ file join [file nativename [GetOutputDistDir]] HammerDB include ]] } { set bli true } else { set bli false }
     Log "Copying HammerDB source from $HammerDBsrcDirIn"
 set zipProg [Get7ZipProg]
-exec -ignorestderr {*}$zipProg u [ file join [GetOutputDistDir] HammerDBLinSrc.7z ] -y -bd $HammerDBsrcDirIn -xr\!Build -xr\!DocBook -xr!.git* -xr!*.bat
+if {![IsWindows]} {
+exec -ignorestderr {*}$zipProg u [ file join [GetOutputDistDir] HammerDBLinSrc.7z ] -y -bd $HammerDBsrcDirIn -xr\!Build -xr\!DocBook -xr\!Docker -xr!.git* -xr!*.bat
 if { [ file tail $HammerDBsrcDirIn ] != "HammerDB" } {
 puts "exec -ignorestderr {*}$zipProg rn [ file join [GetOutputDistDir] HammerDBLinSrc.7z ] [ file tail $HammerDBsrcDirIn ] HammerDB"
 exec -ignorestderr {*}$zipProg rn [ file join [GetOutputDistDir] HammerDBLinSrc.7z ] [ file tail $HammerDBsrcDirIn ] HammerDB
@@ -62,7 +63,17 @@ exec -ignorestderr {*}$zipProg rn [ file join [GetOutputDistDir] HammerDBLinSrc.
     Log "Extracting HammerDB source to [file nativename [GetOutputDistDir]]"
 exec -ignorestderr {*}$zipProg x [ file join [GetOutputDistDir] HammerDBLinSrc.7z ] -y -bd -o[file nativename [GetOutputDistDir]]
 file delete -force [file join [GetOutputDistDir] HammerDBLinSrc.7z ]
-	} 
+		} else {
+exec -ignorestderr {*}$zipProg u [ file join [GetOutputDistDir] HammerDBWinSrc.7z ] -y -bd $HammerDBsrcDirIn -xr\!Build -xr\!DocBook -xr\!Docker -xr!.git*
+if { [ file tail $HammerDBsrcDirIn ] != "HammerDB" } {
+puts "exec -ignorestderr {*}$zipProg rn [ file join [GetOutputDistDir] HammerDBWinSrc.7z ] [ file tail $HammerDBsrcDirIn ] HammerDB"
+exec -ignorestderr {*}$zipProg rn [ file join [GetOutputDistDir] HammerDBWinSrc.7z ] [ file tail $HammerDBsrcDirIn ] HammerDB
+    Log "Extracting HammerDB source to [file nativename [GetOutputDistDir]]"
+exec -ignorestderr {*}$zipProg x [ file join [GetOutputDistDir] HammerDBWinSrc.7z ] -y -bd -o[file nativename [GetOutputDistDir]]
+file delete -force [file join [GetOutputDistDir] HammerDBWinSrc.7z ]
+			}
+		}
+	}
 set version_number [ string trimleft [ lindex [ grep set\ hdb_version [file join [GetOutputDistDir] HammerDB hammerdb ]] end ] v ]
 if { !$bli } {
     Log "Copying bin lib include from [GetOutputDevDir] to [GetOutputDistDir] for rebuild"
@@ -71,5 +82,16 @@ MultiFileCopy [ file join [GetOutputDevDir] HammerDB bin ] [ file join [file nat
 MultiFileCopy [ file join [GetOutputDevDir] HammerDB lib ] [ file join [file nativename [GetOutputDistDir]] HammerDB lib ] "*"  true
 }
 FileRename [ file join [file nativename [GetOutputDistDir]] HammerDB ] [ file join [file nativename [GetOutputDistDir]] HammerDB-$version_number ]
-TarGzip [ file join [file nativename [GetOutputDistDir]] HammerDB-$version_number.tar.gz ] [ file join [file nativename [GetOutputDistDir]] HammerDB-$version_number ]
+if {![IsWindows]} {
+    Log "Creating Distribution tar.gz in [GetOutputDistDir]"
+TarGzip [ file join [file nativename [GetOutputDistDir]] HammerDB-$version_number-Linux.tar.gz ] [ file join [file nativename [GetOutputDistDir]] HammerDB-$version_number ]
+	} else {
+    Log "Creating Distribution Zipfile in [GetOutputDistDir]"
+cd [file nativename [GetOutputDistDir]]
+if {![catch {exec zip -L}] || [lindex $::errorCode 0] eq "NONE"} {
+exec -ignorestderr {*}zip -r HammerDB-$version_number-Win.zip  HammerDB-$version_number
+} else {
+        ErrorAppend "Finalize: Distribution created in  [GetOutputDistDir] but cannot find zip executable" "FATAL"
+	}
+    }
 }


### PR DESCRIPTION
This pull request adds Windows build automation to the existing x64 Linux build automation in #323
This enables the compiling of all HammerDB dependencies from a single command.

Prerequisites are an installation of Microsoft Visual Studio 2022 (gcc is also downloaded at build time) and installations of client or server of Db2, MariaDB, MySQL and PostgreSQL including a development environment (headers and libraries).  Environment variables should be set to the location of the database installations as follows:

```
set MARIADB_CONFIG=C:\Program Files\MariaDB\MariaDB Connector C 64-bit
set MYSQL_CONFIG=C:\Program Files\MySQL\MySQL Server 8.0
set PG_CONFIG=C:\Program Files\PostgreSQL\pgsql\bin
set IBM_DB_DIR=C:\Program Files\IBM\SQLLIB
```

Note that the mysql_config command does not exist on Windows and therefore the MYSQL_CONFIG environment variable should be set to the top level MySQL installation directory. All of the specified database installations are required to fully build HammerDB and if one is missing the build will fail. 

Once the environment is set clone or download the HammerDB repository and from the Build\Bawt-2.1.0 directory run the following command:

`Build-Windows.bat x64 vs2022+gcc Setup\HammerDB-Windows.bawt update`

Only the x64 architecture is supported. 

This will download the requisite files and build HammerDB using Visual Studio for Tcl and database libraries and gcc for non-performance critical packages. (Note that Tcl/Tk is also compiled with gcc to provide the configuration environment for the other packages built with gcc but is not installed).  When complete the Bawt Viewer will show the build completion as follows

![bawtwindows](https://user-images.githubusercontent.com/38044085/170056924-0f38b21f-75bf-45cb-a861-83042e77114a.png)

In the BawtBuild directory the HammerDB distribution will be built and a zipfile created in the vs2022\x64\Release\Distribution directory.

Note that most of the code changes to enable this pull request are in the database libraries themselves within a new win directory, some source modification to enable the windows build where required as well as the .bawt files providing build instructions for the new files.  As per the discussion in #323 this updated source and .bawt files are not included in the HammerDB repository and are downloaded at build time. 

For this reason the bulk of the code changes required to enable the Windows build automation are not included within this pull request and must be browsed manually after running a build. 