### PR TITLE
Add alternative python CLI interface

### DIFF
--- a/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
@@ -12,6 +12,7 @@ Setup libressl          libressl-2.6.4.7z              libressl.bawt
 Setup tcltls            tcltls-1.7.22.7z               tcltls.bawt	
 Setup tksvg             tksvg-0.5.7z                   tksvg.bawt
 Setup tkblt             tkblt-3.2.23.7z                tkblt.bawt
+Setup tclpy             tclpy-0.4.7z                   tclpy.bawt
 # Compiled Tcl Database interface packages.
 Setup oratcl            oratcl-4.6.7z                  oratcl.bawt	
 Setup mariatcl          mariatcl-0.1.7z                mariatcl.bawt	

--- a/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
@@ -14,6 +14,7 @@ Setup TkStubs           Tk-[GetTkVersion].7z           TkStubs.bawt
 Setup twapi		twapi-4.6.0.7z		       twapi.bawt
 Setup tksvg             tksvg-0.5.7z                   tksvg.bawt
 Setup tkblt             tkblt-3.2.23.7z                tkblt.bawt
+Setup tclpy             tclpy-0.4.7z                   tclpy_NMake.bawt
 # Compiled Tcl Database interface packages.
 Setup oratcl            oratcl-4.6.7z                  oratcl_NMake.bawt	
 Setup mariatcl          mariatcl-0.1.7z                mariatcl_NMake.bawt

--- a/agent/agent
+++ b/agent/agent
@@ -40,7 +40,7 @@ namespace import comm::*
 interp recursionlimit {} 3000
 global agentlist S iswin
 set iswin "false"
-set version 4.4
+set version 4.6
 
 if {$tcl_platform(platform) == "windows"} { 
 	package require twapi 

--- a/hammerdb
+++ b/hammerdb
@@ -27,7 +27,7 @@ exit
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.5"
+set hdb_version "v4.6"
 set mainGeometry +10+10
 set UserDefaultDir [ file dirname [ info script ] ]
 ::tcl::tm::path add "$UserDefaultDir/modules"

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -199,8 +199,10 @@ send "sys.ps1 = 'hammerdb>>>'\x0D"
 set timeout -1
 if { $autostart::autostartap == "true" } {
 #run python script
+expect "hammerdb>>>"
 send "exec(open('$autostart::autoloadscript').read())"
-send "\x0D"
+send "\n"
+log_user 1
 expect {"hammerdb>>>"}
 	} else {
 expect "hammerdb>>>"
@@ -212,13 +214,13 @@ interact {
  	\x03 {
 	puts "^C"
 	#send Ctrl-C to Python
-	#send "\x03"
+	send "\x03"
 	return
     	}
  	\x04 {
 	puts "^D"
 	#send Ctrl-D to Python
-	#send "\x04"
+	send "\x04"
 	return
     	}
 	}

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -25,7 +25,7 @@ exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.5"
+set hdb_version "v4.6"
 puts "HammerDB CLI $hdb_version"
 puts "Copyright (C) 2003-2022 Steve Shaw"
 puts "Type \"help\" for a list of commands"

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -172,43 +172,42 @@ catch {package forget tclpy}
 #Remove tclreadline module from common initialisation in Python
 regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
 append cli_common_init $cli_py_append
-set timeout 2
-spawn -noecho python3
+set timeout 10
 log_user 0
+spawn -noecho python3
 expect ">>>"
-send "import sys\n"
+send "import sys\x0D"
 expect ">>>"
-send "sys.path.append('$syspath')\n"
+send "sys.path.append('$syspath')\x0D"
 expect ">>>"
-send "import tclpy\n"
+send "import tclpy\x0D"
 expect ">>>"
-send "tclpy.eval('global hdb_version')\n"
+send "tclpy.eval('global hdb_version')\x0D"
 expect ">>>"
-send "tclpy.eval('set hdb_version $hdb_version')\n"
+send "tclpy.eval('set hdb_version $hdb_version')\x0D"
 expect ">>>"
-send "init_tcl = (r'''\n$cli_common_init\n''')\n"
+send "init_tcl = (r'''\n$cli_common_init\n''')\x0D"
 expect ">>>"
-send "tclpy.eval(init_tcl)\n"
+send "tclpy.eval(init_tcl)\x0D"
 expect ">>>"
-send "from hammerdb import *\n"
+send "from hammerdb import *\x0D"
 expect ">>>"
-if { $autostart::autostartap == "true" } {
-send "runscript(1)\n"
-	} else {
-send "runscript(0)\n"
-	}
-expect ">>>"
-send {sys.ps1 = "hammerdb>>>"}
-send "\n"
-expect {"hammerdb>>>"}
-log_user 1
+if { $autostart::autostartap == "true" } { send "runscript(1)\x0D" } else { send "runscript(0)\x0D" }
+send "sys.stdout.flush()\x0D"
+send "sys.ps1 = 'hammerdb>>>'\x0D"
 #If timeout is set to a +ve value auto scripts will terminate before completion
 set timeout -1
 if { $autostart::autostartap == "true" } {
+#run python script
 send "exec(open('$autostart::autoloadscript').read())"
-send "\n"
+send "\x0D"
 expect {"hammerdb>>>"}
 	} else {
+expect "hammerdb>>>"
+log_user 1
+#-----------------------------#
+#run interactive python shell
+#-----------------------------#
 interact {
  	\x03 {
 	puts "^C"
@@ -218,6 +217,8 @@ interact {
     	}
  	\x04 {
 	puts "^D"
+	#send Ctrl-D to Python
+	#send "\x04"
 	return
     	}
 	}

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -199,9 +199,13 @@ send "sys.ps1 = 'hammerdb>>>'\x0D"
 set timeout -1
 if { $autostart::autostartap == "true" } {
 #run python script
+trap {
+    send "\x03"
+    send_user "^C\n"
+    exit
+} SIGINT
 expect "hammerdb>>>"
-send "exec(open('$autostart::autoloadscript').read())"
-send "\n"
+send "exec(open('$autostart::autoloadscript').read())\x0D"
 log_user 1
 expect {"hammerdb>>>"}
 	} else {
@@ -212,15 +216,9 @@ log_user 1
 #-----------------------------#
 interact {
  	\x03 {
-	puts "^C"
 	#send Ctrl-C to Python
 	send "\x03"
-	return
-    	}
- 	\x04 {
-	puts "^D"
-	#send Ctrl-D to Python
-	send "\x04"
+	send_user "^C"
 	return
     	}
 	}

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -108,14 +108,14 @@ for { set dbsrccount 0 } { $dbsrccount < [llength $dbsrclist] } { incr dbsrccoun
                 puts stderr "Error:loading database source files/$f"
         }
     }}
-#In Tcl only either source file or do tclreadline::interact
+#In Tcl only either source file or do Tclreadline::interact
 set cli_tcl_append {
 if { $autostart::autostartap == "true" } {
         source $autostart::autoloadscript
         } else {
     TclReadLine::interact
         }}
-#In Python already in interact so bypas tclreadline
+#In Python on Linux use expect on Windows use Tclreadline::interact
 set cli_py_append {
 rename putscli _putscli
 proc putscli { output } {
@@ -128,30 +128,115 @@ eval $cli_common_init
 #Initialise CLI in Python
 } elseif { $lang eq "python" } {
 proc pythonVersion {{pythonExecutable "python3"}} {
-puts "did py version"
+if {[string match windows $::tcl_platform(platform)]} { set pythonExecutable "python" }
 if {![catch {exec $pythonExecutable --version}] || [lindex $::errorCode 0] eq "NONE"} {
 } else {
-puts "Error:failed to find executable $pythonExecutable"
-exit
+puts "Error: Failed to find $::tcl_platform(platform) executable \"$pythonExecutable\""
+return -1
 }
 set info [exec $pythonExecutable --version 2>@1]
 if {[regexp {^Python ([\d.]+)$} $info --> version]} {
 return $version
 }
-puts "Error:failed to parse output of $pythonExecutable --version: '$info'"
-exit
+puts "Error: Failed to parse output of $pythonExecutable --version: '$info'"
+return -1
 }
+if {[string match windows $::tcl_platform(platform)]} {
+#Windows
+proc winpause {} { after 3000 } 
+proc bgerror {message} { puts $message }
+#Check python library versions are compatible
+if {[catch {package require tclpy} message]} { 
+set pyver [pythonVersion] 
+if { $pyver != -1 } {
+puts "Error: Python installation [pythonVersion] detected but at incorrect Python version, see HammerDB documentation" 
+	} else {
+puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
+	}
+winpause
+exit
+	} else {
+catch {package forget tclpy}
+	}
+set UserDefaultDir [ file dirname [ info script ] ]
+::tcl::tm::path add "$UserDefaultDir/modules"
+package require tclreadline
+regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
+append cli_common_init $cli_py_append
+set py_init "import os
+import sys
+tcl_dll_location = os.getcwd() + r'\\bin'
+os.add_dll_directory(tcl_dll_location)
+sys.path.append(r'.\\lib\\tclpy0.4')
+import tclpy
+tclpy.eval('global hdb_version')
+tclpy.eval('set hdb_version $hdb_version')
+init_tcl = (r'''\n$cli_common_init\n''')
+tclpy.eval(init_tcl)
+from hammerdb import \*
+sys.stdout.flush()
+sys.ps1 = '<<<'"
+#Reversed the prompt to detect when Python has finished its output, so HammerDB can prompt also.
+proc piperead_interact {pipe echo} {
+    if {![eof $pipe]} {
+        set got [ read -nonewline $pipe ]
+	if {!$echo} { ; } else {
+	TclReadLine::pyclearline 
+	if { [ string equal "<<<" $got ] } { 
+	TclReadLine::prompt ""
+	} else {
+	if { [ string match "*<<<" $got ] } { 
+	set got [ string trimright $got "\n+<<<" ]
+	puts "\r$got\n"
+	TclReadLine::prompt ""
+	} else {
+	puts "\r$got"
+	}}}} else { 
+	close $pipe
+ 	return	
+	 }
+	}
+
+proc piperead_script {pipe} {
+    if {![eof $pipe]} {
+        set got [regsub {.+< } [gets $pipe] ""]
+        puts "$got"
+    }   
+}
+
+set pipe [open "|[ auto_execok python] -uiq 2>@1" r+]
+fconfigure $pipe -buffering line -blocking false -encoding cp1252
+fileevent $pipe readable [list piperead_interact $pipe false]
+set pywait [list]
+foreach pyline [split $py_init \n] {
+# send init line to the pipe
+puts $pipe $pyline
+# need some delay for the pipe
+after 60 [list append pywait ""]
+vwait pywait
+}
+if { $autostart::autostartap == "true" } { 
+puts $pipe "runscript(1)" 
+fileevent $pipe readable [list piperead_script $pipe]
+set pywait [ list ]
+puts $pipe "exec(open('$autostart::autoloadscript').read())"
+after 200 [ list append pywait ""]
+vwait pywait
+close $pipe
+} else { 
+fileevent $pipe readable [ list piperead_interact $pipe true ]
+puts $pipe "runscript(0)" 
+TclReadLine::interactpy $pipe
+}
+winpause
+exit
+} else {
+#Linux
 set syspath [ string trim $env(PYTHONPATH) ":*" ]
 if { ![ file isdirectory $syspath ] } {
 puts "Error:Cannot find HammerDB Python libraries $env(PYTHONPATH) is not a directory"
 exit
 	}
-if {[string match windows $::tcl_platform(platform)]} {
-#Windows
-        package require twapi
-        package require twapi_input
-} else {
-#Linux
 if {[catch {package require Expect} ]} { 
 puts "Error:Failed to load Expect package to run Python" 
 exit
@@ -163,7 +248,7 @@ if { [ info exists pyver ] && $pyver != [pythonVersion] } {
 puts "Error: Python version $pyver required, version [pythonVersion] is installed" 
 exit
 	} else {
-puts "Error: Unable to detect Python installation" 
+puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
 exit
 	}
 	} else {

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -31,139 +31,139 @@ set hdb_version "v4.6"
 puts "HammerDB CLI $hdb_version"
 puts "Copyright (C) 2003-2022 Steve Shaw"
 if { $argc eq 0 } {
-	set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
+set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
 if { $argv0 == "" || $argv0 == "tcl" || $argv0 == "auto" } {
-	set lang "tcl"
-	set extension ".tcl"
-	puts "Type \"help\" for a list of commands"
-	} elseif { $argv0 == "py" || $argv0 == "python" } {
-	set lang "python"
-	set extension ".py"
-	puts "Type \"help()\" for a list of commands"
-	} else {
-	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
-	exit
-	}
+  set lang "tcl"
+  set extension ".tcl"
+  puts "Type \"help\" for a list of commands"
+} elseif { $argv0 == "py" || $argv0 == "python" } {
+  set lang "python"
+  set extension ".py"
+  puts "Type \"help()\" for a list of commands"
+} else {
+  puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+  exit
+}
 
 namespace eval autostart {
-    set autostartap "false"
-	if { $argv0 == "tcl" || $argv0 == "py" || $argv0 == "python" } {
-	set argv [ lreplace $argv 0 0 ]
-	set argc [ expr {$argc - 1} ]
-		}
-    if { $argc eq 0 } { ; } else {
+  set autostartap "false"
+  if { $argv0 == "tcl" || $argv0 == "py" || $argv0 == "python" } {
+    set argv [ lreplace $argv 0 0 ]
+    set argc [ expr {$argc - 1} ]
+  }
+  if { $argc eq 0 } { ; } else {
     if {$argc != 2 || [lindex $argv 0] != "auto" } {
-	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
-	exit
-	} else {
-        set autostartap "true"
-        set autoloadscript [lindex $argv 1]
-if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] eq $extension } {
-;# autostart selected and tcl or py file exists
-	     } else {
-if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] != $extension } {
-	puts "Error: incorrect file extension for $lang" 
-	if { $lang eq "tcl" } {
-	puts {Usage: hammerdbcli [ tcl [ auto [ script_to_autoload.[ tcl ] ] ]}
-		} else {
-	puts {Usage: hammerdbcli [ python [ auto [ script_to_autoload.[ py ] ] ]}
-		       }
-	exit
-		 } else {
-	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
-	 	}
-	     }
-         }
+      puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+      exit
+    } else {
+      set autostartap "true"
+      set autoloadscript [lindex $argv 1]
+      if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] eq $extension } {
+        ;# autostart selected and tcl or py file exists
+      } else {
+        if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] != $extension } {
+          puts "Error: incorrect file extension for $lang" 
+          if { $lang eq "tcl" } {
+            puts {Usage: hammerdbcli [ tcl [ auto [ script_to_autoload.[ tcl ] ] ]}
+          } else {
+            puts {Usage: hammerdbcli [ python [ auto [ script_to_autoload.[ py ] ] ]}
+          }
+          exit
+        } else {
+          puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+        }
+      }
     }
+  }
 }
 #Common CLI initialisation between Tcl and Python
 set cli_common_init {set UserDefaultDir [ file dirname [ info script ] ]
-::tcl::tm::path add "$UserDefaultDir/modules"
-append modulelist { Thread msgcat xml comm tclreadline task reformat_tcl }
-for { set modcount 0 } { $modcount < [llength $modulelist] } { incr modcount } {
+  ::tcl::tm::path add "$UserDefaultDir/modules"
+  append modulelist { Thread msgcat xml comm tclreadline task reformat_tcl }
+  for { set modcount 0 } { $modcount < [llength $modulelist] } { incr modcount } {
     set m [lindex $modulelist $modcount]
-		set loadtext $m
-	if [catch { package require $m }] {
-                puts stderr "While loading module\
+    set loadtext $m
+    if [catch { package require $m }] {
+      puts stderr "While loading module\
                         \"$m\"...\n$errorInfo"
-                exit 1
-        }
+      exit 1
     }
-    
-append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl genmodes.tcl gentccmn.tcl gentccli.tcl geninitcli.tcl gencli.tcl genhelp.tcl genstep.tcl }
-for { set loadcount 0 } { $loadcount < [llength $loadlist] } { incr loadcount } {
-    set f [lindex $loadlist $loadcount]
-		set loadtext $f
-	if [catch {source [ file join $UserDefaultDir src generic $f ]}] {
-                puts stderr "While loading component file\
-                        \"$f\"...\n$errorInfo"
-                exit 1
-        }
-    }
+  }
 
-for { set dbsrccount 0 } { $dbsrccount < [llength $dbsrclist] } { incr dbsrccount } {
+  append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl genmodes.tcl gentccmn.tcl gentccli.tcl geninitcli.tcl gencli.tcl genhelp.tcl genstep.tcl }
+  for { set loadcount 0 } { $loadcount < [llength $loadlist] } { incr loadcount } {
+    set f [lindex $loadlist $loadcount]
+    set loadtext $f
+    if [catch {source [ file join $UserDefaultDir src generic $f ]}] {
+      puts stderr "While loading component file\
+                        \"$f\"...\n$errorInfo"
+      exit 1
+    }
+  }
+
+  for { set dbsrccount 0 } { $dbsrccount < [llength $dbsrclist] } { incr dbsrccount } {
     set f [lindex $dbsrclist $dbsrccount]
-		set loadtext $f
-	if [catch {source [ file join $UserDefaultDir src $f ]}] {
-                puts stderr "Error:loading database source files/$f"
-        }
-    }}
+    set loadtext $f
+    if [catch {source [ file join $UserDefaultDir src $f ]}] {
+      puts stderr "Error:loading database source files/$f"
+    }
+}}
 #In Tcl only either source file or do Tclreadline::interact
 set cli_tcl_append {
-if { $autostart::autostartap == "true" } {
-        source $autostart::autoloadscript
-        } else {
+  if { $autostart::autostartap == "true" } {
+    source $autostart::autoloadscript
+  } else {
     TclReadLine::interact
-        }}
+}}
 #In Python on Linux use expect on Windows use Tclreadline::interact
 set cli_py_append {
-rename putscli _putscli
-proc putscli { output } {
-puts "$output\r"
-	}}
+  rename putscli _putscli
+  proc putscli { output } {
+    puts "$output\r"
+}}
 #Initialise CLI in Tcl
 if { $lang == "tcl" } {
-append cli_common_init $cli_tcl_append
-eval $cli_common_init
-#Initialise CLI in Python
+  append cli_common_init $cli_tcl_append
+  eval $cli_common_init
+  #Initialise CLI in Python
 } elseif { $lang eq "python" } {
-proc pythonVersion {{pythonExecutable "python3"}} {
-if {[string match windows $::tcl_platform(platform)]} { set pythonExecutable "python" }
-if {![catch {exec $pythonExecutable --version}] || [lindex $::errorCode 0] eq "NONE"} {
-} else {
-puts "Error: Failed to find $::tcl_platform(platform) executable \"$pythonExecutable\""
-return -1
-}
-set info [exec $pythonExecutable --version 2>@1]
-if {[regexp {^Python ([\d.]+)$} $info --> version]} {
-return $version
-}
-puts "Error: Failed to parse output of $pythonExecutable --version: '$info'"
-return -1
-}
-if {[string match windows $::tcl_platform(platform)]} {
-#Windows
-proc winpause {} { after 3000 } 
-proc bgerror {message} { puts $message }
-#Check python library versions are compatible
-if {[catch {package require tclpy} message]} { 
-set pyver [pythonVersion] 
-if { $pyver != -1 } {
-puts "Error: Python installation [pythonVersion] detected but at incorrect Python version, see HammerDB documentation" 
-	} else {
-puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
-	}
-winpause
-exit
-	} else {
-catch {package forget tclpy}
-	}
-set UserDefaultDir [ file dirname [ info script ] ]
-::tcl::tm::path add "$UserDefaultDir/modules"
-package require tclreadline
-regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
-append cli_common_init $cli_py_append
-set py_init "import os
+  proc pythonVersion {{pythonExecutable "python3"}} {
+    if {[string match windows $::tcl_platform(platform)]} { set pythonExecutable "python" }
+    if {![catch {exec $pythonExecutable --version}] || [lindex $::errorCode 0] eq "NONE"} {
+    } else {
+      puts "Error: Failed to find $::tcl_platform(platform) executable \"$pythonExecutable\""
+      return -1
+    }
+    set info [exec $pythonExecutable --version 2>@1]
+    if {[regexp {^Python ([\d.]+)$} $info --> version]} {
+      return $version
+    }
+    puts "Error: Failed to parse output of $pythonExecutable --version: '$info'"
+    return -1
+  }
+  if {[string match windows $::tcl_platform(platform)]} {
+    #Windows
+    proc winpause {} { after 3000 } 
+    proc bgerror {message} { puts $message }
+    #Check python library versions are compatible
+    if {[catch {package require tclpy} message]} { 
+      set pyver [pythonVersion] 
+      if { $pyver != -1 } {
+        puts "Error: Python installation [pythonVersion] detected but at incorrect Python version, see HammerDB documentation" 
+      } else {
+        puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
+      }
+      winpause
+      exit
+    } else {
+      catch {package forget tclpy}
+    }
+    set UserDefaultDir [ file dirname [ info script ] ]
+    ::tcl::tm::path add "$UserDefaultDir/modules"
+    package require tclreadline
+    regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
+    append cli_common_init $cli_py_append
+    set py_init "import os
 import sys
 tcl_dll_location = os.getcwd() + r'\\bin'
 os.add_dll_directory(tcl_dll_location)
@@ -176,148 +176,151 @@ tclpy.eval(init_tcl)
 from hammerdb import \*
 sys.stdout.flush()
 sys.ps1 = '>>>'"
-proc piperead_interact {pipe echo} {
-    if {![eof $pipe]} {
+    proc piperead_interact {pipe echo} {
+      if {![eof $pipe]} {
         set got [ read -nonewline $pipe ]
-	if {!$echo} { ; } else {
-	TclReadLine::pyclearline 
-	if { [ string equal ">>>" $got ] } { 
-	TclReadLine::prompt ""
-	} else {
-	if { [ string match "*>>>" $got ] } { 
-	set got [ string trim [ string trimright $got "\n+>>>" ]]
-	puts "\r$got\n"
-	TclReadLine::prompt ""
-	} else {
-	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
-	puts "$got" 
-	}}}} else { 
-	catch {close $pipe}
- 	exit	
-	 }
-	}
+        if {!$echo} { ; } else {
+          TclReadLine::pyclearline 
+          if { [ string equal ">>>" $got ] } { 
+            TclReadLine::prompt ""
+          } else {
+            if { [ string match "*>>>" $got ] } { 
+              set got [ string trim [ string trimright $got "\n+>>>" ]]
+              puts "\r$got\n"
+              TclReadLine::prompt ""
+            } else {
+              set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
+              puts "$got" 
+            }
+          }
+        }
+      } else { 
+        catch {close $pipe}
+        exit	
+      }
+    }
 
-proc piperead_script {pipe} {
-upvar script_end script_end
-    if {![eof $pipe]} {
+    proc piperead_script {pipe} {
+      upvar script_end script_end
+      if {![eof $pipe]} {
         set got [ read -nonewline $pipe ]
-	if { [ string match "*>>>" $got ] } { 
-	puts "PYTHON SCRIPT END"
- 	after 2000
-	set script_end 1
-	}
-	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
+        if { [ string match "*>>>" $got ] } { 
+          puts "PYTHON SCRIPT END"
+          after 2000
+          set script_end 1
+        }
+        set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
         puts "$got"
-    } else {
-	catch {close $pipe}
-	set script_end 1
-	}  
-}
+      } else {
+        catch {close $pipe}
+        set script_end 1
+      }  
+    }
 
-set pipe [open "|[ auto_execok python] -uiq 2>@1" r+]
-fconfigure $pipe -buffering line -blocking false -encoding cp1252
-fileevent $pipe readable [list piperead_interact $pipe false]
-set pywait [list]
-foreach pyline [split $py_init \n] {
-# send init line to the pipe
-puts $pipe $pyline
-# need some delay for the pipe
-after 60 [list append pywait ""]
-vwait pywait
-}
-if { $autostart::autostartap == "true" } { 
-set pywait [ list ]
-puts $pipe "runscript(1)" 
-after 50 [ list append pywait ""]
-vwait pywait
-fileevent $pipe readable [list piperead_script $pipe]
-puts $pipe "exec(open('$autostart::autoloadscript').read())"
-vwait script_end
-} else { 
-fileevent $pipe readable [ list piperead_interact $pipe true ]
-puts $pipe "runscript(0)" 
-TclReadLine::interactpy $pipe
-}
-winpause
-exit
-} else {
-#Linux
-set syspath [ string trim $env(PYTHONPATH) ":*" ]
-if { ![ file isdirectory $syspath ] } {
-puts "Error:Cannot find HammerDB Python libraries $env(PYTHONPATH) is not a directory"
-exit
-	}
-if {[catch {package require Expect} ]} { 
-puts "Error:Failed to load Expect package to run Python" 
-exit
-} 
-#Check python library versions are compatible
-if {[catch {package require tclpy} message]} { 
-regexp {libpython([0-9]+.[0-9]+).so} $message matched pyver 
-if { [ info exists pyver ] && $pyver != [pythonVersion] } {
-puts "Error: Python version $pyver required, version [pythonVersion] is installed" 
-exit
-	} else {
-puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
-exit
-	}
-	} else {
-catch {package forget tclpy}
-	}
-#Remove tclreadline module from common initialisation in Python
-regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
-append cli_common_init $cli_py_append
-set timeout 10
-log_user 0
-spawn -noecho python3
-expect ">>>"
-send "import sys\x0D"
-expect ">>>"
-send "sys.path.append('$syspath')\x0D"
-expect ">>>"
-send "import tclpy\x0D"
-expect ">>>"
-send "tclpy.eval('global hdb_version')\x0D"
-expect ">>>"
-send "tclpy.eval('set hdb_version $hdb_version')\x0D"
-expect ">>>"
-send "init_tcl = (r'''\n$cli_common_init\n''')\x0D"
-expect ">>>"
-send "tclpy.eval(init_tcl)\x0D"
-expect ">>>"
-send "from hammerdb import *\x0D"
-expect ">>>"
-if { $autostart::autostartap == "true" } { send "runscript(1)\x0D" } else { send "runscript(0)\x0D" }
-send "sys.stdout.flush()\x0D"
-send "sys.ps1 = 'hammerdb>>>'\x0D"
-#If timeout is set to a +ve value auto scripts will terminate before completion
-set timeout -1
-if { $autostart::autostartap == "true" } {
-#run python script
-trap {
-    send "\x03"
-    send_user "^C\n"
+    set pipe [open "|[ auto_execok python] -uiq 2>@1" r+]
+    fconfigure $pipe -buffering line -blocking false -encoding cp1252
+    fileevent $pipe readable [list piperead_interact $pipe false]
+    set pywait [list]
+    foreach pyline [split $py_init \n] {
+      # send init line to the pipe
+      puts $pipe $pyline
+      # need some delay for the pipe
+      after 60 [list append pywait ""]
+      vwait pywait
+    }
+    if { $autostart::autostartap == "true" } { 
+      set pywait [ list ]
+      puts $pipe "runscript(1)" 
+      after 50 [ list append pywait ""]
+      vwait pywait
+      fileevent $pipe readable [list piperead_script $pipe]
+      puts $pipe "exec(open('$autostart::autoloadscript').read())"
+      vwait script_end
+    } else { 
+      fileevent $pipe readable [ list piperead_interact $pipe true ]
+      puts $pipe "runscript(0)" 
+      TclReadLine::interactpy $pipe
+    }
+    winpause
     exit
-} SIGINT
-expect "hammerdb>>>"
-send "exec(open('$autostart::autoloadscript').read())\x0D"
-log_user 1
-expect {"hammerdb>>>"}
-	} else {
-expect "hammerdb>>>"
-log_user 1
-#-----------------------------#
-#run interactive python shell
-#-----------------------------#
-interact {
- 	\x03 {
-	#send Ctrl-C to Python
-	send "\x03"
-	send_user "^C"
-	return
-    	}
-	}
-	}
-exit
-	}
+  } else {
+    #Linux
+    set syspath [ string trim $env(PYTHONPATH) ":*" ]
+    if { ![ file isdirectory $syspath ] } {
+      puts "Error:Cannot find HammerDB Python libraries $env(PYTHONPATH) is not a directory"
+      exit
+    }
+    if {[catch {package require Expect} ]} { 
+      puts "Error:Failed to load Expect package to run Python" 
+      exit
+    } 
+    #Check python library versions are compatible
+    if {[catch {package require tclpy} message]} { 
+      regexp {libpython([0-9]+.[0-9]+).so} $message matched pyver 
+      if { [ info exists pyver ] && $pyver != [pythonVersion] } {
+        puts "Error: Python version $pyver required, version [pythonVersion] is installed" 
+        exit
+      } else {
+        puts "Error: Unable to detect $::tcl_platform(platform) Python installation" 
+        exit
+      }
+    } else {
+      catch {package forget tclpy}
+    }
+    #Remove tclreadline module from common initialisation in Python
+    regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
+    append cli_common_init $cli_py_append
+    set timeout 10
+    log_user 0
+    spawn -noecho python3
+    expect ">>>"
+    send "import sys\x0D"
+    expect ">>>"
+    send "sys.path.append('$syspath')\x0D"
+    expect ">>>"
+    send "import tclpy\x0D"
+    expect ">>>"
+    send "tclpy.eval('global hdb_version')\x0D"
+    expect ">>>"
+    send "tclpy.eval('set hdb_version $hdb_version')\x0D"
+    expect ">>>"
+    send "init_tcl = (r'''\n$cli_common_init\n''')\x0D"
+    expect ">>>"
+    send "tclpy.eval(init_tcl)\x0D"
+    expect ">>>"
+    send "from hammerdb import *\x0D"
+    expect ">>>"
+    if { $autostart::autostartap == "true" } { send "runscript(1)\x0D" } else { send "runscript(0)\x0D" }
+    send "sys.stdout.flush()\x0D"
+    send "sys.ps1 = 'hammerdb>>>'\x0D"
+    #If timeout is set to a +ve value auto scripts will terminate before completion
+    set timeout -1
+    if { $autostart::autostartap == "true" } {
+      #run python script
+      trap {
+        send "\x03"
+        send_user "^C\n"
+        exit
+      } SIGINT
+      expect "hammerdb>>>"
+      send "exec(open('$autostart::autoloadscript').read())\x0D"
+      log_user 1
+      expect {"hammerdb>>>"}
+    } else {
+      expect "hammerdb>>>"
+      log_user 1
+      #-----------------------------#
+      #run interactive python shell
+      #-----------------------------#
+      interact {
+        \x03 {
+          #send Ctrl-C to Python
+          send "\x03"
+          send_user "^C"
+          return
+        }
+      }
+    }
+    exit
+  }
 }

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -192,8 +192,8 @@ proc piperead_interact {pipe echo} {
 	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
 	puts "$got" 
 	}}}} else { 
-	catch{close $pipe}
- 	return	
+	catch {close $pipe}
+ 	exit	
 	 }
 	}
 
@@ -209,7 +209,7 @@ upvar script_end script_end
 	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
         puts "$got"
     } else {
-	catch{close $pipe}
+	catch {close $pipe}
 	set script_end 1
 	}  
 }

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -175,33 +175,43 @@ init_tcl = (r'''\n$cli_common_init\n''')
 tclpy.eval(init_tcl)
 from hammerdb import \*
 sys.stdout.flush()
-sys.ps1 = '<<<'"
-#Reversed the prompt to detect when Python has finished its output, so HammerDB can prompt also.
+sys.ps1 = '>>>'"
 proc piperead_interact {pipe echo} {
     if {![eof $pipe]} {
         set got [ read -nonewline $pipe ]
 	if {!$echo} { ; } else {
 	TclReadLine::pyclearline 
-	if { [ string equal "<<<" $got ] } { 
+	if { [ string equal ">>>" $got ] } { 
 	TclReadLine::prompt ""
 	} else {
-	if { [ string match "*<<<" $got ] } { 
-	set got [ string trimright $got "\n+<<<" ]
+	if { [ string match "*>>>" $got ] } { 
+	set got [ string trim [ string trimright $got "\n+>>>" ]]
 	puts "\r$got\n"
 	TclReadLine::prompt ""
 	} else {
-	puts "\r$got"
+	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
+	puts "$got" 
 	}}}} else { 
-	close $pipe
+	catch{close $pipe}
  	return	
 	 }
 	}
 
 proc piperead_script {pipe} {
+upvar script_end script_end
     if {![eof $pipe]} {
-        set got [regsub {.+< } [gets $pipe] ""]
+        set got [ read -nonewline $pipe ]
+	if { [ string match "*>>>" $got ] } { 
+	puts "PYTHON SCRIPT END"
+ 	after 2000
+	set script_end 1
+	}
+	set got [ string trim [regsub -all {\n(?:\s*\n)+} $got \n] \n ]
         puts "$got"
-    }   
+    } else {
+	catch{close $pipe}
+	set script_end 1
+	}  
 }
 
 set pipe [open "|[ auto_execok python] -uiq 2>@1" r+]
@@ -216,13 +226,13 @@ after 60 [list append pywait ""]
 vwait pywait
 }
 if { $autostart::autostartap == "true" } { 
-puts $pipe "runscript(1)" 
-fileevent $pipe readable [list piperead_script $pipe]
 set pywait [ list ]
-puts $pipe "exec(open('$autostart::autoloadscript').read())"
-after 200 [ list append pywait ""]
+puts $pipe "runscript(1)" 
+after 50 [ list append pywait ""]
 vwait pywait
-close $pipe
+fileevent $pipe readable [list piperead_script $pipe]
+puts $pipe "exec(open('$autostart::autoloadscript').read())"
+vwait script_end
 } else { 
 fileevent $pipe readable [ list piperead_interact $pipe true ]
 puts $pipe "runscript(0)" 

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -5,6 +5,8 @@ export LD_LIBRARY_PATH="./lib:$LD_LIBRARY_PATH"
 ## \
 export PATH="./bin:$PATH"
 ## \
+export PYTHONPATH="./lib/tclpy0.4:$PYTHONPATH"
+## \
 exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 ########################################################################
 # HammerDB
@@ -28,29 +30,55 @@ global hdb_version
 set hdb_version "v4.6"
 puts "HammerDB CLI $hdb_version"
 puts "Copyright (C) 2003-2022 Steve Shaw"
-puts "Type \"help\" for a list of commands"
-set UserDefaultDir [ file dirname [ info script ] ]
-::tcl::tm::path add "$UserDefaultDir/modules"
+if { $argc eq 0 } {
+	set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
+if { $argv0 == "" || $argv0 == "tcl" || $argv0 == "auto" } {
+	set lang "tcl"
+	set extension ".tcl"
+	puts "Type \"help\" for a list of commands"
+	} elseif { $argv0 == "py" || $argv0 == "python" } {
+	set lang "python"
+	set extension ".py"
+	puts "Type \"help()\" for a list of commands"
+	} else {
+	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+	exit
+	}
 
 namespace eval autostart {
     set autostartap "false"
-    if {$argc == 0} { ; } else {
+	if { $argv0 == "tcl" || $argv0 == "py" || $argv0 == "python" } {
+	set argv [ lreplace $argv 0 0 ]
+	set argc [ expr {$argc - 1} ]
+		}
+    if { $argc eq 0 } { ; } else {
     if {$argc != 2 || [lindex $argv 0] != "auto" } {
-puts {Usage: hammerdbcli [ auto [ script_to_autoload.tcl  ] ]}
-exit
+	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+	exit
 	} else {
         set autostartap "true"
         set autoloadscript [lindex $argv 1]
-if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] eq ".tcl" } {
-;# autostart selected and tcl file exists
+if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] eq $extension } {
+;# autostart selected and tcl or py file exists
 	     } else {
-puts {Usage: hammerdbcli [ auto [ script_to_autoload.tcl  ] ]}
-exit
-		}
-           } 
-      }
+if { [ file exists $autoloadscript ] && [ file isfile $autoloadscript ] && [ file extension $autoloadscript ] != $extension } {
+	puts "Error: incorrect file extension for $lang" 
+	if { $lang eq "tcl" } {
+	puts {Usage: hammerdbcli [ tcl [ auto [ script_to_autoload.[ tcl ] ] ]}
+		} else {
+	puts {Usage: hammerdbcli [ python [ auto [ script_to_autoload.[ py ] ] ]}
+		       }
+	exit
+		 } else {
+	puts {Usage: hammerdbcli [ tcl|python [ auto [ script_to_autoload.[ tcl|py ] ] ] ]}
+	 	}
+	     }
+         }
+    }
 }
-
+#Common CLI initialisation between Tcl and Python
+set cli_common_init {set UserDefaultDir [ file dirname [ info script ] ]
+::tcl::tm::path add "$UserDefaultDir/modules"
 append modulelist { Thread msgcat xml comm tclreadline task reformat_tcl }
 for { set modcount 0 } { $modcount < [llength $modulelist] } { incr modcount } {
     set m [lindex $modulelist $modcount]
@@ -77,12 +105,123 @@ for { set dbsrccount 0 } { $dbsrccount < [llength $dbsrclist] } { incr dbsrccoun
     set f [lindex $dbsrclist $dbsrccount]
 		set loadtext $f
 	if [catch {source [ file join $UserDefaultDir src $f ]}] {
-                puts stderr "Error loading database source files/$f"
+                puts stderr "Error:loading database source files/$f"
         }
-    }
-
+    }}
+#In Tcl only either source file or do tclreadline::interact
+set cli_tcl_append {
 if { $autostart::autostartap == "true" } {
-	source $autostart::autoloadscript
-	} else {
+        source $autostart::autoloadscript
+        } else {
     TclReadLine::interact
+        }}
+#In Python already in interact so bypas tclreadline
+set cli_py_append {
+rename putscli _putscli
+proc putscli { output } {
+puts "$output\r"
+	}}
+#Initialise CLI in Tcl
+if { $lang == "tcl" } {
+append cli_common_init $cli_tcl_append
+eval $cli_common_init
+#Initialise CLI in Python
+} elseif { $lang eq "python" } {
+proc pythonVersion {{pythonExecutable "python3"}} {
+puts "did py version"
+if {![catch {exec $pythonExecutable --version}] || [lindex $::errorCode 0] eq "NONE"} {
+} else {
+puts "Error:failed to find executable $pythonExecutable"
+exit
+}
+set info [exec $pythonExecutable --version 2>@1]
+if {[regexp {^Python ([\d.]+)$} $info --> version]} {
+return $version
+}
+puts "Error:failed to parse output of $pythonExecutable --version: '$info'"
+exit
+}
+set syspath [ string trim $env(PYTHONPATH) ":*" ]
+if { ![ file isdirectory $syspath ] } {
+puts "Error:Cannot find HammerDB Python libraries $env(PYTHONPATH) is not a directory"
+exit
 	}
+if {[string match windows $::tcl_platform(platform)]} {
+#Windows
+        package require twapi
+        package require twapi_input
+} else {
+#Linux
+if {[catch {package require Expect} ]} { 
+puts "Error:Failed to load Expect package to run Python" 
+exit
+} 
+#Check python library versions are compatible
+if {[catch {package require tclpy} message]} { 
+regexp {libpython([0-9]+.[0-9]+).so} $message matched pyver 
+if { [ info exists pyver ] && $pyver != [pythonVersion] } {
+puts "Error: Python version $pyver required, version [pythonVersion] is installed" 
+exit
+	} else {
+puts "Error: Unable to detect Python installation" 
+exit
+	}
+	} else {
+catch {package forget tclpy}
+	}
+#Remove tclreadline module from common initialisation in Python
+regsub -all -line {tclreadline} $cli_common_init {} cli_common_init
+append cli_common_init $cli_py_append
+set timeout 2
+spawn -noecho python3
+log_user 0
+expect ">>>"
+send "import sys\n"
+expect ">>>"
+send "sys.path.append('$syspath')\n"
+expect ">>>"
+send "import tclpy\n"
+expect ">>>"
+send "tclpy.eval('global hdb_version')\n"
+expect ">>>"
+send "tclpy.eval('set hdb_version $hdb_version')\n"
+expect ">>>"
+send "init_tcl = (r'''\n$cli_common_init\n''')\n"
+expect ">>>"
+send "tclpy.eval(init_tcl)\n"
+expect ">>>"
+send "from hammerdb import *\n"
+expect ">>>"
+if { $autostart::autostartap == "true" } {
+send "runscript(1)\n"
+	} else {
+send "runscript(0)\n"
+	}
+expect ">>>"
+send {sys.ps1 = "hammerdb>>>"}
+send "\n"
+expect {"hammerdb>>>"}
+log_user 1
+#If timeout is set to a +ve value auto scripts will terminate before completion
+set timeout -1
+if { $autostart::autostartap == "true" } {
+send "exec(open('$autostart::autoloadscript').read())"
+send "\n"
+expect {"hammerdb>>>"}
+	} else {
+interact {
+ 	\x03 {
+	puts "^C"
+	#send Ctrl-C to Python
+	#send "\x03"
+	return
+    	}
+ 	\x04 {
+	puts "^D"
+	return
+    	}
+	}
+	}
+exit
+	}
+}

--- a/hammerdbcli.bat
+++ b/hammerdbcli.bat
@@ -1,5 +1,5 @@
 @echo off
 COLOR 07
 set path=.\bin;%PATH%
-CALL tclsh86t hammerdbcli %1 %2
+CALL tclsh86t hammerdbcli %1 %2 %3 %4
 exit

--- a/hammerdbws
+++ b/hammerdbws
@@ -25,7 +25,7 @@ exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.5"
+set hdb_version "v4.6"
 puts "HammerDB Web Service $hdb_version"
 puts "Copyright (C) 2003-2022 Steve Shaw"
 puts "Type \"help\" for a list of commands"


### PR DESCRIPTION
Adds alternative python interface to the CLI for both Linux and Windows, relying on system installed python.
Functionality will allow run scripts to be written in python as well as run interactive sessions. 
The python library will be dependent on a particular version so plan is to use v3.8 on Linux (Unbuntu 20.04), v3.6 on RHEL8 and v3.10 on Windows. However build from source can use any preferred python version instead.
Further discussion in issue #386 