### PR TITLE
Fix calculation of geomean in TPROC-H

### DIFF
--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1277,7 +1277,12 @@ proc do_tpch { host port socket ssl_options user password db scale_factor RAISEE
                         }
                         set t1 [clock clicks -millisec]
                         set value [expr {double($t1-$t0)/1000}]
-                        if {$VERBOSE} { printlist $oput }
+                        set rowcount [ llength $oput ]
+                        if { $rowcount > 0 } { lappend qlist $value }
+                        if {$VERBOSE} {
+                            puts "query $qos returned $rowcount rows"
+                            printlist $oput
+                        }
                         puts "query $qos completed in $value seconds"
                     }
                     incr q15c


### PR DESCRIPTION
Query 15 in TPROC-H is a multi-statement query, which consists of two parts: creating the view and querying that view. Due to that it is handled using separate code then all the other queries. Currently, the execution time of query 15 is not calculated as a part of geometric mean value, which is the metric for that test.

This patch fixes that to include  query execution time in geometric mean metric. Creating/dropping the view is still not taken into that calculation, so no changes here.

Signed-off-by: Igor Konopko <igor.j.konopko@intel.com>