### PR TITLE
Fix fails to delete if SQLite file open for read on Windows closes #512

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1046,6 +1046,7 @@ Version 4.7 Feb 2023
 
 Pull Requests & Issues
 
+HammerDB 4.7 fails to start on Windows if 4.6 SQLite files present #513 (#512)
 Fix calculation of geomean in TPROC-H #504
 Fix TPROC-H query 5 for Columnstore #503
 Use db2tcl to create and drop database for DB2 #501 (#431)

--- a/src/generic/geninit.tcl
+++ b/src/generic/geninit.tcl
@@ -30,10 +30,16 @@ if { $genericdictdb eq "" } {
     #SQLite found, check whether the schema versions from SQLite and XML are consistent
     if { $sqlite_hdb_version ne $hdb_version } {
         puts "The existing SQLite DBs are from version $sqlite_hdb_version. SQLite DBs will be reset to $hdb_version."
+	#Close SQLite before deleting else get permission denied on Windows
+	if { [catch {hdb close} message]} { 
+		puts "Failed to close SQLite: $message" 
+	}
         foreach { dbname } { generic database db2 mariadb mssqlserver mysql oracle postgresql } {
             set dbfile [ CheckSQLiteDB $dbname ]
             #Remove SQLite file
-            file delete $dbfile
+	    if { [catch {file delete $dbfile} message]} { 
+		    puts "Error deleting SQLite file from $sqlite_hdb_version: $message" 
+	    }
         }
         #After remove old SQLite, save genericdict to SQLite DB
         Dict2SQLite "generic" $genericdict

--- a/src/generic/geninitcli.tcl
+++ b/src/generic/geninitcli.tcl
@@ -30,10 +30,16 @@ if { $genericdictdb eq "" } {
     #SQLite found, check whether the schema versions from SQLite and XML are consistent
     if { $sqlite_hdb_version ne $hdb_version } {
         puts "The existing SQLite DBs are from version $sqlite_hdb_version. SQLite DBs will be reset to $hdb_version."
+	#Close SQLite before deleting else get permission denied on Windows
+        if { [catch {hdb close} message]} {
+                puts "Failed to close SQLite: $message"
+        }
         foreach { dbname } { generic database db2 mariadb mssqlserver mysql oracle postgresql } {
             set dbfile [ CheckSQLiteDB $dbname ]
             #Remove SQLite file
-            file delete $dbfile
+	    if { [catch {file delete $dbfile} message]} {
+                    puts "Error deleting SQLite file from $sqlite_hdb_version: $message"
+            }
         }
         #After remove old SQLite, save genericdict to SQLite DB
         Dict2SQLite "generic" $genericdict

--- a/src/generic/geninitws.tcl
+++ b/src/generic/geninitws.tcl
@@ -30,10 +30,16 @@ if { $genericdictdb eq "" } {
     #SQLite found, check whether the schema versions from SQLite and XML are consistent
     if { $sqlite_hdb_version ne $hdb_version } {
         puts "The existing SQLite DBs are from version $sqlite_hdb_version. SQLite DBs will be reset to $hdb_version."
+	#Close SQLite before deleting else get permission denied on Windows
+        if { [catch {hdb close} message]} {
+                puts "Failed to close SQLite: $message"
+        }
         foreach { dbname } { generic database db2 mariadb mssqlserver mysql oracle postgresql } {
             set dbfile [ CheckSQLiteDB $dbname ]
             #Remove SQLite file
-            file delete $dbfile
+	    if { [catch {file delete $dbfile} message]} {
+                    puts "Error deleting SQLite file from $sqlite_hdb_version: $message"
+            }
         }
         #After remove old SQLite, save genericdict to SQLite DB
         Dict2SQLite "generic" $genericdict


### PR DESCRIPTION
Closes issue #512 and enables v4.7 to start if v4.6 SQLite files already exist. 