### PR TITLE
Fix for issue #450

### DIFF
--- a/src/generic/genxml.tcl
+++ b/src/generic/genxml.tcl
@@ -116,7 +116,7 @@ proc SQLiteUpdateKeyValue {dbname table keyname value} {
         if { $sqlitedb ne "" } {
             set sqlcmd "UPDATE $table SET val = \'$value\' WHERE key = \'$keyname\'"
             if [catch {hdb eval $sqlcmd} message ] {
-                puts "Error creating $tablename table in $sqlitedb : $message"
+                puts "Error creating $table table in $sqlitedb : $message"
                 return
             }
         }


### PR DESCRIPTION
Fixed issue #450. Error was being caused by the error message "Error creating $tablename table in $sqlitedb : $message" in src/generic/genxml.tcl. The variable $tablename does not exist inside the function "SQLiteUpdateKeyValue" and hence was throwing an exception. Changed to variable name to $table.