### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # The CODEOWNERS mechanism determines who must review changes to files in the repository.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# In particular, team auto-assignment has been configured to ensure that multiple
+# members of the Code Maintenance Team are assigned as reviewers, as per TPC
+# Procedures, rather than the Github default of one.
+# https://docs.github.com/en/enterprise-cloud@latest/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
 
 # Files in root directory
 * @TPC-Council/HammerDB-Code-Maintenance-Team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # https://docs.github.com/en/enterprise-cloud@latest/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
 
 # Files in root directory
-* @TPC-Council/HammerDB-Code-Maintenance-Team
+* @TPC-Council/hammerdb-code-maintenance-team
 
 # Files in any directory
-/** @TPC-Council/HammerDB-Code-Maintenance-Team
+/** @TPC-Council/hammerdb-code-maintenance-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# The CODEOWNERS mechanism determines who must review changes to files in the repository.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Files in root directory
+* @TPC-Council/HammerDB-Code-Maintenance-Team
+
+# Files in any directory
+/** @TPC-Council/HammerDB-Code-Maintenance-Team


### PR DESCRIPTION
Add a CODEOWNERS file.

Github will request reviewers, based on the rules in this file, for any PR opened against the repository.
When teams are listed, Github will normally require one team member to review and approve.
However, team auto-assignment has been used to ensure that 3 team members are requested to review and approve.
This logic is supposed to exclude the submitter (if a team member), but it's unclear if that excludes them from the assignment or the count or both.