### PR TITLE
Improve Transaction counter look and feel and resize when window resized

### DIFF
--- a/config/generic.xml
+++ b/config/generic.xml
@@ -44,6 +44,7 @@
             <tc_log_to_temp>0</tc_log_to_temp>
 	    <tc_unique_log_name>0</tc_unique_log_name>
 	    <tc_log_timestamps>0</tc_log_timestamps>
+	    <tc_graph_ribbon>false</tc_graph_ribbon>
 	</settings>
     </transaction_counter>
     <metrics>

--- a/hammerdb
+++ b/hammerdb
@@ -189,7 +189,7 @@ if [info exist env(Load_List)] {
     }
 }
 
-append modulelist { Thread msgcat tablelist_tile tooltip tkcon xml xscale ctext comm emu_graph socktest tkblt huddle jobs }
+append modulelist { Thread msgcat tablelist_tile tooltip tkcon xml xscale ctext comm emu_graph socktest tkblt huddle jobs tkpath }
 
 set loadtext "Loading hammerdb modules"
 after 100

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -74,19 +74,19 @@ proc DoDisplay {maxcpu cpu_model caller} {
     set scrollheight [ expr {$height*2} ]
     frame $metframe.f -bd $S(border) -relief flat -bg $CLR(bg)
     if { $ttk::currentTheme eq "black" } {
-        set cnv1 [ canvas $metframe.sv -width 11 -highlightthickness 0 -background #424242 ]
+        set cnv1 [ tkp::canvas $metframe.sv -width 11 -highlightthickness 0 -background #424242 ]
     } else {
-        set cnv1 [ canvas $metframe.sv -width 11 -highlightthickness 0 -background #dcdad5 ]
+        set cnv1 [ tkp::canvas $metframe.sv -width 11 -highlightthickness 0 -background #dcdad5 ]
     }
     pack $cnv1 -expand 0 -fill y -ipadx 0 -ipady 0 -padx 0 -pady 0 -side right
     pack $metframe.f -fill both -expand 1
     #Create fixed header
-    canvas $metframe.f.header -highlightthickness 0 -bd 0 -width $width -height $S(hdscl) -bg $CLR(bg)
+    tkp::canvas $metframe.f.header -highlightthickness 0 -bd 0 -width $width -height $S(hdscl) -bg $CLR(bg)
     $metframe.f.header create text [ expr {$width/2 - $S(hdralign)} ] $S(txtalign) -text "$cpu_model ($maxcpu CPUs)" -fill $CLR(usr) -font {basic} -tags "cpumodel"
     pack $metframe.f.header
     #Height for all objects is the height of the bar and text multiplied by all cpus add header
     set canvforbars $cnvpth.c 
-    canvas $canvforbars -highlightthickness 0 -bd 0 -width $width -height $height -bg $CLR(bg) -scrollregion "0 0 $width $scrollheight" -yscrollcommand "$metframe.sv.scrollY set" -yscrollincrement 10
+    tkp::canvas $canvforbars -highlightthickness 0 -bd 0 -width $width -height $height -bg $CLR(bg) -scrollregion "0 0 $width $scrollheight" -yscrollcommand "$metframe.sv.scrollY set" -yscrollincrement 10
     #Add scrollbar but now can't scroll multiple canvases or a frame so have to put all ojects in one canvas to scroll
     set scr1 [ ttk::scrollbar $metframe.sv.scrollY -orient vertical -command "$canvforbars yview" ]
     pack $canvforbars -expand 0 -fill y -ipadx 0 -ipady 0 -padx 0 -pady 0
@@ -110,12 +110,15 @@ proc DoDisplay {maxcpu cpu_model caller} {
             set x0 [ expr {$x0 - $rowdeduction} ]
             set x1 [expr {$x0 + $S(bar,width)}]
         }
+	#colour gradients for usr and sys
+	set usr [$canvforbars gradient create linear -stops {{0 lightgreen} {1 green}}]
+	set sys [$canvforbars gradient create linear -stops {{0 indianred} {1 darkred}}]
         #hold array of coords for each CPU for later update
         set cpucoords($cpu) [ list $x0 $y0 $x1 $y1 ]
-        $canvforbars create rect $x0 $y1 $x1 $y1 -tag bar$cpu-sys -fill $CLR(sys)
-        $canvforbars create rect $x0 $y1 $x1 $y1 -tag bar$cpu-usr -fill $CLR(usr)
+        $canvforbars create prect $x0 $y1 $x1 $y1 -tag bar$cpu-sys -fill $sys
+        $canvforbars create prect $x0 $y1 $x1 $y1 -tag bar$cpu-usr -fill $usr
         for { set ymask $y0 } { $ymask <= $y1 } { incr ymask $S(mask) } {
-            $canvforbars create rect $x0 $ymask $x1 [ expr $ymask + $S(maskplus) ] -tag bar$cpu-mask -fill $CLR(bg) -outline $CLR(bg)
+           $canvforbars create prect $x0 $ymask $x1 [ expr $ymask + $S(maskplus) ] -tag bar$cpu-mask -fill $CLR(bg)
         }
         #Set CPU utilisation % value and hide with same as background colour
         $canvforbars create text  [ expr $x0 + $S(txtalign) ]  [ expr $y1 + $S(txtalign) ] -text "0%" -fill $CLR(bg) -font [ list basic [ expr [ font actual basic -size ] - 2 ] ]  -tags "pcent$cpu"

--- a/src/generic/gentc.tcl
+++ b/src/generic/gentc.tcl
@@ -859,16 +859,18 @@ proc transcount { } {
     global win_scale_fact
     global tc_scale
     unset -nocomplain tc_scale
-    set scale_width [ expr {(550 / 1.333333) * $win_scale_fact} ]
-    set tcc_height [ expr {(60 / 1.333333) * $win_scale_fact} ]
-    set tcg_height [ expr {(275 / 1.333333) * $win_scale_fact} ]
-    set emug_height [ expr {(160 / 1.333333) * $win_scale_fact} ]
-    set axistextoffset [ expr {(20 / 1.333333) *  $win_scale_fact * 0.50} ]
-    set ticklen [ expr {(10 / 1.333333) *  $win_scale_fact * 0.60} ]
-    set xref [ expr {(75 / 1.333333) *  $win_scale_fact * 0.90} ]
-    #canvas for black on white numbers
-    .ed_mainFrame.tc configure -background white
-    pack [ tkp::canvas .ed_mainFrame.tc.c -width $scale_width -height $tcc_height -background white -highlightthickness 0 ] -side top -anchor ne -padx [ list 0 [ expr {$scale_width * 0.05} ] ] 
+    set scale_width [ expr {(535 / 1.333333) * $win_scale_fact} ]
+set tcc_height [ expr {(60 / 1.333333) * $win_scale_fact} ]
+set tcg_height [ expr {(250 / 1.333333) * $win_scale_fact} ]
+set emug_height [ expr {(150 / 1.333333) * $win_scale_fact} ]
+set axistextoffset [ expr {(20 / 1.333333) * $win_scale_fact * 0.50} ]
+set ticklen [ expr {(10 / 1.333333) * $win_scale_fact * 0.60} ]
+set xref [ expr {(75 / 1.333333) * $win_scale_fact * 0.90} ]
+
+
+#canvas for black on white numbers
+.ed_mainFrame.tc configure -background white
+pack [ tkp::canvas .ed_mainFrame.tc.c -width $scale_width -height $tcc_height -background white -highlightthickness 0 ] -side top -anchor ne -padx [ list 0 [ expr {$scale_width * 0.05} ] ] -ipadx [ expr {$scale_width * 0.10} ]
     #Emu graph canvas
     pack [ tkp::canvas .ed_mainFrame.tc.g -width $scale_width -height $tcg_height -background white -highlightthickness 0 ] -fill both -expand 1 -side left
     unset -nocomplain tc_scale

--- a/src/mariadb/mariaotc.tcl
+++ b/src/mariadb/mariaotc.tcl
@@ -136,7 +136,7 @@ proc tcount_maria {bm interval masterthread} {
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                     if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }
                 } 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break }
                         set iconflag 1

--- a/src/mssqlserver/mssqlsotc.tcl
+++ b/src/mssqlserver/mssqlsotc.tcl
@@ -113,7 +113,7 @@ proc tcount_mssqls {bm interval masterthread} {
                     }
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                 if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }} 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break }
                         set iconflag 1

--- a/src/mysql/mysqlotc.tcl
+++ b/src/mysql/mysqlotc.tcl
@@ -133,7 +133,7 @@ proc tcount_mysql {bm interval masterthread} {
                     }
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                 if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }} 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break }
                         set iconflag 1

--- a/src/oracle/oraotc.tcl
+++ b/src/oracle/oraotc.tcl
@@ -131,7 +131,7 @@ proc tcount_ora {bm interval masterthread} {
                     }
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                 if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }} 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break }
                         set iconflag 1

--- a/src/postgresql/pgotc.tcl
+++ b/src/postgresql/pgotc.tcl
@@ -105,7 +105,7 @@ proc tcount_pg {bm interval masterthread} {
                     }
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                 if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }} 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break }
                         set iconflag 1

--- a/src/redis/redisotc.tcl
+++ b/src/redis/redisotc.tcl
@@ -89,7 +89,7 @@ proc tcount_redis {bm interval masterthread} {
                     }
                     set transval [expr {[expr {abs($new - $old)}] * $mplier}]
                 if { [ catch [ subst {thread::send -async $MASTER {::showLCD $transval }} ] ] } { break }} 
-                if { $tcsize >= 4 } { 
+                if { $tcsize >= 2 } { 
                     if { $iconflag eq 0 } {
                         if { [ catch [ subst {thread::send -async $MASTER { .ed_mainFrame.tc.g delete "all" }} ] ] } { break } 
                         set iconflag 1


### PR DESCRIPTION
PR changes the look of the transaction counter graph and enables it to resize when the window is resized so it doesn't leave a large amount of blank space as per issue https://github.com/TPC-Council/HammerDB/issues/487
Screenshots of update in https://github.com/TPC-Council/HammerDB/issues/487
Has been tested on Windows 10/11 (incl UHD/pixelsense) and Linux Red Hat and Ubuntu.
To test requires build from source with tkpath added in https://github.com/TPC-Council/HammerDB/pull/478. Linux build needs cairo graphics which is installed by default in Ubuntu and Red Hat test installs.
Minor changes also to the CPU metrics.