### PR TITLE
Remove reconnect for PostgreSQL on windows

### DIFF
--- a/src/postgresql/pgmet.tcl
+++ b/src/postgresql/pgmet.tcl
@@ -2042,11 +2042,6 @@ namespace eval pgmet {
                     set handle "Failed" 
                     thread::send -async $parent "::callback_err [ join $err ]"
                 } else {
-                    if {$tcl_platform(platform) == "windows"} {
-                        #Workaround for Bug #95 where first connection fails on Windows
-                        catch {pg_disconnect $handle}
-                        set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-                    }
                     pg_notice_handler $handle puts
                     set result [ pg_exec $handle "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
                     pg_result $result -clear

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -57,11 +57,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -783,11 +778,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port sslmode = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -1377,11 +1367,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -1591,11 +1591,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -2543,11 +2538,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -2858,11 +2848,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -3290,11 +3275,6 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -3446,17 +3426,6 @@ switch $myposition {
                     return "$clientname:login failed:$message"
                 }
             } else {
-                if {$tcl_platform(platform) == "windows"} {
-                    #Workaround for Bug #95 where first connection fails on Windows
-                    catch {pg_disconnect $lda}
-                    if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
-                        set lda "Failed" 
-                        if { $RAISEERROR } {
-                            puts "$clientname:login failed:$message"
-                            return "$clientname:login failed:$message"
-                        }
-                    }
-                }
                 if { $async_verbose } { puts "Connected $clientname:$lda" }
                 pg_notice_handler $lda puts
                 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]

--- a/src/postgresql/pgotc.tcl
+++ b/src/postgresql/pgotc.tcl
@@ -11,11 +11,6 @@ proc tcount_pg {bm interval masterthread} {
             if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
                 set lda "connection failed:$message"
             } else {
-                if {$tcl_platform(platform) == "windows"} {
-                    #Workaround for Bug #95 where first connection fails on Windows
-                    catch {pg_disconnect $lda}
-                    set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]
-                }
                 pg_notice_handler $lda puts
                 set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
                 pg_result $result -clear


### PR DESCRIPTION
Fix for issue #400 by removing previous workaround that did a double connection on Windows.
Fix has been tested on both Linux and Windows with TPROC-C & TPROC-H workloads.