### PR TITLE
Update mssqlsoltp.tcl

### DIFF
--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -2374,7 +2374,7 @@ switch $myposition {
             }
             if { [ tsv::get application abort ] } { break }
             puts "Rampup complete, Taking start Transaction Count."
-            if {[catch {set rows [ odbc allrows "select sum(d_next_o_id) from district" ]} message ]} {
+            if {[catch {set rows [ odbc allrows "select sum(cast(d_next_o_id as bigint)) from district" ]} message ]} {
                 error "Failed to query district table : $message"
             } else {
                 set start_nopm [ lindex {*}$rows 1 ]
@@ -2399,7 +2399,7 @@ switch $myposition {
             }
             if { [ tsv::get application abort ] } { break }
             puts "Test complete, Taking end Transaction Count."
-            if {[catch {set rows [ odbc allrows "select sum(d_next_o_id) from district" ]} message ]} {
+            if {[catch {set rows [ odbc allrows "select sum(cast(d_next_o_id as bigint)) from district" ]} message ]} {
                 error "Failed to query district table : $message"
             } else {
                 set end_nopm [ lindex {*}$rows 1 ]
@@ -2793,7 +2793,7 @@ switch $myposition {
             }
             if { [ tsv::get application abort ] } { break }
             puts "Rampup complete, Taking start Transaction Count."
-            if {[catch {set rows [ odbc allrows "select sum(d_next_o_id) from district" ]} message ]} {
+            if {[catch {set rows [ odbc allrows "select sum(cast(d_next_o_id as bigint)) from district" ]} message ]} {
                 error "Failed to query district table : $message"
             } else {
                 set start_nopm [ lindex {*}$rows 1 ]
@@ -2818,7 +2818,7 @@ switch $myposition {
             }
             if { [ tsv::get application abort ] } { break }
             puts "Test complete, Taking end Transaction Count."
-            if {[catch {set rows [ odbc allrows "select sum(d_next_o_id) from district" ]} message ]} {
+            if {[catch {set rows [ odbc allrows "select sum(cast(d_next_o_id as bigint)) from district" ]} message ]} {
                 error "Failed to query district table : $message"
             } else {
                 set end_nopm [ lindex {*}$rows 1 ]


### PR DESCRIPTION
Replaced  "select sum(d_next_o_id) from district" with "select sum(cast(d_next_o_id as bigint)) from district" in 4 places in the file to avoid arithmetic overflow when running HammerSDB against test database with large number of warehouses.