### PR TITLE
Updates to jobs for Docker scripts

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -1018,8 +1018,8 @@ proc buildschema {} {
     }
     set jobid [guid]
     if { [jobmain $jobid] eq 1 } {
-        dict set jsondict error message "Jobid already exists or error in creating jobid in JOBMAIN table"
-        #return
+        puts "Error: Jobid $jobid already exists or error in creating jobid in JOBMAIN table"
+        return
     }
     upvar #0 dbdict dbdict
     foreach { key } [ dict keys $dbdict ] {
@@ -1095,6 +1095,11 @@ proc buildschema {} {
     #Dict2SQLite $dbname [ dict get [ set $dictname ] ]
     #Add automated waittocomplete to buildschema
     _waittocomplete
+     if { [ info exists jobid ] } {
+        return "jobid=$jobid"
+    } else {
+        return
+    }
 }
 
 proc keepalive {} {

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -26,8 +26,9 @@ Type \"help command\" for more details on specific commands below\n"
                 jobs {
                     putscli "jobs - Usage: jobs"
                     putscli "list all jobs.\n"
-                    putscli {jobs - Usage: jobs [jobid|result|timestamp]}
+                    putscli {jobs - Usage: jobs [jobid|joblist|result|timestamp]}
                     putscli "jobid: list VU output for jobid."
+                    putscli "joblist: returns text list of jobs wthout newlines."
                     putscli "result: list result for all jobs."
                     putscli "timestamp: list starting timestamp for all jobs.\n"
                     putscli {jobs format - Usage: jobs format [ text | JSON ]}


### PR DESCRIPTION
Adds a jobs joblist command that returns a list of all job ids in text. Useful for scripts querying all jobs to get a list to iterate through. Add a help message.
Fix jobs result and jobs timestamp so it reports correctly result and timestamp for all jobs. 
Update jobs format command so accepts upper and lowercase for both text and JSON
Update jobs result so it does not depend on the current set bm value but queries it for each particular job
Add geomean to jobs result for TPROC-H jobs
fix error message in case Jobid already exists
Add jobid return value for buildschema
Fix jobs timestamp was missing conversion to JSON when JSON format was selected
Add return values to python commands for jobs, vurun and buildschema https://github.com/sm-shaw/libtclpy/commit/00830c3f8da00f1cc020d78ddef4b651b844e74b