### PR TITLE
Fix for o_all_local value update and insert

### DIFF
--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -72,7 +72,7 @@ proc CreateStoredProcs { db_handle } {
         DECLARE x		        INTEGER;
         DECLARE rbk		       	INTEGER;
         DECLARE loop_counter    	INT;
-        SET no_o_all_local = 0;
+        SET no_o_all_local = 1;
         SELECT c_discount, c_last, c_credit, w_tax
         INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
         FROM customer, warehouse
@@ -84,8 +84,6 @@ proc CreateStoredProcs { db_handle } {
         WHERE d_id = no_d_id 
         AND d_w_id = no_w_id );
         SET o_id = no_d_next_o_id;
-        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
-        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
         SET rbk = FLOOR(1 + (RAND() * 99));
         SET loop_counter = 1;
         WHILE loop_counter <= no_o_ol_cnt DO
@@ -145,6 +143,8 @@ proc CreateStoredProcs { db_handle } {
         VALUES (o_id, no_d_id, no_w_id, loop_counter, no_ol_i_id, no_ol_supply_w_id, no_ol_quantity, no_ol_amount, no_ol_dist_info);
         set loop_counter = loop_counter + 1;
         END WHILE;
+        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
+        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
     END }
     set sql(2) { CREATE OR REPLACE PROCEDURE PAYMENT (
         IN p_w_id               INTEGER,

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -87,7 +87,7 @@ proc CreateStoredProcs { maria_handler } {
         DECLARE `Constraint Violation` CONDITION FOR SQLSTATE '23000';
         DECLARE EXIT HANDLER FOR `Constraint Violation` ROLLBACK;
         DECLARE EXIT HANDLER FOR NOT FOUND ROLLBACK;
-        SET no_o_all_local = 0;
+        SET no_o_all_local = 1;
         SELECT c_discount, c_last, c_credit, w_tax
         INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
         FROM customer, warehouse
@@ -99,8 +99,6 @@ proc CreateStoredProcs { maria_handler } {
         WHERE d_id = no_d_id AND d_w_id = no_w_id FOR UPDATE;
         UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id;
         SET o_id = no_d_next_o_id;
-        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
-        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
         SET rbk = FLOOR(1 + (RAND() * 99));
         SET loop_counter = 1;
         WHILE loop_counter <= no_o_ol_cnt DO
@@ -163,6 +161,8 @@ proc CreateStoredProcs { maria_handler } {
         VALUES (o_id, no_d_id, no_w_id, loop_counter, no_ol_i_id, no_ol_supply_w_id, no_ol_quantity, no_ol_amount, no_ol_dist_info);
         set loop_counter = loop_counter + 1;
         END WHILE;
+        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
+        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
         COMMIT;
         END 
     }

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -74,7 +74,7 @@ proc CreateStoredProcs { mysql_handler } {
         DECLARE `Constraint Violation` CONDITION FOR SQLSTATE '23000';
         DECLARE EXIT HANDLER FOR `Constraint Violation` ROLLBACK;
         DECLARE EXIT HANDLER FOR NOT FOUND ROLLBACK;
-        SET no_o_all_local = 0;
+        SET no_o_all_local = 1;
         SELECT c_discount, c_last, c_credit, w_tax
         INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
         FROM customer, warehouse
@@ -86,8 +86,6 @@ proc CreateStoredProcs { mysql_handler } {
         WHERE d_id = no_d_id AND d_w_id = no_w_id FOR UPDATE;
         UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id;
         SET o_id = no_d_next_o_id;
-        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
-        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
         SET rbk = FLOOR(1 + (RAND() * 99));
         SET loop_counter = 1;
         WHILE loop_counter <= no_o_ol_cnt DO
@@ -150,6 +148,8 @@ proc CreateStoredProcs { mysql_handler } {
         VALUES (o_id, no_d_id, no_w_id, loop_counter, no_ol_i_id, no_ol_supply_w_id, no_ol_quantity, no_ol_amount, no_ol_dist_info);
         set loop_counter = loop_counter + 1;
         END WHILE;
+        INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
+        INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
         COMMIT;
     END }
     set sql(2) { CREATE PROCEDURE `DELIVERY`(


### PR DESCRIPTION
Testing shows on MariaDB, MySQL and Db2 shows o_all_local updated correctly. 
No major impact on performance discovered on local PC testing.

```
MariaDB [(none)]> use tpcc;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

AFTER INSTALL
Database changed
MariaDB [tpcc]> select count(*) from orders where o_all_local = 0;
+----------+
| count(*) |
+----------+
|        0 |
+----------+
1 row in set (0.101 sec)

MariaDB [tpcc]> select count(*) from orders where o_all_local = 1;
+----------+
| count(*) |
+----------+
|   600000 |
+----------+
1 row in set (0.113 sec)

ORIG
MariaDB [tpcc1]> select count(*) from orders where o_all_local = 0;
+----------+
| count(*) |
+----------+
|    44876 |
+----------+
1 row in set (0.111 sec)

MariaDB [tpcc1]> select count(*) from orders where o_all_local = 1;
+----------+
| count(*) |
+----------+
|   600000 |
+----------+
1 row in set (0.121 sec)

NEW
MariaDB [tpcc]> select count(*) from orders where o_all_local = 0;
+----------+
| count(*) |
+----------+
|     4443 |
+----------+
1 row in set (0.112 sec)

MariaDB [tpcc]> select count(*) from orders where o_all_local = 1;
+----------+
| count(*) |
+----------+
|   642878 |
+----------+
1 row in set (0.121 sec)

ORIG 14916 NOPM
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
SUMMARY OF 1 ACTIVE VIRTUAL USERS : MEDIAN ELAPSED TIME : 180063ms
PROC: NEWORD
CALLS: 45011    MIN: 1.239ms    AVG: 2.222ms    MAX: 15.672ms TOTAL: 100054.186ms
P99: 3.794ms    P95: 2.999ms    P50: 2.201ms    SD: 601.222 RATIO: 55.566%

PROC: PAYMENT
CALLS: 44974    MIN: 0.573ms    AVG: 0.962ms    MAX: 33.101ms TOTAL: 43302.732ms
P99: 1.512ms    P95: 1.292ms    P50: 0.956ms    SD: 304.534 RATIO: 24.049%

PROC: DELIVERY
CALLS: 4514     MIN: 4.596ms    AVG: 5.468ms    MAX: 10.605ms TOTAL: 24683.673ms
P99: 7.766ms    P95: 5.991ms    P50: 5.400ms    SD: 474.712 RATIO: 13.708%

PROC: SLEV
CALLS: 4509     MIN: 0.789ms    AVG: 1.062ms    MAX: 47.378ms TOTAL: 4790.852ms
P99: 1.547ms    P95: 1.202ms    P50: 1.037ms    SD: 697.819 RATIO: 2.661%

PROC: OSTAT
CALLS: 4416     MIN: 0.386ms    AVG: 0.777ms    MAX: 4.012ms TOTAL: 3435.636ms
P99: 1.239ms    P95: 1.077ms    P50: 0.781ms    SD: 187.120 RATIO: 1.908%
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
NEW 14911 NOPM
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
SUMMARY OF 1 ACTIVE VIRTUAL USERS : MEDIAN ELAPSED TIME : 179595ms
PROC: NEWORD
CALLS: 44521    MIN: 1.169ms    AVG: 2.231ms    MAX: 68.834ms TOTAL: 99353.126ms
P99: 3.814ms    P95: 2.991ms    P50: 2.208ms    SD: 744.165 RATIO: 55.321%

PROC: PAYMENT
CALLS: 44200    MIN: 0.576ms    AVG: 0.975ms    MAX: 85.582ms TOTAL: 43124.980ms
P99: 1.548ms    P95: 1.299ms    P50: 0.956ms    SD: 764.609 RATIO: 24.012%

PROC: DELIVERY
CALLS: 4356     MIN: 4.607ms    AVG: 5.590ms    MAX: 31.694ms TOTAL: 24351.414ms
P99: 7.654ms    P95: 6.239ms    P50: 5.512ms    SD: 617.179 RATIO: 13.559%

PROC: SLEV
CALLS: 4368     MIN: 0.783ms    AVG: 1.042ms    MAX: 68.489ms TOTAL: 4553.405ms
P99: 1.272ms    P95: 1.169ms    P50: 1.016ms    SD: 1025.066 RATIO: 2.535%

PROC: OSTAT
CALLS: 4443     MIN: 0.401ms    AVG: 0.998ms    MAX: 31.354ms TOTAL: 4434.578ms
P99: 2.301ms    P95: 1.511ms    P50: 0.827ms    SD: 1607.650 RATIO: 2.469%
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```