### PR TITLE
Prevent CLI hang when scripts finishes before enters event loop

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -1467,7 +1467,9 @@ proc _waittocomplete {} {
     }
     set wcomplete "false"
     wait_to_complete_loop
-    vwait timevar
+    if {![ info exists timevar ] || $timevar != 1 } { 
+    	vwait timevar
+    	}
     return
 }
 
@@ -1499,7 +1501,9 @@ proc _runtimer { seconds } {
     set elapsed 0
     set timevar 0
     runtimer_loop $seconds
-    vwait timevar
+    if {![ info exists timevar ] || $timevar != 1 } { 
+    	vwait timevar
+    	}
     return
 }
 


### PR DESCRIPTION
Fix for Issue #472 

I have used the same clause for consistency even though timevar is not set previously in waittocomplete and is set to 0 in runtimer so the same expression will work if it does not exist or is not set to 1.

`![ info exists timevar ] || $timevar != 1`

Note the || operator is a  "short-circuiting" operator in Tcl. Meaning, they are evaluated left-to-right, and evaluation stops when the expression is known. So if the timevar variable does not exist it will not check $timevar != 1 and then fail because timevar is not set. 

This change fixes the scenario in #472 where a script that is being run fails so quickly it has already set the variable to exit the event loop before the loop has been entered, and therefore once the loop is entered it then waits forever. This would not be encountered under normal circumstances and counts as an edge case, but nevertheless an inconvenience if not knowing why this occurs.  

To fix this we add the check to see whether the timevar variable has been set as the script failed so quickly we didn't have time to enter the loop, if it has, we are in the scenario above and therefore do not set the loop but instead return as there is nothing to wait for. 