### PR TITLE
Deprecate CLI runtimer

### DIFF
--- a/config/db2.xml
+++ b/config/db2.xml
@@ -20,7 +20,7 @@
             <db2_total_iterations>10000000</db2_total_iterations>
             <db2_raiseerror>false</db2_raiseerror>
             <db2_keyandthink>false</db2_keyandthink>
-            <db2_driver>test</db2_driver>
+            <db2_driver>timed</db2_driver>
 	    <db2_rampup>2</db2_rampup>
             <db2_duration>5</db2_duration>
 	    <db2_monreport>0</db2_monreport>

--- a/config/mariadb.xml
+++ b/config/mariadb.xml
@@ -28,7 +28,7 @@
             <maria_total_iterations>10000000</maria_total_iterations>
             <maria_raiseerror>false</maria_raiseerror>
             <maria_keyandthink>false</maria_keyandthink>
-            <maria_driver>test</maria_driver>
+            <maria_driver>timed</maria_driver>
             <maria_rampup>2</maria_rampup>
             <maria_duration>5</maria_duration>
             <maria_allwarehouse>false</maria_allwarehouse>

--- a/config/mssqlserver.xml
+++ b/config/mssqlserver.xml
@@ -29,7 +29,7 @@
             <mssqls_raiseerror>false</mssqls_raiseerror>
             <mssqls_keyandthink>false</mssqls_keyandthink>
 	    <mssqls_checkpoint>false</mssqls_checkpoint>
-            <mssqls_driver>test</mssqls_driver>
+            <mssqls_driver>timed</mssqls_driver>
 	    <mssqls_rampup>2</mssqls_rampup>
             <mssqls_duration>5</mssqls_duration>
             <mssqls_allwarehouse>false</mssqls_allwarehouse>

--- a/config/mysql.xml
+++ b/config/mysql.xml
@@ -28,7 +28,7 @@
             <mysql_total_iterations>10000000</mysql_total_iterations>
             <mysql_raiseerror>false</mysql_raiseerror>
             <mysql_keyandthink>false</mysql_keyandthink>
-            <mysql_driver>test</mysql_driver>
+            <mysql_driver>timed</mysql_driver>
             <mysql_rampup>2</mysql_rampup>
             <mysql_duration>5</mysql_duration>
             <mysql_allwarehouse>false</mysql_allwarehouse>

--- a/config/oracle.xml
+++ b/config/oracle.xml
@@ -24,7 +24,7 @@
             <raiseerror>false</raiseerror>
             <keyandthink>false</keyandthink>
 	    <checkpoint>false</checkpoint>
-            <ora_driver>test</ora_driver>
+            <ora_driver>timed</ora_driver>
             <rampup>2</rampup>
             <duration>5</duration>
             <allwarehouse>false</allwarehouse>

--- a/config/postgresql.xml
+++ b/config/postgresql.xml
@@ -27,7 +27,7 @@
             <pg_total_iterations>10000000</pg_total_iterations>
             <pg_raiseerror>false</pg_raiseerror>
             <pg_keyandthink>false</pg_keyandthink>
-            <pg_driver>test</pg_driver>
+            <pg_driver>timed</pg_driver>
 	    <pg_rampup>2</pg_rampup>
             <pg_duration>5</pg_duration>
             <pg_allwarehouse>false</pg_allwarehouse>

--- a/config/redis.xml
+++ b/config/redis.xml
@@ -14,7 +14,7 @@
             <redis_total_iterations>10000000</redis_total_iterations>
             <redis_raiseerror>false</redis_raiseerror>
             <redis_keyandthink>false</redis_keyandthink>
-            <redis_driver>test</redis_driver>
+            <redis_driver>timed</redis_driver>
 	    <redis_rampup>2</redis_rampup>
             <redis_duration>5</redis_duration>
             <redis_allwarehouse>false</redis_allwarehouse>

--- a/config/trafodion.xml
+++ b/config/trafodion.xml
@@ -23,7 +23,7 @@
             <trafodion_total_iterations>10000000</trafodion_total_iterations>
             <trafodion_raiseerror>false</trafodion_raiseerror>
             <trafodion_keyandthink>false</trafodion_keyandthink>
-            <traf_driver>test</traf_driver>
+            <traf_driver>timed</traf_driver>
 	    <trafodion_rampup>2</trafodion_rampup>
             <trafodion_duration>5</trafodion_duration>
             <trafodion_allwarehouse>false</trafodion_allwarehouse>

--- a/hammerdbws
+++ b/hammerdbws
@@ -62,7 +62,7 @@ for { set modcount 0 } { $modcount < [llength $modulelist] } { incr modcount } {
         }
     }
 
-append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl gentccmn.tcl gentcws.tcl geninitws.tcl genws.tcl genhelp.tcl }
+append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl gentccmn.tcl gentcws.tcl geninitws.tcl genws.tcl genhelp.tcl genstep.tcl }
 for { set loadcount 0 } { $loadcount < [llength $loadlist] } { incr loadcount } {
     set f [lindex $loadlist $loadcount]
 		set loadtext $f

--- a/modules/tclreadline-1.2.tm
+++ b/modules/tclreadline-1.2.tm
@@ -54,7 +54,8 @@ proc TclReadLine::setup_prompt_requirements {} {
         package require Expect
         interp alias {} stty {} exp_stty
         # Prevent sigint from killing our shell:
-        exp_trap SIG_IGN SIGINT
+        # Allow SIGINT to kill shell, uncomment to trap SIGINT
+        #exp_trap SIG_IGN SIGINT
         # Handle terminal resize events:
         exp_trap ::TclReadLine::getColumns SIGWINCH
     }

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -759,7 +759,11 @@ proc ed_status_message { flag message } {
 proc vucreate {} {
     global _ED lprefix vustatus opmode
     if { [ string length $_ED(package) ] eq 0  } {
-        putscli "No Script loaded: Load script before creating Virtual Users"
+    #Try loadscript and recheck before asking the user to load the script if it is empty
+       catch {loadscript}
+       if { [ string length $_ED(package) ] eq 0  } {
+       putscli "No Script loaded: Load script before creating Virtual Users"
+       }
     } else {
         if {[expr [ llength [ threadnames_without_tcthread ] ] - 1 ] > 0} {
             putscli "Error: Virtual Users exist, destroy with vudestroy before creating"
@@ -1020,15 +1024,57 @@ proc buildschema {} {
     }
     #Save dict(all config) to SQLite, if need group saving, uncomment
     #Dict2SQLite $dbname [ dict get [ set $dictname ] ]
+    #Add automated waittocomplete to buildschema
+    _waittocomplete
+}
+
+proc keepalive {} {
+#Routine to keep the main thread alive during vurun
+    global rdbms bm
+    set ka_valid 1
+	if {$bm eq "TPC-C"} {
+#For TPC-C we have a rampup and duration time, find these, check they are valid and call _runtimer automatically with these values
+	 upvar #0 dbdict dbdict
+    foreach { key } [ dict keys $dbdict ] {
+        if { [ dict get $dbdict $key name ] eq $rdbms } {
+            set dictname config$key
+            upvar #0 $dictname $dictname
+    }
+    }
+    set rampup_secs [expr {[ get_base_rampup [ set $dictname ]]*60}]
+    set duration_secs [expr {[ get_base_duration [ set $dictname ]] *60}]
+    foreach { val } [ list $rampup_secs $duration_secs ] {
+    if { ![string is integer -strict $val ] || $val < 60 } {
+	set ka_valid 0 
+    	}
+    }
+    if { $ka_valid } {
+    _runtimer [expr {$rampup_secs + $duration_secs + 10}]
+    	} else {
+tk_messageBox -icon warning -message "Cannot detect rampup and duration times, keepalive for main thread not active"
+	}
+} else {
+#Workload is TPROC-H, call _waittocomplete to wait until vucomplete message after an indeterminate amount of time
+_waittocomplete
+return
+}
 }
 
 proc vurun {} {
     global _ED opmode
+    #If calling vurun and virtual users not created, create them now
+    if {[expr [ llength [ threadnames_without_tcthread ] ] - 1 ] eq 0} {
+        vucreate
+    	}
+    #In turn if script is not already loaded vucreate should call loadscript meaning following should not return no workload to run
     if { [ string length $_ED(package) ] > 0 } { 
         remote_command [ concat vurun ]
         if { [ catch {run_virtual} message ] } {
             putscli "Error: $message"
-        }
+        } else {
+	#Deprecated runtimer replaced with automated keepalive
+	keepalive
+	}
     } else {
         putscli "Error: There is no workload to run because the Script is empty"
     }
@@ -1261,21 +1307,34 @@ proc quit {} {
     exit
 }
 
-proc waittocomplete {} {
+proc waittocomplete { args } {
+global hdb_version
+tk_messageBox -icon warning -message "waittocomplete command has been deprecated and is not required for version $hdb_version"
+}
+
+proc _waittocomplete {} {
+#waittocomplete returns after vucomplete is detected, in v4.5 and earlier it would call exit
+    upvar timevar timevar
     proc wait_to_complete_loop {} {
+    upvar timevar timevar
         upvar wcomplete wcomplete
         set wcomplete [vucomplete]
         if {!$wcomplete} { catch {after 5000 wait_to_complete_loop} } else { 
-            putscli "waittocomplete called script exit"
-            exit
+	set timevar 1
         }
     }
     set wcomplete "false"
     wait_to_complete_loop
-    vwait forever
+    vwait timevar
+    return
 }
 
-proc runtimer { seconds } {
+proc runtimer { args } {
+global hdb_version
+tk_messageBox -icon warning -message "runtimer command has been deprecated and is not required for version $hdb_version"
+}
+
+proc _runtimer { seconds } {
     upvar elapsed elapsed
     upvar timevar timevar
     proc runtimer_loop { seconds } {
@@ -1285,12 +1344,12 @@ proc runtimer { seconds } {
         set rcomplete [vucomplete]
         if { ![ expr {$elapsed % 60} ] } {
             set y [ expr $elapsed / 60 ]
-            putscli "Timer: $y minutes elapsed"
+            #putscli "Timer: $y minutes elapsed"
         }
         if {!$rcomplete && $elapsed < $seconds } {
             ;#Neither vucomplete or time reached, reschedule loop
         catch {after 1000 runtimer_loop $seconds }} else {
-            putscli "runtimer returned after $elapsed seconds"
+            #putscli "keepalive returned after $elapsed seconds"
             set elapsed 0
             set timevar 1
         }

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -4,11 +4,11 @@ proc help { args } {
     if [ llength [ info commands wapp-default ]] { set wsmode 1 } else { set wsmode 0 }
     if $wsmode { set helpbanner "HammerDB $hdb_version WS Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset jobs librarycheck loadscript print quit runtimer tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus waittocomplete ]
+        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset jobs librarycheck loadscript print quit tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     } else {
         set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset distributescript librarycheck loadscript print quit runtimer steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus waittocomplete ]
+        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset distributescript librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     }
     if {[ llength $args ] != 1} {
         puts $helpbanner
@@ -139,15 +139,6 @@ Changed tpcc:count_ware from 1 to 10 for Oracle"
                 datagenrun {
                     putscli "datagenrun - Usage: datagenrun"
                     putscli "Run Data Generation. Equivalent to the Generate option in the graphical interface."
-                }
-                runtimer {
-                    putscli "runtimer - Usage: runtimer seconds"
-                    putscli "Helper routine to run a timer in the main hammerdbcli thread to keep it busy for a period of time whilst the virtual users run a workload. The timer will return when vucomplete returns true or the timer reaches the seconds value. Usually followed by vudestroy."
-
-                }
-                waittocomplete {
-                    putscli "waittocomplete - Usage: waittocomplete"
-                    putscli "Helper routine to enable the main hammerdbcli thread to keep it busy until vucomplete is detected. When vucomplete is detected exit is called causing all virtual users and the main hammerdblci thread to terminate. Often used when calling hammerdb from external scripting commands."
                 }
                 tcset {
                     if $wsmode {

--- a/src/generic/gentcws.tcl
+++ b/src/generic/gentcws.tcl
@@ -10,7 +10,7 @@ proc showLCD {number} {
     #debug output by uncomment next line 
     #putscli "$number $rdbms $metric"
     if { $jobid != "" } {
-        hdb eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,$number,$metric)}
+        hdbws eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,$number,$metric)}
     }
 }
 
@@ -82,11 +82,11 @@ proc show_tc_errmsg {} {
         if [catch {set joinedmsg [ join $tc_errmsg ]} message ] {
             #error in join show unjoined message
             putscli [ subst {{"error": {"message": "Transaction Counter Error: $tc_errmsg"}}} ]
-            hdb eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,0,$tc_errmsg)}
+            hdbws eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,0,$tc_errmsg)}
         } else {
             #show joined message
             putscli [ subst {{"error": {"message": "Transaction Counter Error: $joinedmsg"}}} ]
-            hdb eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,0,$joinedmsg)}
+            hdbws eval {INSERT INTO JOBTCOUNT(jobid,counter,metric) VALUES($jobid,0,$joinedmsg)}
         }
     } else {
         #message is empty


### PR DESCRIPTION
Pull request addresses issues #387 #403 and fixes #414 allowing a simpler command line script such as the following to run a basic timed workload automating loadscript, vucreate and runtimer.
```
dbset db maria
dbset bm TPROC-C
diset tpcc maria_driver timed
diset tpcc maria_rampup 1
diset tpcc maria_duration 2
vuset vu vcpu
vurun
```
The PR automates loadscript for the CLI as per #403 however only if there is no script loaded at all. The script could be refreshed for each run when vucreate is run however if customscript has been used then it would always be overwritten, therefore any existing script will be retained. 
if loadscript, vucreate and runtimer are used they continue to work as before apart from runtimer and waittocomplete that print messages that the command is deprecated.
As the timers are now automated Ctrl-C will be permitted in interactive mode as well as scripted. 
