### PR TITLE
Container file simplication

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,50 +1,8 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
 
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
+FROM  docker.io/tpcorg/hammerdb:oracle as oracle
 
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
+FROM  docker.io/tpcorg/hammerdb:mssqls
 
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
-
-# Install and configure Microsoft SQLServer client libraries
-RUN apt -y install -q \
-    apt -y curl gcc make && \
-    apt update && apt install -y lsb-release && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
-    ACCEPT_EULA=Y apt-get install -y mssql-tools18 && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc && \
-    wget http://www.unixodbc.org/unixODBC-2.3.11.tar.gz && tar -xvzf unixODBC-2.3.11.tar.gz && cd unixODBC-2.3.11 && \
-    ./configure --prefix=/usr/local/unixODBC --enable-gui=no --enable-drivers=no --enable-iconv --with-iconv-char-enc=UTF8 \
-    --with-iconv-ucode-enc=UTF16LE --enable-threads=yes --enable-fastvalidate && make && make install && cd .. && \
-    echo 'export PATH="$PATH:/opt/mssql-tools18/bin:/usr/local/unixODBC/bin" \n\
-    export ODBCINI="/usr/local/unixODBC/etc/odbc.ini" \n\
-    export ODBCSYSINI="/usr/local/unixODBC/etc" \n\
-    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/unixODBC/lib"'  >> ~/.bashrc && \
-    echo "[ODBC Driver 18 for SQL Server] \n\
-    Description=Microsoft ODBC Driver 18 for SQL Server \n\
-    Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.1.so.2.1 \n\
-    UsageCount=1 " >> /usr/local/unixODBC/etc/odbcinst.ini && \
-    odbcinst -j && \
-    rm -rf *.tar.gz *.zip unixODBC-2.3.11
-   
-# Install and configure Oracle client libraries
-RUN wget https://download.oracle.com/otn_software/linux/instantclient/215000/instantclient-basic-linux.x64-21.5.0.0.0dbru.zip && \
-    unzip *.zip && \
-    echo 'export LD_LIBRARY_PATH=/home/hammerdb/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    echo 'export ORACLE_LIBRARY=/home/hammerdb/instantclient_21_5/libclntsh.so'  >> ~/.bashrc
-  
 # Install and configure IBM Db2 client libraries, 
 # You will need to pre-download IDB Db2 client libraries and place in the local folder
 # RUN mkdir -p db2_cli_odbc_driver/odbc_cli
@@ -52,43 +10,16 @@ RUN wget https://download.oracle.com/otn_software/linux/instantclient/215000/ins
 # RUN apt update && \
 #    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
 #    apt -y install libxml2 && \
-#    echo 'export DB2_CLI_DRIVER_INSTALL_PATH="/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver"' >> ~/.bashrc && \
-#    echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
-#    echo 'export LIBPATH="/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
-#    echo 'export PATH="$PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/bin"' >> ~/.bashrc && \
-#    echo 'export PATH="$PATH:/home/hammerdb/db2_cli_odbc_driver/odbc_cli/clidriver/adm"' >>  ~/.bashrc
+#    echo 'export DB2_CLI_DRIVER_INSTALL_PATH="/home/db2_cli_odbc_driver/odbc_cli/clidriver"' >> ~/.bashrc && \
+#    echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
+#    echo 'export LIBPATH="/home/db2_cli_odbc_driver/odbc_cli/clidriver/lib"' >> ~/.bashrc && \
+#    echo 'export PATH="$PATH:/home/db2_cli_odbc_driver/odbc_cli/clidriver/bin"' >> ~/.bashrc && \
+#    echo 'export PATH="$PATH:/home/db2_cli_odbc_driver/odbc_cli/clidriver/adm"' >>  ~/.bashrc
 
-# Install and Configure MariaDB client libraries
-RUN apt install -y libmariadb3
+COPY --from=oracle /home/instantclient_21_5 /home/instantclient_21_5
+ENV ORACLE_LIBRARY=/home/instantclient_21_5/libclntsh.so
+RUN echo 'export LD_LIBRARY_PATH=/home/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc
 
-# Install and configure PostgreSQL client libraries
-RUN apt install -y libpq-dev 
-
-# Install and configuring MySQL client libraries
-RUN apt install -y libmysqlclient21
-
-#Install Python3.8
-RUN apt install -y python3
-
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb3 libpq-dev libmysqlclient21 && \
+    rm -rf /var/lib/apt/lists/*

--- a/Docker/Readme.md
+++ b/Docker/Readme.md
@@ -1,11 +1,11 @@
-# Release Notes for HammerDB 4.7
+# Release Notes for HammerDB Docker images
 
 ##### HammerDB prebuild Docker images can be downloaded directly from [Official TPC-Council HammerDB DockerHub](https://hub.docker.com/r/tpcorg/hammerdb)
         docker pull tpcorg/hammerdb
         docker tag  tpcorg/hammerdb hammerdb
 View all the Official TPC-Council HammerDB DockerHub images available [here](https://hub.docker.com/r/tpcorg/hammerdb/tags)
 
-Alternatively, [Dockerfile](https://github.com/TPC-Council/HammerDB/blob/master/Docker/Dockerfile) can be used to build the same HammerDb-v4.7 client docker image that supports all the databases HammerDB is enabled for, i.e. Oracle, Microsoft SQL Server, MySQL, PostgreSQL and MariaDB, except for IBM Db2. We intend to add it in future releases. TPC-Council#404
+Alternatively, [Dockerfile](https://github.com/TPC-Council/HammerDB/blob/master/Docker/Dockerfile) can be used to build the same HammerDB client docker image that supports all the databases HammerDB is enabled for, i.e. Oracle, Microsoft SQL Server, MySQL, PostgreSQL and MariaDB, except for IBM Db2. We intend to add it in future releases. TPC-Council#404
 ##### To build an image: Go to the folder containing the Dockerfile
         docker build -t hammerdb .
 ##### To create a container named "hammerdb" from the image, "hammerdb"
@@ -33,12 +33,12 @@ Given the wide usage of docker containers is in cloud and emphasizes on being li
          
 ## Example Scripts
 CLI example scripts for each database are included under "scripts folder". Examples for TPROC-C and TPROC-H workloads are given both in python and tcl languages.
-These scripts are recommended to run from the HammerDB home directory, "~/HammerDB-4.7/"
+These scripts are recommended to run from the HammerDB home directory, "/home/hammerdb/" 
 This example Python script for MariaDB Database and HammerDB TPROC-C workload automate the following:
 1. builds schema 
 2. run an TPROC-C workload test
 3. delete schema and
-4. write the results to "~/HammerDB-4.7/TMP" directory.
+4. write the results to "/home/hammerdb/TMP" directory.
         
 ##### This script can be executed as followed. 
         ./scripts/python/maria/tprocc/maria_tprocc_py.sh

--- a/Docker/Readme.md
+++ b/Docker/Readme.md
@@ -50,7 +50,7 @@ This example Python script for MariaDB Database and HammerDB TPROC-C workload au
 Format is similar for every database while using both TCL or Python 
 
 ## Enable GUI Interface for HammerDB in Docker
-To use HammerDB in GUI Mode from running within a Docker container, make sure X11 forwarding is configured and environemnt variable DISPLAY is set appropriately.
+To use HammerDB in GUI Mode from running within a Docker container, make sure X11 forwarding is configured and environment variable DISPLAY is set appropriately.
 ##### For example on Ubuntu,
         export DISPLAY=localhost:10.0
 ##### Additionally disable host control, by executing the following.

--- a/Docker/base/Dockerfile
+++ b/Docker/base/Dockerfile
@@ -1,0 +1,19 @@
+FROM       ubuntu:20.04
+LABEL maintainer="Pooja Jain"
+
+# Update & upgrade apt and download basic utilities
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip gnupg apt-utils libaio1 iputils-ping vim netcat libxft-dev libcairo2-dev xauth python3 && \
+    rm -rf  /var/lib/apt/lists/*
+
+# Install configure HammerDB-v4.7
+ARG HAMMERDB_VERSION=4.8
+RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v$HAMMERDB_VERSION/HammerDB-$HAMMERDB_VERSION-Linux.tar.gz -O - | \
+    tar -xvzf - -C /home/ && \
+    ln -s /home/HammerDB-$HAMMERDB_VERSION /home/hammerdb
+
+WORKDIR /home/hammerdb
+
+CMD tail -f /dev/null

--- a/Docker/maria/Dockerfile
+++ b/Docker/maria/Dockerfile
@@ -1,47 +1,6 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
-
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
-
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
-
+FROM docker.io/tpcorg/hammerdb:base
 
 # Install and Configure MariaDB client libraries
-RUN apt install -y libmariadb3
-
-#Install Python3.8
-RUN apt install -y python3
-
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb3 && \
+	rm -rf /var/lib/apt/lists/*

--- a/Docker/mssqls/Dockerfile
+++ b/Docker/mssqls/Dockerfile
@@ -1,30 +1,13 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
-
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
-
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
+FROM docker.io/tpcorg/hammerdb:base
 
 # Install and configure Microsoft SQLServer client libraries
-RUN apt -y install -q \
-    apt -y curl gcc make && \
-    apt update && apt install -y lsb-release && \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl gcc make lsb-release && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
-    ACCEPT_EULA=Y apt-get install -y mssql-tools18 && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc && \
+    ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y msodbcsql18 && \
+    ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y mssql-tools18 && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc && \
     wget http://www.unixodbc.org/unixODBC-2.3.11.tar.gz && tar -xvzf unixODBC-2.3.11.tar.gz && cd unixODBC-2.3.11 && \
     ./configure --prefix=/usr/local/unixODBC --enable-gui=no --enable-drivers=no --enable-iconv --with-iconv-char-enc=UTF8 \
     --with-iconv-ucode-enc=UTF16LE --enable-threads=yes --enable-fastvalidate && make && make install && cd .. && \
@@ -37,30 +20,5 @@ RUN apt -y install -q \
     Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.1.so.2.1 \n\
     UsageCount=1 " >> /usr/local/unixODBC/etc/odbcinst.ini && \
     odbcinst -j && \
-    rm -rf *.tar.gz *.zip unixODBC-2.3.11
-
-#Install Python3.8
-RUN apt install -y python3
-
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+    apt-get purge -y gcc make && \
+    rm -rf *.tar.gz *.zip unixODBC-2.3.11 /var/lib/apt/lists/*

--- a/Docker/mysql/Dockerfile
+++ b/Docker/mysql/Dockerfile
@@ -1,46 +1,6 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
-
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
-
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
+FROM docker.io/tpcorg/hammerdb:base
 
 # Install and configuring MySQL client libraries
-RUN apt install -y libmysqlclient21
-
-#Install Python3.8
-RUN apt install -y python3
-
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y libmysqlclient21 && \
+        rm -rf /var/lib/apt/lists/*

--- a/Docker/oracle/Dockerfile
+++ b/Docker/oracle/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/tpcorg/hammerdb:base
 # Install and configure Oracle client libraries
 RUN wget https://download.oracle.com/otn_software/linux/instantclient/215000/instantclient-basic-linux.x64-21.5.0.0.0dbru.zip && \
     unzip *.zip -d /home/ && \
-    echo 'export LD_LIBRARY_PATH=/home/hammerdb/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
+    echo 'export LD_LIBRARY_PATH=/home/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
     rm *.zip
 
 ENV ORACLE_LIBRARY=/home/instantclient_21_5/libclntsh.so

--- a/Docker/oracle/Dockerfile
+++ b/Docker/oracle/Dockerfile
@@ -1,49 +1,9 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
-
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
-
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
+FROM docker.io/tpcorg/hammerdb:base
 
 # Install and configure Oracle client libraries
 RUN wget https://download.oracle.com/otn_software/linux/instantclient/215000/instantclient-basic-linux.x64-21.5.0.0.0dbru.zip && \
-    unzip *.zip && \
+    unzip *.zip -d /home/ && \
     echo 'export LD_LIBRARY_PATH=/home/hammerdb/instantclient_21_5/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    echo 'export ORACLE_LIBRARY=/home/hammerdb/instantclient_21_5/libclntsh.so'  >> ~/.bashrc
-  
-#Install Python3.8
-RUN apt install -y python3
+    rm *.zip
 
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+ENV ORACLE_LIBRARY=/home/instantclient_21_5/libclntsh.so

--- a/Docker/postgres/Dockerfile
+++ b/Docker/postgres/Dockerfile
@@ -1,46 +1,6 @@
-FROM       ubuntu:20.04
-LABEL maintainer="Pooja Jain"
-
-# For apt install without question
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Enable apt sources
-RUN sed -i~orig -e 's/# deb-src/deb-src/' /etc/apt/sources.list
-
-# Set working directory
-WORKDIR /home/hammerdb
-
-# Update & upgrade apt and download basic utilities
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install -q \
-    apt -y wget unzip gnupg apt-utils libaio1  iputils-ping vim netcat libxft-dev libcairo2-dev xauth
+FROM docker.io/tpcorg/hammerdb:base
 
 # Install and configure PostgreSQL client libraries
-RUN apt install -y libpq-dev 
-
-#Install Python3.8
-RUN apt install -y python3
-
-# Install configure HammerDB-v4.7
-RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v4.7/HammerDB-4.7-Linux.tar.gz && \
-    tar -xvzf HammerDB-4.7-Linux.tar.gz && ls && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH'  >> ~/.bashrc && \
-    rm -rf *.tar.gz *.zip
-WORKDIR /home/hammerdb/HammerDB-4.7
-
-#CMD "bash"
-CMD tail -f /dev/null
-
-#To create an image: Go to the folder containing the Dockerfile 
-#       docker build -t hammerdb .
-#To start a container with that image
-#       docker run -it --name hammerdb hammerdb bash
-#To use HammerDB in GUI Mode, make sure X11 forwarding is configured, Environemnt variable DISPLAY is set appropriately,  for example on Ubuntu,
-#       export DISPLAY=localhost:10.0
-# and also  disable host control, by executing the following.
-#       xhost+
-#you can then start container:
-#       docker run -it --rm -v /root/.Xauthority:/root/.Xauthority -e DISPLAY=$DISPLAY --network=host --name hammerdb hammerdb bash
-
-
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y libpq-dev && \
+        rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
To reduce the duplication and minimize the image size, base/Dockerfile was created to capture the common elements of the base image.

The database specific files derive from this base image.

The top level Dockerfile uses the mssql, the more complicated image as a base, and using multistage images takes the important aspects out of oracle's image, and does the package installs for maria, mysql and postgres.

A number of changes in the base image where made:
* Apt-sources weren't used so leave them disabled.
* apt doesn't provide a stable command line interfaces, so use apt-get
* to reduce image size,  /var/lib/apt/lists/* is removed
* DEBIAN_FRONTEND=noninteractive is an environment variable rather than a build arg.