### PR TITLE
Add CLI savescript and custommonitor commands

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -971,6 +971,22 @@ proc customscript { customscript } {
     }
 }
 
+proc custommonitor { monitor } {
+global lprefix
+if {  [ info exists lprefix ] } { ; } else { set lprefix "load" }
+if { $monitor eq "test" } {
+set lprefix "load"
+putscli "Monitor Virtual User disabled for custom script"
+return
+} elseif { $monitor eq "timed" } {
+set lprefix "loadtimed"
+putscli "Monitor Virtual User enabled for customscript"
+} else {
+putscli "Usage: custommonitor test|timed"
+}
+return
+}
+
 proc savescript { savefile } {
 	global _ED
 	 if { [ string length $_ED(package) ] eq 0 } {

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -971,6 +971,53 @@ proc customscript { customscript } {
     }
 }
 
+proc savescript { savefile } {
+	global _ED
+	 if { [ string length $_ED(package) ] eq 0 } {
+		putscli "Error: No script loaded to save, use loadscript to load"
+		return
+	 }
+	if { [ file extension $savefile ] != ".tcl" } {
+		#extension is not tcl
+	if { [ file extension $savefile ] eq "" } {
+		#There is no extension add one
+		set savefile [ concat $savefile.tcl ]
+	} else {
+		#There is an extension but its not tcl, change it
+		set savefile "[ file rootname $savefile ].tcl"
+	}
+	}
+		#filename has .tcl extension
+	if { [ file dirname $savefile ] eq "." } {
+		#only filename given save to temp
+		set save_directory [ findtempdir ] 
+		set savefile [ file join $save_directory $savefile ]
+	} else {
+		#directory given, check its writable
+		set directory [ file dirname $savefile ]
+		if { [ file writable $directory ] } {
+		#directory is writable, save file
+		} else {
+		#directory given is not writable, show error
+		putscli "Error: directory $directory not writable to write $savefile for savescript"
+		return
+		}
+	}
+		#filename now in a writable format
+                if { [ catch {set fd [open $savefile w]} message ] } {
+		putscli "Error: Failed to open $savefile for writing"
+		return
+		} else {
+                if { [ catch {puts $fd $_ED(package)} message ] } {
+		putscli "Error: Failed to write to $savefile"
+		} else {
+		putscli "Success ... wrote script to $savefile"
+		catch {close $fd} 
+		return
+		}
+	}
+}
+
 proc distributescript {} {
     global opmode masterlist
     if { $opmode != "Primary" } { 

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -4,11 +4,11 @@ proc help { args } {
     if [ llength [ info commands wapp-default ]] { set wsmode 1 } else { set wsmode 0 }
     if $wsmode { set helpbanner "HammerDB $hdb_version WS Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema deleteschema clearscript customscript datagenrun dbset dgset diset jobs librarycheck loadscript print quit tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
+        set helpcmds [ list buildschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset jobs librarycheck loadscript print quit tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     } else {
         set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema deleteschema clearscript customscript datagenrun dbset dgset diset distributescript jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
+        set helpcmds [ list buildschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus ]
     }
     if {[ llength $args ] != 1} {
         puts $helpbanner
@@ -139,9 +139,17 @@ Changed tpcc:count_ware from 1 to 10 for Oracle"
                     putscli "clearscript - Usage: clearscript"
                     putscli "Clears the script. Equivalent to the \"Clear the Screen\" button in the graphical interface." 
                 }
+                savescript {
+                    putscli "savescript - Usage: savescript"
+                    putscli "Save the script to a file. Equivalent to the \"Save\" button in the graphical interface." 
+                }
                 customscript {
                     putscli "customscript - Usage: customscript scriptname.tcl"
                     putscli "Load an external script. Equivalent to the \"Open Existing File\" button in the graphical interface."  
+                }
+                custommonitor {
+                    putscli "custommonitor - Usage: custommonitor test|timed"
+                    putscli "Causes an additional Virtual User to be created when running vucreate. Used when loading a custom script."  
                 }
                 dgset {
                     putscli "dgset - Usage: dgset \[vu|ware|directory\]" 


### PR DESCRIPTION
Provides enhancement for Issue #521 adding CLI functionality to save and edit CLI scripts and to set the monitor virtual user before doing vucreate for such scripts. 

savescript will add a .tcl extension if one is not already applied and either save to a fully qualified directory if given or to the temp area if not. Example of saving and loading. 
```
hammerdb>savescript test
Success ... wrote script to /tmp/test.tcl

hammerdb>customscript /tmp/test.tcl
Loaded /tmp/test.tcl
```
custommonitor adds the additional monitor virtual user when doing a vucreate if the script is based on a timed script. 
```
hammerdb>custommonitor timed
Monitor Virtual User enabled for customscript

hammerdb>vucreate
Vuser 1 created MONITOR - WAIT IDLE
Vuser 2 created - WAIT IDLE
2 Virtual Users Created with Monitor VU
```

Note a potential perceived issue is that doing just custommonitor test and then vucreate, appears to ignore the setting. This however is not the case as there is no script loaded when vucreate is executed, in this case vucreate will then load the script according to the dict settings and set the monitor v accordingly overridng the settings made by the custommonitor command. So custommonitor is for custom scripts only as the command name should imply. 

```
hammerdb>custommonitor test
Monitor Virtual User disabled for custom script

hammerdb>vucreate
Script loaded, Type "print script" to view
Vuser 1 created MONITOR - WAIT IDLE
Vuser 2 created - WAIT IDLE
2 Virtual Users Created with Monitor VU
```
Built and tested also on Windows. 
```
hammerdb>customscript C:/Users/smsha/AppData/Local/Temp/test.tcl
Loaded C:/Users/smsha/AppData/Local/Temp/test.tcl

hammerdb>custommonitor test
Monitor Virtual User disabled for custom script

hammerdb>vucreate
Vuser 1 created - WAIT IDLE
1 Virtual Users Created

hammerdb>vudestroy
vudestroy success

hammerdb>custommonitor timed
Monitor Virtual User enabled for customscript

hammerdb>vucreate
Vuser 1 created MONITOR - WAIT IDLE
Vuser 2 created - WAIT IDLE
2 Virtual Users Created with Monitor VU

hammerdb>vudestroy
vudestroy success

hammerdb>custommonitor test
Monitor Virtual User disabled for custom script

hammerdb>vucreate
Vuser 1 created - WAIT IDLE
1 Virtual Users Created

hammerdb>
```

Also the tclpy package has been updated to add the savescript and custommonitor commands to the python CLI interface here https://github.com/sm-shaw/libtclpy. This can be updated using build from source. 