### PR TITLE
Add password blank to GUI

### DIFF
--- a/src/db2/db2opt.tcl
+++ b/src/db2/db2opt.tcl
@@ -57,7 +57,7 @@ proc countdb2opts { bm } {
     set Name $Parent.f1.e2
     set Prompt $Parent.f1.p2
     ttk::label $Prompt -text "TPROC-C Db2 User Password :" -image [ create_image hdbicon icons ] -compound left 
-    ttk::entry $Name  -width 30 -textvariable $tmp_db2_pass
+    ttk::entry $Name -show * -width 30 -textvariable $tmp_db2_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
     set Name $Parent.f1.e3
@@ -209,7 +209,7 @@ proc configdb2tpcc {option} {
     set Name $Parent.f1.e2
     set Prompt $Parent.f1.p2
     ttk::label $Prompt -text "TPROC-C Db2 User Password :" -image [ create_image hdbicon icons ] -compound left 
-    ttk::entry $Name  -width 30 -textvariable db2_pass
+    ttk::entry $Name -show * -width 30 -textvariable db2_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
     set Name $Parent.f1.e3
@@ -563,7 +563,7 @@ proc configdb2tpch {option} {
     set Name $Parent.f1.e2
     set Prompt $Parent.f1.p2
     ttk::label $Prompt -text "TPROC-H Db2 User Password :" -image [ create_image hdbicon icons ] -compound left
-    ttk::entry $Name  -width 30 -textvariable db2_tpch_pass
+    ttk::entry $Name -show * -width 30 -textvariable db2_tpch_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
     set Name $Parent.f1.e3

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -271,9 +271,9 @@ proc countmariaopts { bm } {
     ttk::label $Prompt -text "MariaDB User Password :"   
 
     if { $bm eq "TPC-C" } {
-        ttk::entry $Name  -width 30 -textvariable maria_pass
+        ttk::entry $Name -show * -width 30 -textvariable maria_pass
     } else {
-        ttk::entry $Name  -width 30 -textvariable maria_tpch_pass
+        ttk::entry $Name -show * -width 30 -textvariable maria_tpch_pass
     }
 
     grid $Prompt -column 0 -row 13 -sticky e
@@ -567,7 +567,7 @@ proc configmariatpcc {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "MariaDB User Password :"   
-    ttk::entry $Name  -width 30 -textvariable maria_pass
+    ttk::entry $Name -show * -width 30 -textvariable maria_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
     set Name $Parent.f1.e5
@@ -1059,7 +1059,7 @@ proc configmariatpch {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "MariaDB User Password :"   
-    ttk::entry $Name  -width 30 -textvariable maria_tpch_pass
+    ttk::entry $Name -show * -width 30 -textvariable maria_tpch_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
     set Name $Parent.f1.e5

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -140,7 +140,7 @@ proc countmssqlsopts { bm } {
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
-    ttk::entry $Name  -width 30 -textvariable mssqls_pass
+    ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 11 -sticky e
     grid $Name -column 1 -row 11 -sticky ew
     if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
@@ -366,7 +366,7 @@ proc configmssqlstpcc {option} {
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
-    ttk::entry $Name  -width 30 -textvariable mssqls_pass
+    ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 11 -sticky e
     grid $Name -column 1 -row 11 -sticky ew
     if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
@@ -808,7 +808,7 @@ proc configmssqlstpch {option} {
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"
-    ttk::entry $Name  -width 30 -textvariable mssqls_pass
+    ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 11 -sticky e
     grid $Name -column 1 -row 11 -sticky ew
     if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {

--- a/src/mysql/mysqlopt.tcl
+++ b/src/mysql/mysqlopt.tcl
@@ -262,9 +262,9 @@ proc countmysqlopts { bm } {
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
     if { $bm eq "TPC-C" } {
-        ttk::entry $Name  -width 30 -textvariable mysql_pass
+        ttk::entry $Name -show * -width 30 -textvariable mysql_pass
     } else {
-        ttk::entry $Name  -width 30 -textvariable mysql_tpch_pass
+        ttk::entry $Name -show * -width 30 -textvariable mysql_tpch_pass
     }
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
@@ -550,7 +550,7 @@ proc configmysqltpcc {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
-    ttk::entry $Name  -width 30 -textvariable mysql_pass
+    ttk::entry $Name -show * -width 30 -textvariable mysql_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
     set Name $Parent.f1.e5
@@ -1003,7 +1003,7 @@ proc configmysqltpch {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
-    ttk::entry $Name  -width 30 -textvariable mysql_tpch_pass
+    ttk::entry $Name -show * -width 30 -textvariable mysql_tpch_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
     set Name $Parent.f1.e5

--- a/src/oracle/oraopt.tcl
+++ b/src/oracle/oraopt.tcl
@@ -70,7 +70,7 @@ proc countoraopts { bm } {
     set Name $Parent.f1.e3
     set Prompt $Parent.f1.p3
     ttk::label $Prompt -text "System User Password :"   
-    ttk::entry $Name  -width 30 -textvariable system_password
+    ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     set Name $Parent.f1.e4
@@ -226,7 +226,7 @@ proc configoratpcc {option} {
     set Name $Parent.f1.e3
     set Prompt $Parent.f1.p3
     ttk::label $Prompt -text "System User Password :"   
-    ttk::entry $Name  -width 30 -textvariable system_password
+    ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     set Name $Parent.f1.e4
@@ -238,7 +238,7 @@ proc configoratpcc {option} {
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "TPROC-C User Password :" -image [ create_image hdbicon icons ] -compound left
-    ttk::entry $Name  -width 30 -textvariable tpcc_pass
+    ttk::entry $Name -show * -width 30 -textvariable tpcc_pass
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky ew
     if { $option eq "all" || $option eq "build" } {
@@ -651,7 +651,7 @@ proc configoratpch {option} {
     set Name $Parent.f1.e2
     set Prompt $Parent.f1.p2
     ttk::label $Prompt -text "System User Password :"
-    ttk::entry $Name -width 30 -textvariable system_password
+    ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -columnspan 4 -sticky ew
     set Name $Parent.f1.e3
@@ -663,7 +663,7 @@ proc configoratpch {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "TPROC-H User Password :" -image [ create_image hdbicon icons ] -compound left
-    ttk::entry $Name  -width 30 -textvariable tpch_pass
+    ttk::entry $Name -show * -width 30 -textvariable tpch_pass
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -columnspan 4 -sticky ew
     if { $option eq "all" || $option eq "build" } {
@@ -930,7 +930,7 @@ proc metoraopts {} {
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "System User Password :"
-    ttk::entry $Name  -width 30 -textvariable system_password
+    ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky ew
     set Name $Parent.b4

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -79,9 +79,9 @@ proc countpgopts { bm } {
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
     if { $bm eq "TPC-C" } {
-        ttk::entry $Name  -width 30 -textvariable pg_superuserpass
+        ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
     } else {
-        ttk::entry $Name  -width 30 -textvariable pg_tpch_superuserpass
+        ttk::entry $Name -show * -width 30 -textvariable pg_tpch_superuserpass
     }
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
@@ -268,7 +268,7 @@ proc configpgtpcc {option} {
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
-    ttk::entry $Name  -width 30 -textvariable pg_superuserpass
+    ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
     set Name $Parent.f1.e5
@@ -286,7 +286,7 @@ proc configpgtpcc {option} {
     set Name $Parent.f1.e7
     set Prompt $Parent.f1.p7
     ttk::label $Prompt -text "TPROC-C PostgreSQL User Password :" -image [ create_image hdbicon icons ] -compound left 
-    ttk::entry $Name  -width 30 -textvariable pg_pass
+    ttk::entry $Name -show * -width 30 -textvariable pg_pass
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
     set Name $Parent.f1.e8
@@ -698,7 +698,7 @@ proc configpgtpch {option} {
         set Name $Parent.f1.e4
         set Prompt $Parent.f1.p4
         ttk::label $Prompt -text "PostgreSQL Superuser Password :"
-        ttk::entry $Name  -width 30 -textvariable pg_tpch_superuserpass
+        ttk::entry $Name -show * -width 30 -textvariable pg_tpch_superuserpass
         grid $Prompt -column 0 -row 4 -sticky e
         grid $Name -column 1 -row 4 -sticky ew
         set Name $Parent.f1.e5
@@ -717,7 +717,7 @@ proc configpgtpch {option} {
     set Name $Parent.f1.e7
     set Prompt $Parent.f1.p7
     ttk::label $Prompt -text "TPROC-H PostgreSQL User Password :" -image [ create_image hdbicon icons ] -compound left
-    ttk::entry $Name  -width 30 -textvariable pg_tpch_pass
+    ttk::entry $Name -show * -width 30 -textvariable pg_tpch_pass
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
     set Name $Parent.f1.e8
@@ -1012,9 +1012,9 @@ proc metpgopts {} {
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
     if { $bm eq "TPC-C" } {
-        ttk::entry $Name  -width 30 -textvariable pg_superuserpass
+        ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
     } else {
-        ttk::entry $Name  -width 30 -textvariable pg_tpch_superuserpass
+        ttk::entry $Name -show * -width 30 -textvariable pg_tpch_superuserpass
     }
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew


### PR DESCRIPTION
As partly prompted by discussion in  #561 on other area adds password blanking for GUI fields.
May seem superfluous as the passwords will still be entered in the script editor in clear text, stored in the config dict and the SQLite database which is why it hasn't been done before.  
However may be of benefit when sharing screen shots of the GUI and don't want to share password field. 