### PR TITLE
Improve CLI diset error message

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -517,6 +517,18 @@ proc vuset { args } {
             }
 }}}
 
+proc findakey { key2find dictname } {
+        upvar #0 $dictname $dictname
+        foreach key [dict keys [ set $dictname]] {
+                dict for {k v} [dict get [ set $dictname ] $key] {
+                if { $k eq $key2find } {
+                return $key
+                }
+                }
+        }
+return {}
+}
+
 proc diset { args } {
     global rdbms opmode
     if {[ llength $args ] != 3} {
@@ -554,11 +566,15 @@ proc diset { args } {
                               	SQLiteUpdateKeyValue $key $dct $key2 $val
                                 remote_command [ concat diset $dct $key2 [ list \{$val\} ]]
                         }}
-                    } else {
-                        putscli {Usage: diset dict key value}
-                        putscli "Dictionary \"$dct\" for $rdbms exists but key \"$key2\" doesn't"
-                        putscli "Type \"print dict\" for valid dictionaries and keys for $rdbms"
-                    }
+                    		} else {
+		       		set key2find [ findakey $key2 $dictname ]
+                       		if { [ string length $key2find ] > 0 } {
+                        	putscli "Dictionary \"$dct\" for $rdbms exists but key \"$key2\" doesn't, key \"$key2\" is in the \"$key2find\" dictionary"
+                        	} else {
+                        	putscli "Dictionary \"$dct\" for $rdbms exists but key \"$key2\" doesn't, key \"$key2\" cannot be found in any $rdbms dictionary"
+                        	}
+                        	putscli "Type \"print dict\" for valid dictionaries and keys for $rdbms"
+                    	}
                 } else {
                     putscli {Usage: diset dict key value}
                     putscli "Dictionary \"$dct\" for $rdbms does not exist"


### PR DESCRIPTION

Change CLI diset error message so if incorrect dictionary is given, error message reports the dictionary that the key is in or reports that the key is not in any dictionary. 

```
steve@CRANE:/opt/HammerDB-4.5$ ./hammerdbcli
HammerDB CLI v4.5
Copyright (C) 2003-2022 Steve Shaw
Type "help" for a list of commands
hammerdb>dbset db mysql
Database set to MySQL

hammerdb>diset tpcc mysql_ssl true
Dictionary "tpcc" for MySQL exists but key "mysql_ssl" doesn't, key "mysql_ssl" is in the "connection" dictionary
Type "print dict" for valid dictionaries and keys for MySQL

hammerdb>diset connection mysql_ssl true
Changed connection:mysql_ssl from false to true for MySQL

hammerdb>diset connection mysql_sst true
Dictionary "connection" for MySQL exists but key "mysql_sst" doesn't, key "mysql_sst" cannot be found in any MySQL dictionary
Type "print dict" for valid dictionaries and keys for MySQL

hammerdb>
```