### PR TITLE
HammerDB: Passwordless MariaDB connection

### DIFF
--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -66,7 +66,10 @@ proc ConnectToMaria { host port socket ssl_options user password } {
         foreach key [ dict keys $ssl_options ] {
         append connectstring " $key [ dict get $ssl_options $key ] "
         }
-        append connectstring " -user $user -password $password"
+        append connectstring " -user $user"
+        if { [ string tolower $password ] != "null" } {
+        append connectstring " -password $password"
+        }
         set login_command "mariaconnect [ dict get $connectstring ]"
         #eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -698,7 +701,10 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
         foreach key [ dict keys $ssl_options ] {
         append connectstring " $key [ dict get $ssl_options $key ] "
         }
-        append connectstring " -user $user -password $password"
+        append connectstring " -user $user"
+        if { [ string tolower $password ] != "null" } {
+        append connectstring " -password $password"
+        }
         set login_command "mariaconnect [ dict get $connectstring ]"
         #eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -1286,7 +1292,10 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
         foreach key [ dict keys $ssl_options ] {
         append connectstring " $key [ dict get $ssl_options $key ] "
         }
-        append connectstring " -user $user -password $password"
+        append connectstring " -user $user"
+        if { [ string tolower $password ] != "null" } {
+        append connectstring " -password $password"
+        }
         set login_command "mariaconnect [ dict get $connectstring ]"
         #eval the login command
         if [catch {set maria_handler [eval $login_command]}] {

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -474,7 +474,10 @@ proc ConnectToMaria { host port socket ssl_options user password } {
 	foreach key [ dict keys $ssl_options ] {
 	append connectstring " $key [ dict get $ssl_options $key ] "
 	}
-	append connectstring " -user $user -password $password"
+	append connectstring " -user $user"
+	if { [ string tolower $password ] != "null" } {
+	append connectstring " -password $password"
+	}
 	set login_command "mariaconnect [ dict get $connectstring ]"
 	#eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -1399,7 +1402,10 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
 	foreach key [ dict keys $ssl_options ] {
 	append connectstring " $key [ dict get $ssl_options $key ] "
 	}
-	append connectstring " -user $user -password $password"
+	append connectstring " -user $user"
+	if { [ string tolower $password ] != "null" } {
+	append connectstring " -password $password"
+	}
 	set login_command "mariaconnect [ dict get $connectstring ]"
 	#eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -1729,7 +1735,10 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
 	foreach key [ dict keys $ssl_options ] {
 	append connectstring " $key [ dict get $ssl_options $key ] "
 	}
-	append connectstring " -user $user -password $password"
+	append connectstring " -user $user"
+	if { [ string tolower $password ] != "null" } {
+	append connectstring " -password $password"
+	}
 	set login_command "mariaconnect [ dict get $connectstring ]"
 	#eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -2114,7 +2123,10 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
 	foreach key [ dict keys $ssl_options ] {
 	append connectstring " $key [ dict get $ssl_options $key ] "
 	}
-	append connectstring " -user $user -password $password"
+	append connectstring " -user $user"
+	if { [ string tolower $password ] != "null" } {
+	append connectstring " -password $password"
+	}
 	set login_command "mariaconnect [ dict get $connectstring ]"
 	#eval the login command
         if [catch {set maria_handler [eval $login_command]}] {
@@ -2154,7 +2166,10 @@ proc ConnectToMariaAsynch { host port socket ssl_options user password db client
 	foreach key [ dict keys $ssl_options ] {
 	append connectstring " $key [ dict get $ssl_options $key ] "
 	}
-	append connectstring " -user $user -password $password"
+	append connectstring " -user $user"
+	if { [ string tolower $password ] != "null" } {
+	append connectstring " -password $password"
+	}
 	set login_command "mariaconnect [ dict get $connectstring ]"
 	#eval the login command
         if [catch {set maria_handler [eval $login_command]}] {

--- a/src/mariadb/mariaotc.tcl
+++ b/src/mariadb/mariaotc.tcl
@@ -28,7 +28,10 @@ proc tcount_maria {bm interval masterthread} {
         foreach key [ dict keys $ssl_options ] {
         append connectstring " $key [ dict get $ssl_options $key ] "
         }
-        append connectstring " -user $user -password $password"
+        append connectstring " -user $user"
+        if { [ string tolower $password ] != "null" } {
+        append connectstring " -password $password"
+        }
         set login_command "mariaconnect [ dict get $connectstring ]"
         #eval the login command
         if [catch {set maria_handler [eval $login_command]}] {


### PR DESCRIPTION
When using SSL connection to MariaDB we are able to authenticate user solely based on SSL subject and issuer. In such a case we need to pass SSL certificate and SSL key to authenticate and we cannot pass user password, because such an user might not have an password set, which is the goal of such an configuration. Currently HammerDB always append '-password' to connection string, so we are not able to connect to MariaDB with user configured as described above. This patch adds the ability to use special keyword "null" in order to skip appending password to connection string. Such a special keyword instead of empty string was chosen in order to avoid breaking other layers of HammerDB and in order to keep the number of changes minimal.

Signed-off-by: Igor Konopko <igor.j.konopko@intel.com>