### PR TITLE
Add drop schema functionality

### DIFF
--- a/config/oracle.xml
+++ b/config/oracle.xml
@@ -12,8 +12,8 @@
 	    <num_vu>1</num_vu>
             <tpcc_user>tpcc</tpcc_user>
             <tpcc_pass>tpcc</tpcc_pass>
-            <tpcc_def_tab>tpcctab</tpcc_def_tab>
-            <tpcc_ol_tab>tpcctab</tpcc_ol_tab>
+            <tpcc_def_tab>users</tpcc_def_tab>
+            <tpcc_ol_tab>users</tpcc_ol_tab>
             <tpcc_def_temp>temp</tpcc_def_temp>
 	    <partition>false</partition>
 	    <hash_clusters>false</hash_clusters>
@@ -41,7 +41,7 @@
             <scale_fact>1</scale_fact>
             <tpch_user>tpch</tpch_user>
             <tpch_pass>tpch</tpch_pass>
-            <tpch_def_tab>tpchtab</tpch_def_tab>
+            <tpch_def_tab>users</tpch_def_tab>
             <tpch_def_temp>temp</tpch_def_temp>
             <num_tpch_threads>1</num_tpch_threads>
 	    <tpch_tt_compat>false</tpch_tt_compat>

--- a/images/icons.tcl
+++ b/images/icons.tcl
@@ -1,6 +1,6 @@
 #All icons orignally sourced for from open-iconic https://github.com/iconic/open-iconic
-#non-scalable icons are PNG in base64 format (modified with GIMP)
-#scalable icons are SVG format (modified with Inkscape)
+#non-scaleable icons are PNG in base64 format (modified with GIMP)
+#scaleable icons are SVG format (modified with Inkscape)
 #All icon sets in HammerDB including modification and colouring by Lucas Shaw
 proc create_icon_images { iconset } {
 switch $iconset {
@@ -473,6 +473,7 @@ vbtoU5a4VCE1EwXqHoID7Ilmw4RAH38IElMgmipw45HAMJqSb3/NAuPWaTAL4lAAToDzXykQTQk4
 xD86okfeFN81cAwUJ0BgCTiII9BhcujE1cCK5ftQHAhUXd+Grsj9N4HYX7IBMD2heK/jC19a1VBp
 7vgA2QAAAABJRU5ErkJggg==
 }
+
 dict set icons hdbicon {
 iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAIZAAACGQHBpymoAAAA
 GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAS9JREFUOMvdkbFKA1EQRc8+AmvA
@@ -482,6 +483,35 @@ HO4aeMnOJaC16AevQAy8ZX0L2ATKWY0XGZyJSNV13TVVPQQaIlIXkaaIbNdqtWVjTFNVL7PHfkQ4
 EpGLvLy+71c9zxtNJpOGqvaAcuELvxeG4ZO1dstxnAPgVkSOAcIw3FfVK6CeJEkK9AABTvKGiKpW
 h8PhwPO8AbAyRb8DhUVrXKpUKsUZYoDC9BB/hTyDeyCJ4zgF+nkGz3Pyn0ZRFHe73TFwPkf/+AH+
 yWuzBhiMfwAAAABJRU5ErkJggg==
+}
+
+dict set icons delete {
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC53pUWHRSYXcgcHJvZmlsZSB0eXBl
+IGV4aWYAAHja7ZZbktwgDEX/WUWWgCSExHIwmKrsIMvPBT+me2byquQnVW3KgGVZyPfIdIf929cR
+vuCgkmNIap5LzhFHKqlwxcTjcZTVU0yrPy/iNXmyh/sGwyQY5bi0evpX2PXtgWsN2p7twc877Geg
+K/IZUObKjEl/TBJ2PuyUzkBlPya5uD2muvExttNxpXKeYiv0HWReh0dDMqjUFV7CvAtJXL0fGcg8
+WSpGX73CjyRhjiNgSHJlAkGeXu8WMD4K9CTyNQvv1b9n78TnetrlnZb51AiTT2+Qfi7+kvhhYbkz
+4ucbxleojyKP0X2M/Xi7mjIUzWdFxXCpM5+B4wbJZT2W0QynYm6rFTSPNTbA6bHFDa1RIQaVEShR
+p0qD9jU2akgx8c5IjZkby7K5GBducnBCo8EmRToIsjTeA8gl4TsXWuuWtV4jx8qd4MqEYLTw/6CF
+n938kxbGaFMiin5rhbx4Vi7SmORmDy8AoXFy0yXw1U788aF+UKogqEtmxwvWuB0hNqW32pLFWeCn
+GI+vgoL1MwAkwtqKZEhAIGYSpUyoBzYi6OgAVJE5S+INBEiVO5LkJJI5GDvPtfGM0fJl5czTjL0J
+IFSyGNgUqYCVkqJ+LDlqqKpoUtWsph60aM2SU9acs+W5yVUTS6aWzcytWHXx5OrZzd2L18JFsAdq
+ycWKl1Jq5VCxUEWsCv8Ky8abbGnTLW+2+Va22lA+LTVtuVnzVlrt3KVjm+i5W/deet0p7Ngp9rTr
+nnfbfS97Hai1ISMNHXnY8FFGvamdVD+0P6BGJzVepKaf3dRgDWZXCJrbiU5mIMaJQNwmARQ0T2bR
+KSWe5CazWBgfhTKS1MkmdJrEgDDtxDroZvdG7re4BfXf4sa/Ihcmun9BLgDdR26fUOvzd64tYsdX
+ODWNgq+vQQevAb9ncU7+dnwFegV6BXoFegV6BXoF+u8DCf46lPAdYlGcFX5B9KwAAAGEaUNDUElD
+QyBwcm9maWxlAAB4nH2RPUjDQBzFX1NLi7Q42EHEIUN1akFUxFGrUIQKoVZo1cHk0i9o0pKkuDgK
+rgUHPxarDi7Oujq4CoLgB4ijk5Oii5T4v6TQIsaD4368u/e4ewcIrSrTzL5xQNMtI5NKirn8qhh8
+RQgBRDCEuMzM+pwkpeE5vu7h4+tdgmd5n/tzRNSCyQCfSDzL6oZFvEE8vWnVOe8TR1lZVonPieMG
+XZD4keuKy2+cSw4LPDNqZDPzxFFisdTDSg+zsqERTxHHVE2nfCHnssp5i7NWbbDOPfkLwwV9ZZnr
+NEeQwiKWIEGEggYqqMJCgladFBMZ2k96+Icdv0QuhVwVMHIsoAYNsuMH/4Pf3ZrFyQk3KZwEAi+2
+/TEKBHeBdtO2v49tu30C+J+BK73rr7WAmU/Sm10tdgQMbAMX111N2QMud4Chp7psyI7kpykUi8D7
+GX1THhi8BfrX3N46+zh9ALLUVfoGODgExkqUve7x7lBvb/+e6fT3A1nVcp12BiYhAAAABmJLR0QA
+/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5ggFDSEuU/ZiswAAAMZJREFU
+OMu9k8ENwjAMRV9RV0CKOkG3gOxAF+ixzANLlB3KGCh3ClKHgIuNLBNAqAhLOeTH/9V2mqJtW+bE
+gpnhAQ1w+2ZZwBLYmf0ZGDMfHYFLroK9QDRpDUQHGUWLwNUCGmCTaS8ZiJoTUGhSmSkdoAIGY4ii
+J6CWs6AAW/o7CN78s2vsgOnFtKMpuwZOdoAKmIDtB/Mg6wmiLfTAwUEK13MwEOwtaHTASgZaAUfR
+g8lRyEO3Q/StBGfO6qU77O1P8pfXeAfACjlJ4tupCQAAAABJRU5ErkJggg==
 }
 return [ set icons ]
 }
@@ -785,6 +815,35 @@ Idadod/naCqaCOtOIK4YVXSI8hfeRSFDDGVt1TdU1J0hhr5CxuGv4h8YlHIz0V6su01RNY/2sYNH
 XOMpxVOiAfSkq/mTQT0kaqJe0ZyisbBpJCQmQ2JYh4poErtpMRBiXXzdmQ8bdnKvhLikpuLOkzFt
 B+j5+AbTcdWlYFAwKzoKiQWIa2ZEexjxoCU6wL5g8b2D7Kg51jCkga4vuWeUvh9jQadx5Qwx6QT/
 9COdart3o4WL7wyucnLLIXEdtjWxlcM5fwEKukWjV0kHBgAAAABJRU5ErkJggg==
+}
+
+dict set icons delete {
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC9XpUWHRSYXcgcHJvZmlsZSB0eXBl
+IGV4aWYAAHja7ZddltwoDIXfWUWWgCSExHIwmHNmB7P8XPBPV3V3ks5MHvJQ5hiwkIV8P6C6w/7v
+PyN8w0Ulp5DUPJecI65UUuGKjsfjKqummFZ9PsSr82QP9wDDJGjleLR6+lfY9e2Faw7anu3BzxH2
+M9AV+Qwoc2ZGpz8mCTsfdkpnoLIfnVzcHlPd+Gjb6bhSOW+xFfoOMp/DoyEZVOoKL2HehSSu2o8M
+ZN4sFa2vWuFHktAXSQGNyvWtEOTp824B46NATyJfvfBe/bv3Tnyup13eaZlPjdD5dID0c/GXxA8T
+y50RPw+YXqE+ijxG9zH24+tqylA0nysqhkud+Q4cN0gu67WMYrgVfVuloHissQFOjy1uKI0KMaiM
+QIk6VRq0r7ZRQ4qJdza0zI1l2VyMCzc5OKHQYJMiHQRZGu9hohO+c6E1b1nzNXLM3AmuTAhGC/8P
+SvjZ4O+UMEabElH0WyvkxXPlIo1JbtbwAhAaJzddAl/lxB8f1g+WKgjqktnxgTVuR4hN6W1tyeIs
+8FO0x66gYP0MAIkwtyIZEhCImUQpUzRmI4KODkAVmbMk3kCAVLkjSU4imYOx85wb7xgtX1bOPM04
+mwBCJYuBTZEKWCkp1o8lxxqq2FtJVbOaetCiNUtOWXPOluchV00smVo2M7di1cWTq2c3dy9eCxfB
+GaglFyteSqmVQ8VEFbEq/CssG2+ypU23vNnmW9lqw/JpqWnLzZq30mrnLh3HRM/duvfS605hx0mx
+p133vNvue9nrwFobMtLQkYcNH2XUm9pJ9UP5DWp0UuNFavrZTQ3WYHaFoHmc6GQGYpwIxG0SwILm
+ySw6pcST3GQWC2NTKCNJnWxCp0kMCNNOrINudm/kvsQtqH+JG/+KXJjo/gS5AHQfuX1Crc/fubaI
+HbtwahoFu69LZa+BtwERRkpxPuLX7T+2If7PAK9Ar0CvQK9Ar0CvQK9Af0cgwR8Q+Ec2fAeBQJ5L
+eOONgwAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVfU0uLtDjYQcQhQ3VqQVTEUatQhAqh
+VmjVweTSL2jSkqS4OAquBQc/FqsOLs66OrgKguAHiKOTk6KLlPi/pNAixoPjfry797h7BwitKtPM
+vnFA0y0jk0qKufyqGHxFCAFEMIS4zMz6nCSl4Tm+7uHj612CZ3mf+3NE1ILJAJ9IPMvqhkW8QTy9
+adU57xNHWVlWic+J4wZdkPiR64rLb5xLDgs8M2pkM/PEUWKx1MNKD7OyoRFPEcdUTad8IeeyynmL
+s1ZtsM49+QvDBX1lmes0R5DCIpYgQYSCBiqowkKCVp0UExnaT3r4hx2/RC6FXBUwciygBg2y4wf/
+g9/dmsXJCTcpnAQCL7b9MQoEd4F207a/j227fQL4n4ErveuvtYCZT9KbXS12BAxsAxfXXU3ZAy53
+gKGnumzIjuSnKRSLwPsZfVMeGLwF+tfc3jr7OH0AstRV+gY4OATGSpS97vHuUG9v/57p9PcDWdVy
+nXYGJiEAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfmCAUN
+Ijn7CLS3AAAAxklEQVQ4y72T3wnCMBCHv0hXKAQHkI5hd7BL6AQdRJeoO3QKQfJuFTpEfUng5zUi
+YjFwD7ncffc3bmr56axgWUADTN+IAkrgKPcbMGSCDsA9l8EpQpLRFqgNZIi6GngooAF2mfKCQJJz
+AFwyclNLCVwkuo0WgE3UBaACesADFCZ1PetomCBY58XGuAfGN92uJe0KuGoDE2AEDh+c+ygzSCqh
+A84G4kzNXiDoFHSRdBopTW/AL3ptoi3FZ5xn+sI8drokf/mNT0IHPSwVihKdAAAAAElFTkSuQmCC
 }
 return [ set icons ]
 }
@@ -3344,6 +3403,64 @@ dict set iconssvg hdbiconsvg {
      style="fill:#626262;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.133333"
      id="path30" /></svg>
 }
+dict set iconssvg deletesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="delete-g.svg"
+   id="svg22"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg22"
+     inkscape:window-maximized="0"
+     inkscape:window-y="130"
+     inkscape:window-x="910"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="91.75"
+     showgrid="false"
+     id="namedview24"
+     inkscape:window-height="783"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#626262;fill-opacity:1"
+     id="path20"
+     transform="translate(0 1)"
+     d="M2 0l-2 3 2 3h6v-6h-6zm1.5.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
+</svg>
+}
 return [ set iconssvg ]
 }
 
@@ -5490,6 +5607,64 @@ dict set iconssvg hdbiconsvg {
      id="path30"
      style="fill:#ff7900;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.133333"
      d="m 83.861533,1.2401157 h -25.30134 c -3.50266,0 -3.97866,1.592005 -3.97866,4.294665 V 45.321451 H 35.166863 V 5.5347807 c 0,-3.817331 -2.07067,-4.294665 -4.61733,-4.294665 H 5.7255329 c -3.02267,0.158667 -4.14,1.433335 -4.14,4.294665 V 109.29877 c 0,3.81734 1.59067,4.296 4.776,4.296 H 35.072193 c 0.93867,-5 2.092,-8.82266 2.092,-8.82266 h 2.98134 V 85.384111 l -0.27867,-5.85334 c -0.248,-4.52132 -3.14533,-6.50799 -6.38667,-6.65466 -5.17733,-0.236 -5.69466,2.56134 -8.97466,3.116 -3.39067,0.56267 -6.51467,0.35334 -6.51467,0.35334 -1.8,0.0987 -3.25867,-1.09867 -3.25867,-2.67467 v -14.37733 c 0,-1.57867 1.45867,-2.75734 3.25867,-2.64 0,0 3.17467,-0.144 6.51467,0.42933 3.344,0.572 3.66666,2.27333 6.73466,3.364 3.076,1.09867 4.28934,-1.33733 6.53067,-2.94933 2.24933,-1.61867 8.34267,-1.68134 12.944,-1.36534 4.6,0.31467 9.19467,1.24134 9.19467,1.24134 20.24133,5.34933 22.512,22.29732 22.512,22.29732 -13.31867,-14.18932 -24.39734,-9.01066 -29.412,-3.21866 -3.33734,3.852 -2.86134,9.404 -2.86134,9.404 h -0.0253 v 18.915999 h 2.04 c 0,0 1.15467,3.82266 2.09067,8.82266 h 29.76933 c 3.02267,0 4.29467,-0.796 4.29467,-4.296 V 5.3761207 c 0,-3.498671 -1.272,-4.136005 -4.456,-4.136005" /></svg>
+}
+dict set iconssvg deletesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="delete-o.svg"
+   id="svg22"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg22"
+     inkscape:window-maximized="0"
+     inkscape:window-y="130"
+     inkscape:window-x="910"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="91.75"
+     showgrid="false"
+     id="namedview24"
+     inkscape:window-height="783"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ff7900;fill-opacity:1"
+     id="path20"
+     transform="translate(0 1)"
+     d="M2 0l-2 3 2 3h6v-6h-6zm1.5.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
+</svg>
 }
 return [ set iconssvg ]
 }

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1195,13 +1195,19 @@ proc ConnectToDb2 { dbname user password } {
 }
 
 proc drop_schema { dbname user password } {
-    set db_handle [ ConnectToDb2 $dbname $user $password ]
-    if { $db_handle ne "" } {
-        set sql "drop database tpch"
-        db2_exec_direct $db_handle $sql
-        db2_disconnect $db_handle
-        puts "TPROC-H schema has been deleted successfully."
+    global tcl_platform
+    if {$tcl_platform(platform) == "windows"} {
+        set cmd "db2cmd -c -w -i db2 drop database tpch"
+    } else {
+        set cmd "db2 drop database tpch"
     }
+
+    if {[ catch {eval exec $cmd} message ]} {
+        error $message
+    } else {
+        puts "TPROC-H Schema has been deleted successfully."
+    }
+
     return
 }
 

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1156,3 +1156,57 @@ if { $refresh_on } {
     do_tpch $dbname $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets $myposition
 }}
 }
+
+proc delete_db2tpch {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict db2 library ]} {
+        set library [ dict get $dbdict db2 library ]
+    } else { set library "db2tcl" }
+    upvar #0 configdb2 configdb2
+    #set variables to values in dict
+    setlocaltpchvars $configdb2
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete TPROC-H schema under user [ string toupper $db2_tpch_user ]\n in database [ string toupper $db2_tpch_dbase ]?" -type yesno ] == yes} {
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "Db2 TPROC-H deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create threads for schema deletion: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc ConnectToDb2 { dbname user password } {
+    puts "Connecting to database $dbname"
+    if {[catch {set db_handle [db2_connect $dbname $user $password ]} message]} {
+        error $message
+    } else {
+        puts "Connection established"
+        return $db_handle
+    }
+}
+
+proc drop_schema { dbname user password } {
+    set db_handle [ ConnectToDb2 $dbname $user $password ]
+    if { $db_handle ne "" } {
+        set sql "drop database tpch"
+        db2_exec_direct $db_handle $sql
+        db2_disconnect $db_handle
+        puts "TPROC-H schema has been deleted successfully."
+    }
+    return
+}
+
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $db2_tpch_dbase $db2_tpch_user $db2_tpch_pass"
+    } else { return }
+}
+

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1166,7 +1166,7 @@ proc delete_db2tpch {} {
     upvar #0 configdb2 configdb2
     #set variables to values in dict
     setlocaltpchvars $configdb2
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete TPROC-H schema under user [ string toupper $db2_tpch_user ]\n in database [ string toupper $db2_tpch_dbase ]?" -type yesno ] == yes} {
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $db2_tpch_dbase ] TPROC-H schema under user [ string toupper $db2_tpch_user ]?" -type yesno ] == yes} {
         set maxvuser 1
         set suppo 1
         set ntimes 1
@@ -1184,33 +1184,21 @@ set library $library
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
 if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
 
-proc ConnectToDb2 { dbname user password } {
-    puts "Connecting to database $dbname"
-    if {[catch {set db_handle [db2_connect $dbname $user $password ]} message]} {
-        error $message
-    } else {
-        puts "Connection established"
-        return $db_handle
-    }
-}
-
 proc drop_schema { dbname user password } {
     global tcl_platform
     if {$tcl_platform(platform) == "windows"} {
-        set cmd "db2cmd -c -w -i db2 drop database tpch"
+        set cmd "db2cmd -c -w -i db2 drop database $dbname"
     } else {
-        set cmd "db2 drop database tpch"
+        set cmd "db2 drop database $dbname"
     }
 
     if {[ catch {eval exec $cmd} message ]} {
         error $message
     } else {
-        puts "TPROC-H Schema has been deleted successfully."
+        puts "$dbname TPROC-H Schema has been deleted successfully."
     }
-
     return
 }
-
 }
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $db2_tpch_dbase $db2_tpch_user $db2_tpch_pass"
     } else { return }

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1201,7 +1201,7 @@ proc drop_schema { dbname user password } {
  if {[ catch {eval exec [ concat $prefix $drop ]} message ]} {
         error $message
     } else {
-        puts "$dbname TPROC-H schema has been deletedi successfully."
+        puts "$dbname TPROC-H schema has been deleted successfully."
     }
 }
     return

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1189,7 +1189,7 @@ proc drop_schema { dbname user password } {
         set force "db2 force applications all"
         set drop "db2 drop database $dbname"
     if {$tcl_platform(platform) == "windows"} {
-        set prefix "db2cmd -c -w -i"
+        set prefix "db2cmd -c"
     } else {
         set prefix ""
     }

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1186,17 +1186,24 @@ if [catch {package require tpchcommon} ] { error "Failed to load tpch common fun
 
 proc drop_schema { dbname user password } {
     global tcl_platform
+        set force "db2 force applications all"
+        set drop "db2 drop database $dbname"
     if {$tcl_platform(platform) == "windows"} {
-        set cmd "db2cmd -c -w -i db2 drop database $dbname"
+        set prefix "db2cmd -c -w -i"
     } else {
-        set cmd "db2 drop database $dbname"
+        set prefix ""
     }
 
-    if {[ catch {eval exec $cmd} message ]} {
+    if {[ catch {eval exec [ concat $prefix $force ]} message ]} {
         error $message
     } else {
-        puts "$dbname TPROC-H Schema has been deleted successfully."
+        puts "force applications all complete."
+ if {[ catch {eval exec [ concat $prefix $drop ]} message ]} {
+        error $message
+    } else {
+        puts "$dbname TPROC-H schema has been deletedi successfully."
     }
+}
     return
 }
 }

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -2350,13 +2350,19 @@ proc ConnectToDb2 { dbname user password } {
 }
 
 proc drop_schema { dbname user password } {
-    set db_handle [ ConnectToDb2 $dbname $user $password ]
-    if { $db_handle ne "" } {
-        set sql "drop database tpcc"
-        db2_exec_direct $db_handle $sql
-        db2_disconnect $db_handle
-        puts "TPROC-C schema has been deleted successfully."
+    global tcl_platform
+    if {$tcl_platform(platform) == "windows"} {
+        set cmd "db2cmd -c -w -i db2 drop database tpcc"
+    } else {
+        set cmd "db2 drop database tpcc"
     }
+
+    if {[ catch {eval exec $cmd} message ]} {
+        error $message
+    } else {
+        puts "TPROC-C Schema has been deleted successfully."
+    }
+
     return
 }
 

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -2339,7 +2339,7 @@ proc drop_schema { dbname user password } {
         set force "db2 force applications all"
         set drop "db2 drop database $dbname"
     if {$tcl_platform(platform) == "windows"} {
-        set prefix "db2cmd -c -w -i"
+        set prefix "db2cmd -c"
     } else {
         set prefix ""
     }

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -2336,18 +2336,24 @@ if [catch {package require tpcccommon} ] { error "Failed to load tpcc common fun
 
 proc drop_schema { dbname user password } {
     global tcl_platform
+        set force "db2 force applications all"
+        set drop "db2 drop database $dbname"
     if {$tcl_platform(platform) == "windows"} {
-        set cmd "db2cmd -c -w -i db2 drop database $dbname"
+        set prefix "db2cmd -c -w -i"
     } else {
-        set cmd "db2 drop database $dbname"
+        set prefix ""
     }
 
-    if {[ catch {eval exec $cmd} message ]} {
+    if {[ catch {eval exec [ concat $prefix $force ]} message ]} {
         error $message
     } else {
-        puts "$dbname TPROC-C Schema has been deleted successfully."
+        puts "force applications all complete."
+ if {[ catch {eval exec [ concat $prefix $drop ]} message ]} {
+        error $message
+    } else {
+        puts "$dbname TPROC-C schema has been deleted successfully."
     }
-
+}
     return
 }
 }

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -2316,12 +2316,8 @@ proc delete_db2tpcc {} {
     upvar #0 configdb2 configdb2
     #set variables to values in dict
     setlocaltpccvars $configdb2
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete Db2 TPROC-C schema\nunder user [ string toupper $db2_user ] in existing database [ string toupper $db2_dbase ]?" -type yesno ] == yes} { 
-        if { $db2_num_vu eq 1 || $db2_count_ware eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $db2_num_vu + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $db2_dbase ] Db2 TPROC-C schema\nunder user [ string toupper $db2_user ]?" -type yesno ] == yes} { 
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -2338,36 +2334,23 @@ set library $library
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
 if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
 
-proc ConnectToDb2 { dbname user password } {
-    puts "Connecting to database $dbname"
-    if {[catch {set db_handle [db2_connect $dbname $user $password ]} message]} {
-        error $message
-        return ""
-    } else {
-        puts "Connection established"
-        return $db_handle
-    }
-}
-
 proc drop_schema { dbname user password } {
     global tcl_platform
     if {$tcl_platform(platform) == "windows"} {
-        set cmd "db2cmd -c -w -i db2 drop database tpcc"
+        set cmd "db2cmd -c -w -i db2 drop database $dbname"
     } else {
-        set cmd "db2 drop database tpcc"
+        set cmd "db2 drop database $dbname"
     }
 
     if {[ catch {eval exec $cmd} message ]} {
         error $message
     } else {
-        puts "TPROC-C Schema has been deleted successfully."
+        puts "$dbname TPROC-C Schema has been deleted successfully."
     }
 
     return
 }
-
 }
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $db2_dbase $db2_user $db2_pass"
     } else { return }
 }
-

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -428,7 +428,7 @@ proc populate_tree {rdbms bm icons iconalt} {
     bind .ed_mainFrame.treeframe.treeview <Leave> { ed_status_message -perm }
     $Name insert $rdbms end -id $rdbms.$bm -text [ regsub -all {(TP)(C)(-[CH])} $bm {\1RO\2\3} ] -image [ create_image hdbicon icons ]
     dict set treeidicons $rdbms.$bm hdbicon
-    $Name insert $rdbms.$bm end -id $rdbms.$bm.build -text "Schema Build" -image [ create_image boxes icons ]
+    $Name insert $rdbms.$bm end -id $rdbms.$bm.build -text "Schema" -image [ create_image boxes icons ]
     dict set treeidicons $rdbms.$bm.build boxes
     $Name item $rdbms.$bm.build -tags $rdbms.$bm.buildhlp
     tooltip::tooltip $Name -item $rdbms.$bm.build "Configure and Build $rdbms $bm Schema"
@@ -442,6 +442,11 @@ proc populate_tree {rdbms bm icons iconalt} {
     $Name item $rdbms.$bm.build.go -tags builsch
     tooltip::tooltip $Name -item $rdbms.$bm.build.go "Create $rdbms $bm Schema"
     $Name tag bind builsch <Double-ButtonPress-1> { if { ![ string match [ .ed_mainFrame.treeframe.treeview state ] "disabled focus hover" ] } { build_schema } }
+    $Name insert $rdbms.$bm.build end -id $rdbms.$bm.build.del -text "Delete" -image [ create_image delete icons ]
+    dict set treeidicons $rdbms.$bm.build.del boxes
+    $Name item $rdbms.$bm.build.del -tags deletesch
+    tooltip::tooltip $Name -item $rdbms.$bm.build.del "Delete $rdbms $bm Schema"
+    $Name tag bind deletesch <Double-ButtonPress-1> { if { ![ string match [ .ed_mainFrame.treeframe.treeview state ] "disabled focus hover" ] } { delete_schema } }
     $Name insert $rdbms.$bm end -id $rdbms.$bm.driver -text "Driver Script" -image [ create_image driveroptim icons ]
     dict set treeidicons $rdbms.$bm.driver driveroptim
     $Name item $rdbms.$bm.driver -tags {drvhlp}
@@ -3098,6 +3103,45 @@ proc build_schema {} {
         return
     } else {
         #Yes was pressed at schema creation run
+        run_virtual
+    }
+}
+
+proc delete_schema {} {
+    #This runs the schema deletion
+    upvar #0 dbdict dbdict
+    global _ED bm rdbms threadscreated 
+    #Clear the Script Editor first to make sure a genuine schema is run
+    ed_edit_clear
+    if { [ info exists threadscreated ] } {
+        tk_messageBox -icon error -message "Cannot delete schema with Virtual Users active, destroy Virtual Users first"
+        #clear script editor so cannot be re-run with incorrect v user count
+        return 1
+    }
+    #puts "delete_schema $mysql_user"
+    foreach { key } [ dict keys $dbdict ] {
+        if { [ dict get $dbdict $key name ] eq $rdbms } {
+            set prefix [ dict get $dbdict $key prefix ]
+            if { $bm == "TPC-C" }  {
+                set command [ concat [subst {delete_$prefix}]tpcc ]
+            } else {
+                set command [ concat [subst {delete_$prefix}]tpch ]
+            }
+            eval $command
+            break
+        }
+    }
+
+    .ed_mainFrame.notebook select .ed_mainFrame.mainwin
+    applyctexthighlight .ed_mainFrame.mainwin.textFrame.left.text
+    .ed_mainFrame.notebook select .ed_mainFrame.tw
+    #Commit to update values in script editor
+    ed_edit_commit
+    if { [ string length $_ED(package)] eq 1 } {
+        #No was pressed at schema deletion and editor is empty do not run
+        return
+    } else {
+        #Yes was pressed at schema deletion run
         run_virtual
     }
 }

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -192,6 +192,7 @@ proc ed_start_gui { dbdict icons iconalt } {
     set Parent .ed_mainFrame
     construct_button $Parent.buttons.hmenu bar hmenu new.ppm "pop_up_menu"  "Open Edit Menu"
     construct_button $Parent.buttons.boxes bar boxes boxes.ppm "build_schema" "Create TPROC Schema" 
+    #construct_button $Parent.buttons.delete bar delete delete.ppm "delete_schema" "Delete TPROC Schema" 
     construct_button $Parent.buttons.drive bar driveroptim drive.ppm {if {$bm eq "TPROC-C"} {loadtpcc} else {loadtpch} } "Load Driver Script" 
     construct_button $Parent.buttons.lvuser bar lvuser arrow.ppm "remote_command load_virtual; load_virtual" "Create Virtual Users" 
     construct_button $Parent.buttons.runworld bar runworld world.ppm "remote_command run_virtual; run_virtual" "Run Virtual Users" 
@@ -443,7 +444,7 @@ proc populate_tree {rdbms bm icons iconalt} {
     tooltip::tooltip $Name -item $rdbms.$bm.build.go "Create $rdbms $bm Schema"
     $Name tag bind builsch <Double-ButtonPress-1> { if { ![ string match [ .ed_mainFrame.treeframe.treeview state ] "disabled focus hover" ] } { build_schema } }
     $Name insert $rdbms.$bm.build end -id $rdbms.$bm.build.del -text "Delete" -image [ create_image delete icons ]
-    dict set treeidicons $rdbms.$bm.build.del boxes
+    dict set treeidicons $rdbms.$bm.build.del delete
     $Name item $rdbms.$bm.build.del -tags deletesch
     tooltip::tooltip $Name -item $rdbms.$bm.build.del "Delete $rdbms $bm Schema"
     $Name tag bind deletesch <Double-ButtonPress-1> { if { ![ string match [ .ed_mainFrame.treeframe.treeview state ] "disabled focus hover" ] } { delete_schema } }

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -192,7 +192,7 @@ proc ed_start_gui { dbdict icons iconalt } {
     set Parent .ed_mainFrame
     construct_button $Parent.buttons.hmenu bar hmenu new.ppm "pop_up_menu"  "Open Edit Menu"
     construct_button $Parent.buttons.boxes bar boxes boxes.ppm "build_schema" "Create TPROC Schema" 
-    #construct_button $Parent.buttons.delete bar delete delete.ppm "delete_schema" "Delete TPROC Schema" 
+    construct_button $Parent.buttons.delete bar delete delete.ppm "delete_schema" "Delete TPROC Schema" 
     construct_button $Parent.buttons.drive bar driveroptim drive.ppm {if {$bm eq "TPROC-C"} {loadtpcc} else {loadtpch} } "Load Driver Script" 
     construct_button $Parent.buttons.lvuser bar lvuser arrow.ppm "remote_command load_virtual; load_virtual" "Create Virtual Users" 
     construct_button $Parent.buttons.runworld bar runworld world.ppm "remote_command run_virtual; run_virtual" "Run Virtual Users" 

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -4,11 +4,11 @@ proc help { args } {
     if [ llength [ info commands wapp-default ]] { set wsmode 1 } else { set wsmode 0 }
     if $wsmode { set helpbanner "HammerDB $hdb_version WS Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset jobs librarycheck loadscript print quit tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
+        set helpcmds [ list buildschema deleteschema clearscript customscript datagenrun dbset dgset diset jobs librarycheck loadscript print quit tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     } else {
         set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema clearscript customscript datagenrun dbset dgset diset distributescript librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
+        set helpcmds [ list buildschema deleteschema clearscript customscript datagenrun dbset dgset diset distributescript librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     }
     if {[ llength $args ] != 1} {
         puts $helpbanner
@@ -95,6 +95,10 @@ Changed tpcc:count_ware from 1 to 10 for Oracle"
                 buildschema {
                     putscli "buildschema - Usage: buildschema"
                     putscli "Runs the schema build for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Build command in the graphical interface." 
+                }
+                deleteschema {
+                    putscli "deleteschema - Usage: deleteschema"
+                    putscli "Runs the schema delete for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Delete command in the graphical interface." 
                 }
                 vuset {
                     putscli "vuset - Usage: vuset \[vu|delay|repeat|iterations|showoutput|logtotemp|unique|nobuff|timestamps\]"
@@ -227,6 +231,9 @@ proc wapp-page-help {} {
         <br>
         <b>GET buildschema</b>: Runs the schema build for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Build command in the graphical interface. Creates a job id associated with all output. 
         get http://localhost:8080/buildschema
+        <br>
+        <b>GET deleteschema</b>: Runs the schema delete for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Delete command in the graphical interface. Creates a job id associated with all output. 
+        get http://localhost:8080/deleteschema
         <br>
         <b>GET jobs</b>: Show the job ids, configuration, output, status, results and timings of jobs created by buildschema and vurun. Job output is equivalent to the output viewed in the graphical interface or command line.
         get http://localhost:8080/jobs

--- a/src/generic/gentheme.tcl
+++ b/src/generic/gentheme.tcl
@@ -473,8 +473,22 @@ if {[dict exists $tmpgendict theme scaling ]} {
         }
         rename tk_messageBox _tk_messageBox
         proc tk_messageBox {args} {
+        variable ::ttk::dialog_module::window_name
+	    if [ winfo exists $window_name ] {
+		    raise $window_name
+		    if [ llength $::ttk::dialog_module::args ] {
+			    if [ dict exists $::ttk::dialog_module::args -title ] {
+		    puts "Warning: [ dict get $::ttk::dialog_module::args -title ] dialog is already open, close it first"
+		    	} else {
+		    puts "Warning: a dialog is already open, close it first"
+			}
+		    }
+		    return
+	    } else {
+	    set ::ttk::dialog_module::args $args
             bell
             ttk::messageBox {*}$args
+    		}
         }
         initscaletheme $theme $pixelsperpoint
     } else {
@@ -493,10 +507,24 @@ if {[dict exists $tmpgendict theme scaling ]} {
                 set defaultBackground #efebe7
                 set defaultForeground black
                 rename tk_messageBox _tk_messageBox
-                proc tk_messageBox {args} {
-                    bell
-                    ttk::messageBox {*}$args
-                }
+        proc tk_messageBox {args} {
+        variable ::ttk::dialog_module::window_name
+	    if [ winfo exists $window_name ] {
+		    raise $window_name
+		    if [ llength $::ttk::dialog_module::args ] {
+			    if [ dict exists $::ttk::dialog_module::args -title ] {
+		    puts "Warning: [ dict get $::ttk::dialog_module::args -title ] dialog is already open, close it first"
+		    	} else {
+		    puts "Warning: a dialog is already open, close it first"
+			}
+		    }
+		    return
+	    } else {
+	    set ::ttk::dialog_module::args $args
+            bell
+            ttk::messageBox {*}$args
+    		}
+        }
             }
         }
         initfixedtheme $theme

--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -231,6 +231,8 @@ proc load_virtual {}  {
     $Name configure -state disabled
     set Name .ed_mainFrame.buttons.boxes 
     $Name configure -state disabled
+    set Name .ed_mainFrame.buttons.delete 
+    $Name configure -state disabled
     set Name .ed_mainFrame.editbuttons.test 
     $Name configure -state disabled
     for { set vuser 0 } {$vuser < $maxvuser } {incr vuser} {
@@ -531,6 +533,8 @@ proc ed_kill_vusers {args} {
     set Name .ed_mainFrame.buttons.datagen 
     $Name configure -state normal
     set Name .ed_mainFrame.buttons.boxes 
+    $Name configure -state normal
+    set Name .ed_mainFrame.buttons.delete 
     $Name configure -state normal
     set Name .ed_mainFrame.editbuttons.test 
     $Name configure -state normal

--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -213,12 +213,17 @@ proc load_virtual {}  {
     if { $result != -1 }  {
         set virtual_users $maxvuser
     } else {
+    set result [ lsearch [ lindex [ split [ join [ stacktrace ] ] ] ] "delete_schema" ]
+    if { $result != -1 }  {
+        set virtual_users $maxvuser
+	} else {
         #Find if workload test or timed set when script is loaded as lprefix
         set maxvuser $virtual_users
         if { $lprefix eq "loadtimed" } {
             set maxvuser [expr {$virtual_users + 1}]
             set suppo 1
         } else { ; }        
+	}
     } 
     #Moved to running of virtual users
     #disable_enable_options_menu disable

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1383,3 +1383,108 @@ proc do_cloud { host port socket ssl_options user password db RAISEERROR VERBOSE
 do_cloud $host $port $socket $ssl_options $user $password $db $RAISEERROR $VERBOSE
 }
 }
+
+proc delete_mariatpch {} {
+    global maxvuser suppo ntimes threadscreated _ED maria_ssl_options
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict maria library ]} {
+        set library [ dict get $dbdict maria library ]
+    } else {
+        set library "mariatcl" 
+    }
+    upvar #0 configmariadb configmariadb
+    #set variables to values in dict
+    setlocaltpchvars $configmariadb
+    #If the options menu has been run under the GUI maria_ssl_options is set
+    #If build is run under the GUI, CLI or WS maria_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb }
+    if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { set maria_connector "$maria_host:$maria_port" }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ] in database [ string toupper $maria_tpch_dbase ]?" -type yesno ] == yes} {
+        if { $maria_num_tpch_threads eq 1 } {
+            set maxvuser 1
+        } else {
+            set maxvuser [ expr $maria_num_tpch_threads + 1 ]
+        }
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "MariaDB TPROC-H deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create threads for schema deletion: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
+if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMaria { host port socket ssl_options user password } {
+    global mariastatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+        set use_socket "true"
+        append connectstring " -socket $socket"
+         } else {
+        set use_socket "false"
+        append connectstring " -host $host -port $port"
+        }
+        foreach key [ dict keys $ssl_options ] {
+        append connectstring " $key [ dict get $ssl_options $key ] "
+        }
+        append connectstring " -user $user -password $password"
+        set login_command "mariaconnect [ dict get $connectstring ]"
+        #eval the login command
+        if [catch {set maria_handler [eval $login_command]}] {
+                if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+    } else {
+            puts "the tcp connection to $host:$port could not be established"
+    }
+        set connected "false"
+        } else {
+        set connected "true"
+        }
+    if {$connected} {
+        maria::autocommit $maria_handler 0
+        catch {set ssl_status [ maria::sel $maria_handler "show session status like 'ssl_cipher'" -list ]}
+        if { [ info exists ssl_status ] } {
+        puts [ join $ssl_status ]
+        }
+        return $maria_handler
+    } else {
+        error $mariastatus(message)
+        return
+    }
+}
+
+proc drop_schema { host port socket ssl_options user password } {
+    global mariastatus
+
+    set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
+    if {[ catch {mariaexec $maria_handler "drop database tpch;"} message ] } {
+        puts "$message"
+    } else {
+        puts "TPROC-H Schema has been deleted successfully."
+    }
+    mariaclose $maria_handler
+
+    return
+}
+
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_tpch_user $maria_tpch_pass"
+    } else { return }
+}

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1400,12 +1400,8 @@ proc delete_mariatpch {} {
     #Set it now if it doesn't exist
     if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb }
     if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { set maria_connector "$maria_host:$maria_port" }
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ] in database [ string toupper $maria_tpch_dbase ]?" -type yesno ] == yes} {
-        if { $maria_num_tpch_threads eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $maria_num_tpch_threads + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete [ string toupper $maria_tpch_dbase ] TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -1470,14 +1466,14 @@ proc ConnectToMaria { host port socket ssl_options user password } {
     }
 }
 
-proc drop_schema { host port socket ssl_options user password } {
+proc drop_schema { host port socket ssl_options user password dbase } {
     global mariastatus
 
     set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
-    if {[ catch {mariaexec $maria_handler "drop database tpch;"} message ] } {
+    if {[ catch {mariaexec $maria_handler "drop database $dbase"} message ] } {
         puts "$message"
     } else {
-        puts "TPROC-H Schema has been deleted successfully."
+        puts "$dbase TPROC-H Schema has been deleted successfully."
     }
     mariaclose $maria_handler
 
@@ -1485,6 +1481,6 @@ proc drop_schema { host port socket ssl_options user password } {
 }
 
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_tpch_user $maria_tpch_pass"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_tpch_user $maria_tpch_pass $maria_tpch_dbase"
     } else { return }
 }

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1400,7 +1400,7 @@ proc delete_mariatpch {} {
     #Set it now if it doesn't exist
     if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb }
     if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { set maria_connector "$maria_host:$maria_port" }
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete [ string toupper $maria_tpch_dbase ] TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ]?" -type yesno ] == yes} {
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $maria_tpch_dbase ] TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ]?" -type yesno ] == yes} {
         set maxvuser 1
         set suppo 1
         set ntimes 1

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -2533,3 +2533,113 @@ insert_mariaconnectpool_drivescript timed async
 }
 }
 }
+
+proc delete_mariatpcc {} {
+    global maxvuser suppo ntimes threadscreated _ED maria_ssl_options
+    upvar #0 dbdict dbdict
+
+    if {[dict exists $dbdict maria library ]} {
+        set library [ dict get $dbdict maria library ]
+    } else {
+        set library "mariatcl" 
+    }
+
+    upvar #0 configmariadb configmariadb
+    #set variables to values in dict
+    setlocaltpccvars $configmariadb
+    #If the options menu has been run under the GUI maria_ssl_options is set
+    #If build is run under the GUI, CLI or WS maria_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb } 
+    if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { 
+        set maria_connector "$maria_host:$maria_port" 
+    }
+
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_user ] in database [ string toupper $maria_dbase ]?" -type yesno ] == yes} {
+        if { $maria_num_vu eq 1 || $maria_count_ware eq 1 } {
+            set maxvuser 1
+        } else {
+            set maxvuser [ expr $maria_num_vu + 1 ]
+        }
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-C deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create threads for schema deletion: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
+if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMaria { host port socket ssl_options user password } {
+    global mariastatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+	set use_socket "true"
+	append connectstring " -socket $socket"
+	 } else {
+	set use_socket "false"
+	append connectstring " -host $host -port $port"
+	}
+	foreach key [ dict keys $ssl_options ] {
+	append connectstring " $key [ dict get $ssl_options $key ] "
+	}
+	append connectstring " -user $user -password $password"
+	set login_command "mariaconnect [ dict get $connectstring ]"
+	#eval the login command
+        if [catch {set maria_handler [eval $login_command]}] {
+		if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+    } else {
+            puts "the tcp connection to $host:$port could not be established"
+    }
+        set connected "false"
+        } else {
+        set connected "true"
+        }
+    if {$connected} {
+        maria::autocommit $maria_handler 0
+	catch {set ssl_status [ maria::sel $maria_handler "show session status like 'ssl_cipher'" -list ]}
+	if { [ info exists ssl_status ] } {
+	puts [ join $ssl_status ]
+	}
+        return $maria_handler
+    } else {
+        error $mariastatus(message)
+        return
+    }
+}
+
+proc drop_schema { host port socket ssl_options user password } {
+    global mariastatus
+
+    set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
+    if {[ catch {mariaexec $maria_handler "drop database tpcc;"} message ] } {
+        puts "$message"
+    } else {
+        puts "TPROC-C Schema has been deleted successfully."
+    }
+    mariaclose $maria_handler
+
+    return
+}
+
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_user $maria_pass"
+    } else { return }
+}

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -2555,12 +2555,8 @@ proc delete_mariatpcc {} {
         set maria_connector "$maria_host:$maria_port" 
     }
 
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_user ] in database [ string toupper $maria_dbase ]?" -type yesno ] == yes} {
-        if { $maria_num_vu eq 1 || $maria_count_ware eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $maria_num_vu + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $maria_dbase ] TPROC-C schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -2625,21 +2621,20 @@ proc ConnectToMaria { host port socket ssl_options user password } {
     }
 }
 
-proc drop_schema { host port socket ssl_options user password } {
+proc drop_schema { host port socket ssl_options user password dbase } {
     global mariastatus
 
     set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
-    if {[ catch {mariaexec $maria_handler "drop database tpcc;"} message ] } {
+    if {[ catch {mariaexec $maria_handler "drop database $dbase"} message ] } {
         puts "$message"
     } else {
-        puts "TPROC-C Schema has been deleted successfully."
+        puts "$dbase TPROC-C Schema has been deleted successfully."
     }
     mariaclose $maria_handler
 
     return
 }
-
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_user $maria_pass"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_user $maria_pass $maria_dbase"
     } else { return }
 }

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -1162,3 +1162,79 @@ if { $refresh_on } {
     do_tpch $server $port $scale_factor $odbc_driver $authentication $uid $pwd $tcp $azure $database $encrypt $trust_cert $RAISEERROR $VERBOSE $maxdop $total_querysets $myposition
 }}
 }
+
+proc delete_mssqlstpch {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict mssqlserver library ]} {
+        set library [ dict get $dbdict mssqlserver library ]
+    } else { set library "tdbc::odbc 1.0.6" }
+    if { [ llength $library ] > 1 } {
+        set version [ lindex $library 1 ]
+        set library [ lindex $library 0 ]
+    }
+    upvar #0 configmssqlserver configmssqlserver
+    #set variables to values in dict
+    setlocaltpchvars $configmssqlserver
+    if {![string match windows $::tcl_platform(platform)]} {
+        set mssqls_server $mssqls_linux_server
+        set mssqls_odbc_driver $mssqls_linux_odbc
+        set mssqls_authentication $mssqls_linux_authent
+    }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete MS SQL Server TPROC-H schema\nin host [string toupper $mssqls_server ] in database [ string toupper $mssqls_tpch_dbase ]?" -type yesno ] == yes} { 
+        if { $mssqls_num_tpch_threads eq 1 } {
+            set maxvuser 1
+        } else {
+            set maxvuser [ expr $mssqls_num_tpch_threads + 1 ]
+        }
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "SQL Server TPROC-H deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create threads for schema deletion: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+set version $version
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library $version} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc connect_string { server port odbc_driver authentication uid pwd tcp azure db } {
+    if { $tcp eq "true" } { set server tcp:$server,$port }
+    if {[ string toupper $authentication ] eq "WINDOWS" } {
+        set connection "DRIVER=$odbc_driver;SERVER=$server;TRUSTED_CONNECTION=YES"
+    } else {
+        if {[ string toupper $authentication ] eq "SQL" } {
+            set connection "DRIVER=$odbc_driver;SERVER=$server;UID=$uid;PWD=$pwd"
+        } else {
+            puts stderr "Error: neither WINDOWS or SQL Authentication has been specified"
+            set connection "DRIVER=$odbc_driver;SERVER=$server"
+        }
+    }
+    if { $azure eq "true" } { append connection ";" "DATABASE=$db" }
+    return $connection
+}
+
+proc drop_tpch { server port scale_fact odbc_driver authentication uid pwd tcp azure db } {
+    set connection [ connect_string $server $port $odbc_driver $authentication $uid $pwd $tcp $azure $db ]
+    
+    if [catch {tdbc::odbc::connection create odbc $connection} message ] {
+        error "Connection to $connection could not be established : $message"
+    } else {
+        #if {!$azure} {odbc evaldirect "use $db"}
+        odbc evaldirect "drop database tpch"
+        puts "TPROC-H schema has been deleted successfully."
+    } 
+    odbc close
+    return
+}
+
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpch {$mssqls_server} $mssqls_port $mssqls_scale_fact {$mssqls_odbc_driver} $mssqls_authentication $mssqls_uid $mssqls_pass $mssqls_tcp $mssqls_azure $mssqls_tpch_dbase"
+    } else { return }
+}

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -1351,3 +1351,105 @@ proc do_cloud { host port socket ssl_options user password db RAISEERROR VERBOSE
 #RUN CLOUD ANALYTIC TPC-H
 do_cloud $host $port $socket $ssl_options $user $password $db $RAISEERROR $VERBOSE}
 }
+
+proc delete_mysqltpch {} {
+    global maxvuser suppo ntimes threadscreated _ED mysql_ssl_options
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict mysql library ]} {
+        set library [ dict get $dbdict mysql library ]
+    } else { set library "mysqltcl" }
+    upvar #0 configmysql configmysql
+    #set variables to values in dict
+    setlocaltpchvars $configmysql
+    #If the options menu has been run under the GUI mysql_ssl_options is set
+    #If build is run under the GUI, CLI or WS mysql_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists mysql_ssl_options ] { check_mysql_ssl $configmysql }
+    if { ![string match windows $::tcl_platform(platform)] && ($mysql_host eq "127.0.0.1" || [ string tolower $mysql_host ] eq "localhost") && [ string tolower $mysql_socket ] != "null" } { set mysql_connector "$mysql_host:$mysql_socket" } else { set mysql_connector "$mysql_host:$mysql_port" }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_tpch_user ] in database [ string toupper $mysql_tpch_dbase ]?" -type yesno ] == yes} {
+        if { $mysql_num_tpch_threads eq 1 } {
+            set maxvuser 1
+        } else {
+            set maxvuser [ expr $mysql_num_tpch_threads + 1 ]
+        }
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "MySQL TPROC-H deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create threads for schema deletion: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMySQL { host port socket ssl_options user password } {
+    global mysqlstatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+        set use_socket "true"
+        append connectstring " -socket $socket"
+    } else {
+        set use_socket "false"
+        append connectstring " -host $host -port $port"
+    }
+    foreach key [ dict keys $ssl_options ] {
+        append connectstring " $key [ dict get $ssl_options $key ] "
+    }
+    append connectstring " -user $user -password $password"
+    set login_command "mysqlconnect [ dict get $connectstring ]"
+    #eval the login command
+    if [catch {set mysql_handler [eval $login_command]}] {
+        if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+        } else {
+            puts "the tcp connection to $host:$port could not be established"
+        }
+        set connected "false"
+    } else {
+        set connected "true"
+    }
+    if {$connected} {
+        mysql::autocommit $mysql_handler 0
+        catch {set ssl_status [ mysql::sel $mysql_handler "show session status like 'ssl_cipher'" -list ]}
+        if { [ info exists ssl_status ] } {
+        puts [ join $ssl_status ]
+        }
+        return $mysql_handler
+    } else {
+        error $mysqlstatus(message)
+        return
+    }
+}
+
+proc drop_schema { host port socket ssl_options user password } {
+    global mysqlstatus
+
+    set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password ]
+    if {[ catch {mysqlexec $mysql_handler "drop database tpch;"} message ] } {
+        puts "$message"
+    } else {
+        puts "TPROC-H Schema has been deleted successfully."
+    }
+    mysqlclose $mysql_handler
+
+    return
+}
+
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_tpch_user $mysql_tpch_pass"
+    } else { return }
+}

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -1366,12 +1366,8 @@ proc delete_mysqltpch {} {
     #Set it now if it doesn't exist
     if ![ info exists mysql_ssl_options ] { check_mysql_ssl $configmysql }
     if { ![string match windows $::tcl_platform(platform)] && ($mysql_host eq "127.0.0.1" || [ string tolower $mysql_host ] eq "localhost") && [ string tolower $mysql_socket ] != "null" } { set mysql_connector "$mysql_host:$mysql_socket" } else { set mysql_connector "$mysql_host:$mysql_port" }
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_tpch_user ] in database [ string toupper $mysql_tpch_dbase ]?" -type yesno ] == yes} {
-        if { $mysql_num_tpch_threads eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $mysql_num_tpch_threads + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $mysql_tpch_dbase ] TPROC-H schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_tpch_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -1435,14 +1431,14 @@ proc ConnectToMySQL { host port socket ssl_options user password } {
     }
 }
 
-proc drop_schema { host port socket ssl_options user password } {
+proc drop_schema { host port socket ssl_options user password dbase } {
     global mysqlstatus
 
     set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password ]
-    if {[ catch {mysqlexec $mysql_handler "drop database tpch;"} message ] } {
+    if {[ catch {mysqlexec $mysql_handler "drop database $dbase"} message ] } {
         puts "$message"
     } else {
-        puts "TPROC-H Schema has been deleted successfully."
+        puts "$dbase TPROC-H Schema has been deleted successfully."
     }
     mysqlclose $mysql_handler
 
@@ -1450,6 +1446,6 @@ proc drop_schema { host port socket ssl_options user password } {
 }
 
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_tpch_user $mysql_tpch_pass"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_tpch_user $mysql_tpch_pass $mysql_tpch_dbase"
     } else { return }
 }

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -2485,12 +2485,8 @@ proc delete_mysqltpcc {} {
     #Set it now if it doesn't exist
     if ![ info exists mysql_ssl_options ] { check_mysql_ssl $configmysql } 
     if { ![string match windows $::tcl_platform(platform)] && ($mysql_host eq "127.0.0.1" || [ string tolower $mysql_host ] eq "localhost") && [ string tolower $mysql_socket ] != "null" } { set mysql_connector "$mysql_host:$mysql_socket" } else { set mysql_connector "$mysql_host:$mysql_port" }
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete TPROC-H schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_user ] in database [ string toupper $mysql_dbase ]?" -type yesno ] == yes} {
-        if { $mysql_num_vu eq 1 || $mysql_count_ware eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $mysql_num_vu + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $mysql_dbase ] TPROC-C schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -2554,14 +2550,14 @@ proc ConnectToMySQL { host port socket ssl_options user password } {
     }
 }
 
-proc drop_schema { host port socket ssl_options user password } {
+proc drop_schema { host port socket ssl_options user password dbase } {
     global mysqlstatus
 
     set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password ]
-    if {[ catch {mysqlexec $mysql_handler "drop database tpcc;"} message ] } {
+    if {[ catch {mysqlexec $mysql_handler "drop database $dbase"} message ] } {
         puts "$message"
     } else {
-        puts "TPROC-C Schema has been deleted successfully."
+        puts "$dbase TPROC-C Schema has been deleted successfully."
     }
     mysqlclose $mysql_handler
 
@@ -2569,6 +2565,6 @@ proc drop_schema { host port socket ssl_options user password } {
 }
 
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_user $mysql_pass"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_user $mysql_pass $mysql_dbase"
     } else { return }
 }

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1658,16 +1658,12 @@ proc delete_oratpch {} {
     upvar #0 configoracle configoracle
     setlocaltpchvars $configoracle
     if { $tpch_tt_compat eq "true" } {
-        set install_message "Ready to delete TimesTen TPROC-H schema\nin the existing database [string toupper $instance]\n under existing user [ string toupper $tpch_user ]?"
+        set install_message "Do you want to delete the [ string toupper $tpch_user ] TimesTen TPROC-H schema\nin the instance [string toupper $instance]?"
     } else {
-        set install_message "Ready to delete TPROC-H schema in database [string toupper $instance]\n under user [ string toupper $tpch_user ] in tablespace [ string toupper $tpch_def_tab]?"
+        set install_message "Do you want to delete the [ string toupper $tpch_user ] TPROC-H schema in the instance [string toupper $instance]?"
     }
     if {[ tk_messageBox -title "Delete Schema" -icon question -message $install_message -type yesno ] == yes} {
-        if { $num_tpch_threads eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $num_tpch_threads + 1 ]
-        }
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -1690,16 +1686,13 @@ proc drop_tpch { system_user system_password instance tpch_user } {
     set curn [oraopen $lda ]
     set dropsql "drop user $tpch_user cascade\n"
     if {[ catch {orasql $curn $dropsql} message ] } {
-        puts "$dropsql : $message"
-        #puts [ oramsg $curn all ]
+	      error [ regsub -all {\{|\}} [ oramsg $curn all ] "" ]
     } else {
-        puts "TPROC-H schema has been deleted successfully."
+        puts "$tpch_user TPROC-H schema has been deleted successfully."
     }
     oralogoff $lda
-
     return
 }
-
 }
 
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpch $system_user $system_password $instance $tpch_user"

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -3283,3 +3283,69 @@ switch $myposition {
         } 
     }
 }
+
+proc delete_oratpcc {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict oracle library ]} {
+        set library [ dict get $dbdict oracle library ]
+    } else { set library "Oratcl" } 
+    upvar #0 configoracle configoracle
+    setlocaltpccvars $configoracle
+    if { $tpcc_tt_compat eq "true" } {
+        set install_message "Ready to delete TimesTen TPROC-C schema\nin the existing database [string toupper $instance] under existing user [ string toupper $tpcc_user ]?" 
+    } else {
+        set install_message "Ready to delete Oracle TPROC-C schema\nin database [string toupper $instance] under user [ string toupper $tpcc_user ] in tablespace [ string toupper $tpcc_def_tab]?" 
+    }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message $install_message -type yesno ] == yes} { 
+        if { $num_vu eq 1 || $count_ware eq 1 } {
+            set maxvuser 1
+        } else {
+            set maxvuser [ expr $num_vu + 1 ]
+        }
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-C deletion"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread(s) for schema deletion: $message"
+            return 1
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc drop_tpcc { system_user system_password instance tpcc_user hash_clusters } {
+    set connect $system_user/$system_password@$instance
+    set lda [ oralogon $connect ]
+    set curn [oraopen $lda ]
+    if  { $hash_clusters } {
+        foreach table { WAREHOUSE DISTRICT CUSTOMER ITEM STOCK ORDERS NEW_ORDER ORDER_LINE HISTORY } {
+            set sql "ALTER TABLE $table DISABLE TABLE LOCK\n"
+            if {[ catch {orasql $curn $sql} message ] } {
+                puts "$sql : $message"
+                #puts [ oramsg $curn all ]
+            }
+        }
+    }
+    set dropsql "drop user $tpcc_user cascade\n"
+    if {[ catch {orasql $curn $dropsql} message ] } {
+        puts "$dropsql : $message"
+        #puts [ oramsg $curn all ]
+    } else {
+        puts "TPROC-C schema has been deleted successfully."
+    }
+    oralogoff $lda
+
+    return
+}
+
+}
+
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpcc $system_user $system_password $instance $tpcc_user $hash_clusters"
+    } else { return }
+}

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -3293,16 +3293,12 @@ proc delete_oratpcc {} {
     upvar #0 configoracle configoracle
     setlocaltpccvars $configoracle
     if { $tpcc_tt_compat eq "true" } {
-        set install_message "Ready to delete TimesTen TPROC-C schema\nin the existing database [string toupper $instance] under existing user [ string toupper $tpcc_user ]?" 
+        set delete_message "Do you want to delete the [ string toupper $tpcc_user ] TimesTen TPROC-C schema\nin the instance [string toupper $instance]?" 
     } else {
-        set install_message "Ready to delete Oracle TPROC-C schema\nin database [string toupper $instance] under user [ string toupper $tpcc_user ] in tablespace [ string toupper $tpcc_def_tab]?" 
+        set delete_message "Do you want to delete the [ string toupper $tpcc_user ] Oracle TPROC-C schema\nin the instance [string toupper $instance]?" 
     }
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message $install_message -type yesno ] == yes} { 
-        if { $num_vu eq 1 || $count_ware eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $num_vu + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message $delete_message -type yesno ] == yes} { 
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -3325,25 +3321,21 @@ proc drop_tpcc { system_user system_password instance tpcc_user hash_clusters } 
     set curn [oraopen $lda ]
     if  { $hash_clusters } {
         foreach table { WAREHOUSE DISTRICT CUSTOMER ITEM STOCK ORDERS NEW_ORDER ORDER_LINE HISTORY } {
-            set sql "ALTER TABLE $table DISABLE TABLE LOCK\n"
+            set sql "ALTER TABLE $table ENABLE TABLE LOCK\n"
             if {[ catch {orasql $curn $sql} message ] } {
-                puts "$sql : $message"
-                #puts [ oramsg $curn all ]
+	      error [ regsub -all {\{|\}} [ oramsg $curn all ] "" ]
             }
         }
     }
     set dropsql "drop user $tpcc_user cascade\n"
     if {[ catch {orasql $curn $dropsql} message ] } {
-        puts "$dropsql : $message"
-        #puts [ oramsg $curn all ]
+	      error [ regsub -all {\{|\}} [ oramsg $curn all ] "" ]
     } else {
-        puts "TPROC-C schema has been deleted successfully."
+        puts "$tpcc_user TPROC-C schema has been deleted successfully."
     }
     oralogoff $lda
-
     return
 }
-
 }
 
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpcc $system_user $system_password $instance $tpcc_user $hash_clusters"

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -1489,12 +1489,8 @@ proc delete_pgtpch {} {
     upvar #0 configpostgresql configpostgresql
     #set variables to values in dict
     setlocaltpchvars $configpostgresql
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete TPROC-H schema\n in host [string toupper $pg_host:$pg_port] under user [ string toupper $pg_tpch_superuser ]?" -type yesno ] == yes} {
-        if { $pg_num_tpch_threads eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $pg_num_tpch_threads + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $pg_tpch_dbase ] TPROC-H schema and role [ string toupper $pg_tpch_user ]\n in host [string toupper $pg_host:$pg_port] under user [ string toupper $pg_tpch_superuser ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -1512,17 +1508,12 @@ if [catch {package require $library} message] { error "Failed to load $library -
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
 if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
 
-proc ConnectToPostgresWithoutDB { host port sslmode user password } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
     global tcl_platform
-    if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password ]]} message]} {
+    if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -1530,32 +1521,31 @@ proc ConnectToPostgresWithoutDB { host port sslmode user password } {
     return $lda
 }
 
-proc drop_schema { host port sslmode superuser superuser_password } {
-    set existing_db [ ConnectToPostgresWithoutDB $host $port $sslmode $superuser $superuser_password ]
-    if { $existing_db eq "Failed" } {
+proc drop_schema { host port sslmode user superuser superuser_password default_dbase dbase } {
+    set suconnect [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_dbase ]
+    if { $suconnect eq "Failed" } {
         error "error, the database connection to $host could not be established"
     } else {
-        set result [ pg_exec $existing_db "drop database tpch;"]
+        set result [ pg_exec $suconnect "drop database $dbase"]
         if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
             error "[pg_result $result -error]"
         } else {
-            puts "TPROC-H schema has been deleted successfully."
+            puts "$dbase TPROC-H schema has been deleted successfully."
             pg_result $result -clear
-    
-            set result [ pg_exec $existing_db "drop role tpch;"]
-            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-                error "[pg_result $result -error]"
-            } else {
-                puts "Role tpch has been deleted successfully."
-                pg_result $result -clear
-            }
         }
-        pg_disconnect $existing_db
+        set result [ pg_exec $suconnect "drop role $user"]
+        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+            error "[pg_result $result -error]"
+        } else {
+            puts "$user TPROC-H role has been deleted successfully."
+            pg_result $result -clear
+        }
+        pg_disconnect $suconnect
     }
     return
 }
-
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_tpch_superuser $pg_tpch_superuserpass"
+
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_tpch_user $pg_tpch_superuser $pg_tpch_superuserpass $pg_tpch_defaultdbase $pg_tpch_dbase"
     } else { return }
 }

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -3709,12 +3709,8 @@ proc delete_pgtpcc {} {
     upvar #0 configpostgresql configpostgresql
     #set variables to values in dict
     setlocaltpccvars $configpostgresql
-    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Ready to delete TPROC-H schema\n in host [string toupper $pg_host:$pg_port] under user [ string toupper $pg_superuser ]?" -type yesno ] == yes} {
-        if { $pg_num_vu eq 1 || $pg_count_ware eq 1 } {
-            set maxvuser 1
-        } else {
-            set maxvuser [ expr $pg_num_vu + 1 ]
-        }
+    if {[ tk_messageBox -title "Delete Schema" -icon question -message "Do you want to delete the [ string toupper $pg_dbase ] TPROC-C schema and role [ string toupper $pg_user ]\n in host [string toupper $pg_host:$pg_port] under user [ string toupper $pg_superuser ]?" -type yesno ] == yes} {
+        set maxvuser 1
         set suppo 1
         set ntimes 1
         ed_edit_clear
@@ -3732,17 +3728,12 @@ if [catch {package require $library} message] { error "Failed to load $library -
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
 if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
 
-proc ConnectToPostgresWithoutDB { host port sslmode user password } {
+proc ConnectToPostgres { host port sslmode user password dbname } {
     global tcl_platform
-    if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password ]]} message]} {
+    if {[catch {set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password dbname = $dbname ]]} message]} {
         set lda "Failed" ; puts $message
         error $message
     } else {
-        if {$tcl_platform(platform) == "windows"} {
-            #Workaround for Bug #95 where first connection fails on Windows
-            catch {pg_disconnect $lda}
-            set lda [pg_connect -conninfo [list host = $host port = $port sslmode = $sslmode user = $user password = $password ]]
-        }
         pg_notice_handler $lda puts
         set result [ pg_exec $lda "set CLIENT_MIN_MESSAGES TO 'ERROR'" ]
         pg_result $result -clear
@@ -3750,32 +3741,31 @@ proc ConnectToPostgresWithoutDB { host port sslmode user password } {
     return $lda
 }
 
-proc drop_schema { host port sslmode superuser superuser_password } {
-    set existing_db [ ConnectToPostgresWithoutDB $host $port $sslmode $superuser $superuser_password ]
-    if { $existing_db eq "Failed" } {
+proc drop_schema { host port sslmode user superuser superuser_password default_dbase dbase } {
+    set suconnect [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_dbase ]
+    if { $suconnect eq "Failed" } {
         error "error, the database connection to $host could not be established"
     } else {
-        set result [ pg_exec $existing_db "drop database tpcc;"]
+        set result [ pg_exec $suconnect "drop database $dbase"]
         if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
             error "[pg_result $result -error]"
         } else {
-            puts "TPROC-C schema has been deleted successfully."
+            puts "$dbase TPROC-C schema has been deleted successfully."
             pg_result $result -clear
-    
-            set result [ pg_exec $existing_db "drop role tpcc;"]
-            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-                error "[pg_result $result -error]"
-            } else {
-                puts "Role tpcc has been deleted successfully."
-                pg_result $result -clear
-            }
         }
-        pg_disconnect $existing_db
+        set result [ pg_exec $suconnect "drop role $user"]
+        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+            error "[pg_result $result -error]"
+        } else {
+            puts "$user TPROC-C role has been deleted successfully."
+            pg_result $result -clear
+        }
+        pg_disconnect $suconnect
     }
     return
 }
-
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_superuser $pg_superuserpass"
+
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_user $pg_superuser $pg_superuserpass $pg_defaultdbase $pg_dbase"
     } else { return }
 }


### PR DESCRIPTION
Closes Issue #351 

Adds GUI Icon and CLI command to drop the schema created by Build Schema.

For Db2 functionality is added by running external command. To do this correctly we need to add the sqlecrea and the sqledrpd APIs to db2tcl and then we can both create and drop the schema from within HammerDB. 

![deleteschema2](https://user-images.githubusercontent.com/38044085/190472726-e74ac856-451f-4c56-82b1-6710e774389a.PNG)
