### PR TITLE
4.7 versions and changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1039,3 +1039,22 @@ Add SQL Server encrypt connection and trust certificate #406
 Remove reconnect for PostgreSQL on windows #402
 Hdb docker #401
 fix typos #388
+
+---------------------------------------------------------------------
+
+Version 4.7 Feb 2023
+
+Pull Requests & Issues
+
+Use db2tcl to create and drop database for DB2 #501 (#431)
+Improve Transaction counter look and feel and resize when window resized #494 (#487)
+remove trafodion configuration and files #485 (#484)
+MySQL Heatwave TPROC-H support #483 (#482)
+Query update for tpch columnstore benchmark #481 (#480)
+Add tkpath to build #478
+Prevent CLI hang when scripts finishes before enters event loop #473 (#472)
+Updates to jobs for Docker scripts #471
+Fix for Issue #467 CLI myerrproc and remote_command opmode #468 (#467)
+Update omitted Changelog for v4.6 release #466
+Fixing queries for Columnstore issue 459 #460 (#459)
+Make jobs functionality modular #458

--- a/ChangeLog
+++ b/ChangeLog
@@ -1046,6 +1046,8 @@ Version 4.7 Feb 2023
 
 Pull Requests & Issues
 
+Fix calculation of geomean in TPROC-H #504
+Fix TPROC-H query 5 for Columnstore #503
 Use db2tcl to create and drop database for DB2 #501 (#431)
 Improve Transaction counter look and feel and resize when window resized #494 (#487)
 remove trafodion configuration and files #485 (#484)

--- a/agent/agent
+++ b/agent/agent
@@ -15,7 +15,7 @@ exit
 # mpstatPlot -- visual display of mpstat idle value for all processors
 # by Keith Vetter
 #
-# Copyright (C) 2003-2022 Steve Shaw
+# Copyright (C) 2003-2023 Steve Shaw
 # Author contact information at: http://www.hammerdb.com
 #
 # This program is free software; you can redistribute it and/or
@@ -40,7 +40,7 @@ namespace import comm::*
 interp recursionlimit {} 3000
 global agentlist S iswin
 set iswin "false"
-set version 4.6
+set version 4.7
 
 if {$tcl_platform(platform) == "windows"} { 
 	package require twapi 

--- a/agent/mpstat.bat
+++ b/agent/mpstat.bat
@@ -16,7 +16,7 @@ tclsh86t %0 %*
 #
 #Simulation of Linux mpstat program for Windows using Twapi
 #
-# Copyright (C) 2003-2022 Steve Shaw
+# Copyright (C) 2003-2023 Steve Shaw
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public

--- a/hammerdb
+++ b/hammerdb
@@ -10,7 +10,7 @@ exec wish8.6 -file $0 ${1+"$@"}
 exit
 ########################################################################
 # HammerDB
-# Copyright (C) 2003-2022 Steve Shaw
+# Copyright (C) 2003-2023 Steve Shaw
 # Author contact information at: http://www.hammerdb.com
 #
 # This program is free software; you can redistribute it and/or
@@ -27,7 +27,7 @@ exit
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.6"
+set hdb_version "v4.7"
 set mainGeometry +10+10
 set UserDefaultDir [ file dirname [ info script ] ]
 ::tcl::tm::path add "$UserDefaultDir/modules"

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -10,7 +10,7 @@ export PYTHONPATH="./lib/tclpy0.4:$PYTHONPATH"
 exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 ########################################################################
 # HammerDB
-# Copyright (C) 2003-2022 Steve Shaw
+# Copyright (C) 2003-2023 Steve Shaw
 # Author contact information at: http://www.hammerdb.com
 #
 # This program is free software; you can redistribute it and/or
@@ -27,9 +27,9 @@ exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.6"
+set hdb_version "v4.7"
 puts "HammerDB CLI $hdb_version"
-puts "Copyright (C) 2003-2022 Steve Shaw"
+puts "Copyright (C) 2003-2023 Steve Shaw"
 if { $argc eq 0 } {
 set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
 if { $argv0 == "" || $argv0 == "tcl" || $argv0 == "auto" } {

--- a/hammerdbws
+++ b/hammerdbws
@@ -8,7 +8,7 @@ export PATH="./bin:$PATH"
 exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 ########################################################################
 # HammerDB
-# Copyright (C) 2003-2022 Steve Shaw
+# Copyright (C) 2003-2023 Steve Shaw
 # Author contact information at: http://www.hammerdb.com
 #
 # This program is free software; you can redistribute it and/or
@@ -25,9 +25,9 @@ exec ./bin/tclsh8.6 "$0" ${1+"$@"}
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v4.6"
+set hdb_version "v4.7"
 puts "HammerDB Web Service $hdb_version"
-puts "Copyright (C) 2003-2022 Steve Shaw"
+puts "Copyright (C) 2003-2023 Steve Shaw"
 puts "Type \"help\" for a list of commands"
 set UserDefaultDir [ file dirname [ info script ] ]
 ::tcl::tm::path add "$UserDefaultDir/modules"

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -1939,14 +1939,14 @@ proc vuser_options {} {
 proc about { } {
     global hdb_version
     tk_messageBox -title About -message "HammerDB $hdb_version
-Copyright (C) 2003-2022
+Copyright (C) 2003-2023
 Steve Shaw\n" 
 }
 
 proc license { } {
     tk_messageBox -title License -message "
 This copyright notice must be included in all distributions.
-Copyright (C) 2003-2022 Steve Shaw
+Copyright (C) 2003-2023 Steve Shaw
 
 This program is free software: you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation,


### PR DESCRIPTION
Bump version numbers to 4.7, update copyright date to 2023 and remembering changelog update after omission for v4.6