### PR TITLE
Fix User and Repeat delay reversed

### DIFF
--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -246,16 +246,16 @@ proc load_virtual {}  {
     $Name configure -state disabled
     for { set vuser 0 } {$vuser < $maxvuser } {incr vuser} {
         set threadID [thread::create {
-            proc runVuser { MASTER ID NTIMES DELAYMS OTSQL } {
+            proc runVuser { MASTER ID NTIMES CONPAUSE OTSQL } {
                 for { set cnta 0} {$cnta < $NTIMES} {incr cnta } {
                     eval [subst {thread::send -async $MASTER {::runninguser $ID}}]
                     if {[set op [catch "eval $OTSQL" result]]} {
                         eval [subst {thread::send -async $MASTER {::myerrorproc [list $ID $result]}}]
                     }
                     eval [subst {thread::send -async $MASTER {::printresult [list $op $ID]}}]
-                    set dms 0
-                    after $DELAYMS { set dms 1 }
-                    vwait dms
+                    set cp 0
+                    after $CONPAUSE { set cp 1 }
+                    vwait cp
                 }
             }
 
@@ -509,10 +509,10 @@ proc run_virtual {} {
                 return
             }
             for { set vuser 0} {$vuser < $maxvuser} {incr vuser} {
-                eval [ subst {thread::send -async $threadscreated($vuser) {runVuser $masterthread $threadscreated($vuser) $ntimes $delayms $script_to_send}}]
-                set cp 0
-                after $conpause { set cp 1 }
-                vwait cp
+                eval [ subst {thread::send -async $threadscreated($vuser) {runVuser $masterthread $threadscreated($vuser) $ntimes $conpause $script_to_send}}]
+                set dms 0
+                after $delayms { set dms 1 }
+                vwait dms
             }
             .ed_mainFrame configure -cursor {}
         } else {


### PR DESCRIPTION
User and repeat delay are reversed from what is documented. So User delay is repeat delay and vice versa. This PR modifies the options to be as documented.  (By default they are both set to 500ms, so unlikely to be picked up in regualr testing). 

![vuopt](https://github.com/TPC-Council/HammerDB/assets/38044085/3a8520f2-acbe-4efc-98dd-35e7e9acb50d)

<html><body>
<!--StartFragment-->

Option | Description
-- | --
User Delay(ms) | User  Delay(ms) defines the time to wait a Virtual User will wait behind the  previous Virtual User before starting its test, this is to prevent a  login storm with all Virtual Users attempting to login at the same time.
Repeat Delay(ms) | Repeat  Delay(ms) is the time that each Virtual User will wait before running  its next Iteration of the Driver Script. For the TPROC-C workload this  should be considered as an 'outer loop' to the 'inner loop' of the Total  Transactions per User in the TPROC-C Driver Script.

<!--EndFragment-->
</body>
</html>
