### PR TITLE
Fix for vu specific timing printed twice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1046,6 +1046,8 @@ Version 4.7 Feb 2023
 
 Pull Requests & Issues
 
+Jobs query for VU specific timing prints data twice, with second always in
+text #515 (#514)
 HammerDB 4.7 fails to start on Windows if 4.6 SQLite files present #513 (#512)
 Fix calculation of geomean in TPROC-H #504
 Fix TPROC-H query 5 for Columnstore #503

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -539,11 +539,10 @@ proc getjob { query } {
           if { ![ dict size $jobtiming ] eq 0 } {
           set huddleobj [ huddle compile {dict * dict} $jobtiming ]
           if { $outputformat eq "JSON" } {
-            puts [ huddle jsondump $huddleobj ]
+          return [ huddle jsondump $huddleobj ]
           } else {
-                  puts $jobtiming
-	}
-            return $jobtiming
+          return $jobtiming
+	  }
           } else {
             puts "No Timing Data for VU $vuid for JOB $jobid: jobs jobid timing vuid"
             return


### PR DESCRIPTION
Fixes the issue where vu specific job timing when queried always gets printed out in text after being printed in preferred format of JSON or text. 

