### PR TITLE
Add Optional Invisible Primary Key to History for Replication in MySQL and MariaDB

### DIFF
--- a/config/mariadb.xml
+++ b/config/mariadb.xml
@@ -23,6 +23,7 @@
             <maria_storage_engine>innodb</maria_storage_engine>
             <maria_partition>false</maria_partition>
             <maria_prepared>false</maria_prepared>
+            <maria_history_pk>false</maria_history_pk>
         </schema>
         <driver>
             <maria_total_iterations>10000000</maria_total_iterations>

--- a/config/mysql.xml
+++ b/config/mysql.xml
@@ -23,6 +23,7 @@
             <mysql_storage_engine>innodb</mysql_storage_engine>
             <mysql_partition>false</mysql_partition>
             <mysql_prepared>false</mysql_prepared>
+            <mysql_history_pk>false</mysql_history_pk>
         </schema>
         <driver>
             <mysql_total_iterations>10000000</mysql_total_iterations>

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -520,8 +520,18 @@ proc CreateDatabase { maria_handler db } {
     return
 }
 
-proc CreateTables { maria_handler maria_storage_engine num_part } {
+proc CreateTables { maria_handler maria_storage_engine num_part history_pk } {
     puts "CREATING TPCC TABLES"
+    if { [ string toupper $maria_storage_engine ] eq "INNODB" && $history_pk } {
+    set pkmin_version "10.3.3"
+    set version [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]
+    if { [ package vcompare $version $pkmin_version ]  eq -1 } {
+            puts "Minimum MariaDB version for invisible PK is $pkmin_version"
+            set history_pk "false"
+    }
+    } else {
+    set history_pk "false"
+    }
     set sql(1) "CREATE TABLE `customer` (
 `c_id` INT(5) NOT NULL,
 `c_d_id` INT(2) NOT NULL,
@@ -563,6 +573,21 @@ ENGINE = $maria_storage_engine"
 PRIMARY KEY (`d_w_id`,`d_id`)
 )
 ENGINE = $maria_storage_engine"
+if $history_pk {
+    set sql(3) "CREATE TABLE `history` (
+  `h_c_id` INT NULL,
+  `h_c_d_id` INT NULL,
+  `h_c_w_id` INT NULL,
+  `h_d_id` INT NULL,
+  `h_w_id` INT NULL,
+  `h_date` DATETIME NULL,
+  `h_amount` DECIMAL(6, 2) NULL,
+  `h_data` VARCHAR(24) BINARY NULL,
+  `id` INT NOT NULL AUTO_INCREMENT INVISIBLE,
+PRIMARY KEY (`id`)
+)
+ENGINE = $maria_storage_engine"
+        } else {
     set sql(3) "CREATE TABLE `history` (
 `h_c_id` INT NULL,
 `h_c_d_id` INT NULL,
@@ -574,6 +599,7 @@ ENGINE = $maria_storage_engine"
 `h_data` VARCHAR(24) BINARY NULL
 )
 ENGINE = $maria_storage_engine"
+	}
     set sql(4) "CREATE TABLE `item` (
 `i_id` INT(6) NOT NULL,
 `i_im_id` INT NULL,
@@ -963,7 +989,7 @@ proc chk_socket { host socket } {
     }
 }
 
-proc do_tpcc { host port socket ssl_options count_ware user password db maria_storage_engine partition num_vu } {
+proc do_tpcc { host port socket ssl_options count_ware user password db maria_storage_engine partition history_pk num_vu } {
     global mariastatus
     set MAXITEMS 100000
     set CUST_PER_DIST 3000
@@ -1008,7 +1034,7 @@ proc do_tpcc { host port socket ssl_options count_ware user password db maria_st
             } else {
                 set num_part 0
             }
-            CreateTables $maria_handler $maria_storage_engine $num_part
+            CreateTables $maria_handler $maria_storage_engine $num_part $history_pk
         if { $threaded eq "MULTI-THREADED" } {
             tsv::set application load "READY"
             LoadItems $maria_handler $MAXITEMS
@@ -1077,7 +1103,7 @@ proc do_tpcc { host port socket ssl_options count_ware user password db maria_st
 }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_count_ware $maria_user $maria_pass $maria_dbase $maria_storage_engine $maria_partition $maria_num_vu" 
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_count_ware $maria_user $maria_pass $maria_dbase $maria_storage_engine $maria_partition $maria_history_pk $maria_num_vu" 
     } else {
         return 
     }

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -384,7 +384,7 @@ proc configmariatpcc {option} {
 
     #set variables to values in dict
     setlocaltpccvars $configmariadb
-    set tpccfields [ dict create tpcc {maria_user {.tpc.f1.e3 get} maria_pass {.tpc.f1.e4 get} maria_dbase {.tpc.f1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_connect_pool $maria_connect_pool} ]
+    set tpccfields [ dict create tpcc {maria_user {.tpc.f1.e3 get} maria_pass {.tpc.f1.e4 get} maria_dbase {.tpc.f1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_connect_pool $maria_connect_pool maria_history_pk $maria_history_pk} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
     set mariaconn [ dict create connection {maria_host {.tpc.f1.e1 get} maria_port {.tpc.f1.e2 get} maria_socket {.tpc.f1.e2a get} maria_ssl_ca {.tpc.f1.e2d get} maria_ssl_cert {.tpc.f1.e2e get} maria_ssl_key {.tpc.f1.e2f get} maria_ssl_cipher {.tpc.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} ]
@@ -628,24 +628,32 @@ proc configmariatpcc {option} {
         if {$maria_count_ware <= 200 } {
             $Name configure -state disabled
         }
+	grid $Prompt -column 0 -row 19 -sticky e
+        grid $Name -column 1 -row 19 -sticky ew
+        set Prompt $Parent.f1.p11
+        ttk::label $Prompt -text "History Table Primary Key :"
+        set Name $Parent.f1.e11
+        ttk::checkbutton $Name -text "" -variable maria_history_pk -onvalue "true" -offvalue "false"
+        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Name -column 1 -row 20 -sticky w
     }
 
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {
             set Prompt $Parent.f1.h3
             ttk::label $Prompt -image [ create_image driveroptlo icons ]
-            grid $Prompt -column 0 -row 19 -sticky e
+            grid $Prompt -column 0 -row 21 -sticky e
             set Prompt $Parent.f1.h4
             ttk::label $Prompt -text "Driver Options"
-            grid $Prompt -column 1 -row 19 -sticky w
+            grid $Prompt -column 1 -row 21 -sticky w
         }
 
         set Prompt $Parent.f1.p12
         ttk::label $Prompt -text "TPROC-C Driver Script :" -image [ create_image hdbicon icons ] -compound left
-        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Prompt -column 0 -row 22 -sticky e
         set Name $Parent.f1.r1
         ttk::radiobutton $Name -value "test" -text "Test Driver Script" -variable maria_driver
-        grid $Name -column 1 -row 20 -sticky w
+        grid $Name -column 1 -row 22 -sticky w
 
         bind .tpc.f1.r1 <ButtonPress-1> {
             set maria_allwarehouse "false"
@@ -664,7 +672,7 @@ proc configmariatpcc {option} {
 
         set Name $Parent.f1.r2
         ttk::radiobutton $Name -value "timed" -text "Timed Driver Script" -variable maria_driver
-        grid $Name -column 1 -row 21 -sticky w
+        grid $Name -column 1 -row 23 -sticky w
 
         bind .tpc.f1.r2 <ButtonPress-1> {
             .tpc.f1.e17 configure -state normal
@@ -683,14 +691,14 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p14
         ttk::label $Prompt -text "Total Transactions per User :"
         ttk::entry $Name -width 30 -textvariable maria_total_iterations
-        grid $Prompt -column 0 -row 22 -sticky e
-        grid $Name -column 1 -row 22 -sticky ew
+        grid $Prompt -column 0 -row 24 -sticky e
+        grid $Name -column 1 -row 24 -sticky ew
         set Prompt $Parent.f1.p15
         ttk::label $Prompt -text "Exit on MariaDB Error :"
         set Name $Parent.f1.e15
         ttk::checkbutton $Name -text "" -variable maria_raiseerror -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 23 -sticky e
-        grid $Name -column 1 -row 23 -sticky w
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky w
         set Prompt $Parent.f1.p16
         ttk::label $Prompt -text "Keying and Thinking Time :"
         set Name $Parent.f1.e16
@@ -707,20 +715,20 @@ proc configmariatpcc {option} {
             }
         }
 
-        grid $Prompt -column 0 -row 24 -sticky e
-        grid $Name -column 1 -row 24 -sticky w
+        grid $Prompt -column 0 -row 26 -sticky e
+        grid $Name -column 1 -row 26 -sticky w
         set Prompt $Parent.f1.p16a
         ttk::label $Prompt -text "Prepare Statements :"
         set Name $Parent.f1.e16a
         ttk::checkbutton $Name -text "" -variable maria_prepared -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 25 -sticky e
-        grid $Name -column 1 -row 25 -sticky w
+        grid $Prompt -column 0 -row 27 -sticky e
+        grid $Name -column 1 -row 27 -sticky w
         set Name $Parent.f1.e17
         set Prompt $Parent.f1.p17
         ttk::label $Prompt -text "Minutes of Rampup Time :"
         ttk::entry $Name -width 30 -textvariable maria_rampup
-        grid $Prompt -column 0 -row 26 -sticky e
-        grid $Name -column 1 -row 26 -sticky ew
+        grid $Prompt -column 0 -row 28 -sticky e
+        grid $Name -column 1 -row 28 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -730,8 +738,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p18
         ttk::label $Prompt -text "Minutes for Test Duration :"
         ttk::entry $Name -width 30 -textvariable maria_duration
-        grid $Prompt -column 0 -row 27 -sticky e
-        grid $Name -column 1 -row 27 -sticky ew
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -741,8 +749,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p19
         ttk::label $Prompt -text "Use All Warehouses :"
         ttk::checkbutton $Name -text "" -variable maria_allwarehouse -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 28 -sticky e
-        grid $Name -column 1 -row 28 -sticky ew
+        grid $Prompt -column 0 -row 30 -sticky e
+        grid $Name -column 1 -row 30 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -752,8 +760,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p20
         ttk::label $Prompt -text "Time Profile :"
         ttk::checkbutton $Name -text "" -variable maria_timeprofile -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 29 -sticky e
-        grid $Name -column 1 -row 29 -sticky ew
+        grid $Prompt -column 0 -row 31 -sticky e
+        grid $Name -column 1 -row 31 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -763,8 +771,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p21
         ttk::label $Prompt -text "Asynchronous Scaling :"
         ttk::checkbutton $Name -text "" -variable maria_async_scale -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 30 -sticky e
-        grid $Name -column 1 -row 30 -sticky ew
+        grid $Prompt -column 0 -row 32 -sticky e
+        grid $Name -column 1 -row 32 -sticky ew
 
         if {$maria_driver == "test" } {
             set maria_async_scale "false"
@@ -791,8 +799,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p22
         ttk::label $Prompt -text "Asynch Clients per Virtual User :"
         ttk::entry $Name -width 30 -textvariable maria_async_client
-        grid $Prompt -column 0 -row 31 -sticky e
-        grid $Name -column 1 -row 31 -sticky ew
+        grid $Prompt -column 0 -row 33 -sticky e
+        grid $Name -column 1 -row 33 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             $Name configure -state disabled
@@ -802,8 +810,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p23
         ttk::label $Prompt -text "Asynch Client Login Delay :"
         ttk::entry $Name -width 30 -textvariable maria_async_delay
-        grid $Prompt -column 0 -row 32 -sticky e
-        grid $Name -column 1 -row 32 -sticky ew
+        grid $Prompt -column 0 -row 34 -sticky e
+        grid $Name -column 1 -row 34 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             $Name configure -state disabled
@@ -813,8 +821,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p24
         ttk::label $Prompt -text "Asynchronous Verbose :"
         ttk::checkbutton $Name -text "" -variable maria_async_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 33 -sticky e
-        grid $Name -column 1 -row 33 -sticky ew
+        grid $Prompt -column 0 -row 35 -sticky e
+        grid $Name -column 1 -row 35 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             set maria_async_verbose "false"
@@ -825,8 +833,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p25
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable maria_connect_pool -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 34 -sticky e
-        grid $Name -column 1 -row 34 -sticky ew
+        grid $Prompt -column 0 -row 36 -sticky e
+        grid $Name -column 1 -row 36 -sticky ew
     }
 
     #This is the Cancel button variables stay as before

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -507,7 +507,7 @@ proc CreateTables { mysql_handler mysql_storage_engine num_part history_pk } {
     set pkmin_version "8.0.30"
     set version [ list [ mysql::sel $mysql_handler "select version()" -list ] ]
     if { [ package vcompare $version $pkmin_version ]  eq -1 } {
-	    puts "Minimum MySQL version for invisible PK is 8.0.30"
+	    puts "Minimum MySQL version for invisible PK is $pkmin_version"
 	    set history_pk "false"
     }
     } else {
@@ -555,7 +555,6 @@ PRIMARY KEY (`d_w_id`,`d_id`)
 )
 ENGINE = $mysql_storage_engine"
 if $history_pk {
-
     set sql(3) "CREATE TABLE `history` (
   `h_c_id` INT NULL,
   `h_c_d_id` INT NULL,

--- a/src/mysql/mysqlopt.tcl
+++ b/src/mysql/mysqlopt.tcl
@@ -372,7 +372,7 @@ proc configmysqltpcc {option} {
     upvar #0 configmysql configmysql
     #set variables to values in dict
     setlocaltpccvars $configmysql
-    set tpccfields [ dict create tpcc {mysql_user {.tpc.f1.e3 get} mysql_pass {.tpc.f1.e4 get} mysql_dbase {.tpc.f1.e5 get} mysql_storage_engine {.tpc.f1.e6 get} mysql_total_iterations {.tpc.f1.e14 get} mysql_rampup {.tpc.f1.e17 get} mysql_duration {.tpc.f1.e18 get} mysql_async_client {.tpc.f1.e22 get} mysql_async_delay {.tpc.f1.e23 get} mysql_count_ware $mysql_count_ware mysql_num_vu $mysql_num_vu mysql_partition $mysql_partition mysql_driver $mysql_driver mysql_raiseerror $mysql_raiseerror mysql_keyandthink $mysql_keyandthink mysql_allwarehouse $mysql_allwarehouse mysql_timeprofile $mysql_timeprofile mysql_async_scale $mysql_async_scale mysql_async_verbose $mysql_async_verbose mysql_prepared $mysql_prepared mysql_connect_pool $mysql_connect_pool} ]
+    set tpccfields [ dict create tpcc {mysql_user {.tpc.f1.e3 get} mysql_pass {.tpc.f1.e4 get} mysql_dbase {.tpc.f1.e5 get} mysql_storage_engine {.tpc.f1.e6 get} mysql_total_iterations {.tpc.f1.e14 get} mysql_rampup {.tpc.f1.e17 get} mysql_duration {.tpc.f1.e18 get} mysql_async_client {.tpc.f1.e22 get} mysql_async_delay {.tpc.f1.e23 get} mysql_count_ware $mysql_count_ware mysql_num_vu $mysql_num_vu mysql_partition $mysql_partition mysql_driver $mysql_driver mysql_raiseerror $mysql_raiseerror mysql_keyandthink $mysql_keyandthink mysql_allwarehouse $mysql_allwarehouse mysql_timeprofile $mysql_timeprofile mysql_async_scale $mysql_async_scale mysql_async_verbose $mysql_async_verbose mysql_prepared $mysql_prepared mysql_connect_pool $mysql_connect_pool mysql_history_pk $mysql_history_pk} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
         set mysqlconn [ dict create connection {mysql_host {.tpc.f1.e1 get} mysql_port {.tpc.f1.e2 get} mysql_socket {.tpc.f1.e2a get} mysql_ssl_ca {.tpc.f1.e2d get} mysql_ssl_cert {.tpc.f1.e2e get} mysql_ssl_key {.tpc.f1.e2f get} mysql_ssl_cipher {.tpc.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath} ]
@@ -605,22 +605,30 @@ proc configmysqltpcc {option} {
         if {$mysql_count_ware <= 200 } {
             $Name configure -state disabled
         }
+	grid $Prompt -column 0 -row 19 -sticky e
+        grid $Name -column 1 -row 19 -sticky ew
+        set Prompt $Parent.f1.p11
+        ttk::label $Prompt -text "History Table Primary Key :"
+        set Name $Parent.f1.e11
+        ttk::checkbutton $Name -text "" -variable mysql_history_pk -onvalue "true" -offvalue "false"
+        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Name -column 1 -row 20 -sticky w
     }
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {
             set Prompt $Parent.f1.h3
             ttk::label $Prompt -image [ create_image driveroptlo icons ]
-            grid $Prompt -column 0 -row 19 -sticky e
+            grid $Prompt -column 0 -row 21 -sticky e
             set Prompt $Parent.f1.h4
             ttk::label $Prompt -text "Driver Options"
-            grid $Prompt -column 1 -row 19 -sticky w
+            grid $Prompt -column 1 -row 21 -sticky w
         }
         set Prompt $Parent.f1.p12
         ttk::label $Prompt -text "TPROC-C Driver Script :" -image [ create_image hdbicon icons ] -compound left
-        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Prompt -column 0 -row 22 -sticky e
         set Name $Parent.f1.r1
         ttk::radiobutton $Name -value "test" -text "Test Driver Script" -variable mysql_driver
-        grid $Name -column 1 -row 20 -sticky w
+        grid $Name -column 1 -row 22 -sticky w
         bind .tpc.f1.r1 <ButtonPress-1> {
             set mysql_allwarehouse "false"
             set mysql_timeprofile "false"
@@ -637,7 +645,7 @@ proc configmysqltpcc {option} {
         }
         set Name $Parent.f1.r2
         ttk::radiobutton $Name -value "timed" -text "Timed Driver Script" -variable mysql_driver
-        grid $Name -column 1 -row 21 -sticky w
+        grid $Name -column 1 -row 23 -sticky w
         bind .tpc.f1.r2 <ButtonPress-1> {
             .tpc.f1.e17 configure -state normal
             .tpc.f1.e18 configure -state normal
@@ -654,14 +662,14 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p14
         ttk::label $Prompt -text "Total Transactions per User :"
         ttk::entry $Name -width 30 -textvariable mysql_total_iterations
-        grid $Prompt -column 0 -row 22 -sticky e
-        grid $Name -column 1 -row 22 -sticky ew
+        grid $Prompt -column 0 -row 24 -sticky e
+        grid $Name -column 1 -row 24 -sticky ew
         set Prompt $Parent.f1.p15
         ttk::label $Prompt -text "Exit on MySQL Error :"
         set Name $Parent.f1.e15
         ttk::checkbutton $Name -text "" -variable mysql_raiseerror -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 23 -sticky e
-        grid $Name -column 1 -row 23 -sticky w
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky w
         set Prompt $Parent.f1.p16
         ttk::label $Prompt -text "Keying and Thinking Time :"
         set Name $Parent.f1.e16
@@ -677,20 +685,20 @@ proc configmysqltpcc {option} {
                 }
             }
         }
-        grid $Prompt -column 0 -row 24 -sticky e
-        grid $Name -column 1 -row 24 -sticky w
+        grid $Prompt -column 0 -row 26 -sticky e
+        grid $Name -column 1 -row 26 -sticky w
         set Prompt $Parent.f1.p16a
         ttk::label $Prompt -text "Prepare Statements :"
         set Name $Parent.f1.e16a
         ttk::checkbutton $Name -text "" -variable mysql_prepared -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 25 -sticky e
-        grid $Name -column 1 -row 25 -sticky w
+        grid $Prompt -column 0 -row 27 -sticky e
+        grid $Name -column 1 -row 27 -sticky w
         set Name $Parent.f1.e17
         set Prompt $Parent.f1.p17
         ttk::label $Prompt -text "Minutes of Rampup Time :"
         ttk::entry $Name -width 30 -textvariable mysql_rampup
-        grid $Prompt -column 0 -row 26 -sticky e
-        grid $Name -column 1 -row 26 -sticky ew
+        grid $Prompt -column 0 -row 28 -sticky e
+        grid $Name -column 1 -row 28 -sticky ew
         if {$mysql_driver == "test" } {
             $Name configure -state disabled
         }
@@ -698,8 +706,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p18
         ttk::label $Prompt -text "Minutes for Test Duration :"
         ttk::entry $Name -width 30 -textvariable mysql_duration
-        grid $Prompt -column 0 -row 27 -sticky e
-        grid $Name -column 1 -row 27 -sticky ew
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky ew
         if {$mysql_driver == "test" } {
             $Name configure -state disabled
         }
@@ -707,8 +715,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p19
         ttk::label $Prompt -text "Use All Warehouses :"
         ttk::checkbutton $Name -text "" -variable mysql_allwarehouse -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 28 -sticky e
-        grid $Name -column 1 -row 28 -sticky ew
+        grid $Prompt -column 0 -row 30 -sticky e
+        grid $Name -column 1 -row 30 -sticky ew
         if {$mysql_driver == "test" } {
             $Name configure -state disabled
         }
@@ -716,8 +724,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p20
         ttk::label $Prompt -text "Time Profile :"
         ttk::checkbutton $Name -text "" -variable mysql_timeprofile -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 29 -sticky e
-        grid $Name -column 1 -row 29 -sticky ew
+        grid $Prompt -column 0 -row 31 -sticky e
+        grid $Name -column 1 -row 31 -sticky ew
         if {$mysql_driver == "test" } {
             $Name configure -state disabled
         }
@@ -725,8 +733,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p21
         ttk::label $Prompt -text "Asynchronous Scaling :"
         ttk::checkbutton $Name -text "" -variable mysql_async_scale -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 30 -sticky e
-        grid $Name -column 1 -row 30 -sticky ew
+        grid $Prompt -column 0 -row 32 -sticky e
+        grid $Name -column 1 -row 32 -sticky ew
         if {$mysql_driver == "test" } {
             set mysql_async_scale "false"
             $Name configure -state disabled
@@ -750,8 +758,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p22
         ttk::label $Prompt -text "Asynch Clients per Virtual User :"
         ttk::entry $Name -width 30 -textvariable mysql_async_client
-        grid $Prompt -column 0 -row 31 -sticky e
-        grid $Name -column 1 -row 31 -sticky ew
+        grid $Prompt -column 0 -row 33 -sticky e
+        grid $Name -column 1 -row 33 -sticky ew
         if {$mysql_driver == "test" || $mysql_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -759,8 +767,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p23
         ttk::label $Prompt -text "Asynch Client Login Delay :"
         ttk::entry $Name -width 30 -textvariable mysql_async_delay
-        grid $Prompt -column 0 -row 32 -sticky e
-        grid $Name -column 1 -row 32 -sticky ew
+        grid $Prompt -column 0 -row 34 -sticky e
+        grid $Name -column 1 -row 34 -sticky ew
         if {$mysql_driver == "test" || $mysql_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -768,8 +776,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p24
         ttk::label $Prompt -text "Asynchronous Verbose :"
         ttk::checkbutton $Name -text "" -variable mysql_async_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 33 -sticky e
-        grid $Name -column 1 -row 33 -sticky ew
+        grid $Prompt -column 0 -row 35 -sticky e
+        grid $Name -column 1 -row 35 -sticky ew
         if {$mysql_driver == "test" || $mysql_async_scale == "false" } {
             set mysql_async_verbose "false"
             $Name configure -state disabled
@@ -778,8 +786,8 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p25
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mysql_connect_pool -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 34 -sticky e
-        grid $Name -column 1 -row 34 -sticky ew
+        grid $Prompt -column 0 -row 36 -sticky e
+        grid $Name -column 1 -row 36 -sticky ew
     }
     #This is the Cancel button variables stay as before
     set Name $Parent.b2


### PR DESCRIPTION
 Pull Request adds an optional primary key for the history table which is needed for replication. 

![mysqlhistorypk](https://github.com/TPC-Council/HammerDB/assets/38044085/55c80b1a-6afe-4d0d-a388-4fbd537e0884)

option mysql/maria_history_pk is added to the config/CLI. 
```
<schema>
            <mysql_count_ware>1</mysql_count_ware>
            <mysql_num_vu>1</mysql_num_vu>
            <mysql_user>root</mysql_user>
            <mysql_pass>mysql</mysql_pass>
            <mysql_dbase>tpcc</mysql_dbase>
<mysql_storage_engine>innodb</mysql_storage_engine>
            <mysql_partition>false</mysql_partition>
            <mysql_prepared>false</mysql_prepared>
            <mysql_history_pk>false</mysql_history_pk>
        </schema>
```
Change will check that the InnoDB storage engine is being used and that the MySQL/MariaDB version is at a level that supports inivisible primary keys before adding one. If not it falls back to the default option. 

Example change in table with and without. 
```
mysql> show create table history\G
*************************** 1. row ***************************
       Table: history
Create Table: CREATE TABLE `history` (
  `h_c_id` int DEFAULT NULL,
  `h_c_d_id` int DEFAULT NULL,
  `h_c_w_id` int DEFAULT NULL,
  `h_d_id` int DEFAULT NULL,
  `h_w_id` int DEFAULT NULL,
  `h_date` datetime DEFAULT NULL,
  `h_amount` decimal(6,2) DEFAULT NULL,
  `h_data` varchar(24) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
  `id` int NOT NULL AUTO_INCREMENT /*!80023 INVISIBLE */,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=30001 DEFAULT CHARSET=latin1
1 row in set (0.00 sec)
*************************** 1. row ***************************
       Table: history
Create Table: CREATE TABLE `history` (
  `h_c_id` int DEFAULT NULL,
  `h_c_d_id` int DEFAULT NULL,
  `h_c_w_id` int DEFAULT NULL,
  `h_d_id` int DEFAULT NULL,
  `h_w_id` int DEFAULT NULL,
  `h_date` datetime DEFAULT NULL,
  `h_amount` decimal(6,2) DEFAULT NULL,
  `h_data` varchar(24) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=latin1
1 row in set (0.00 sec)
```
When testing on an incompatible version

```
mysql> select @@version;
+-----------+
| @@version |
+-----------+
| 8.0.20    |
+-----------+
1 row in set (0.00 sec)
```
Message is reported the minimum supported version but continues anyway without the invisible PK.
```
Hammerdb Log @ Tue Aug 22 15:18:16 BST 2023
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
Vuser 1:Monitor Thread
Vuser 1:CREATING TPCC2 SCHEMA
Vuser 1:Ssl_cipher
Vuser 1:CREATING DATABASE tpcc2
Vuser 1:CREATING TPCC TABLES
Vuser 1:Minimum MySQL version for invisible PK is 8.0.30
Vuser 1:Loading Item
```
This way it should allow adding the primary key for replication where it is needed, but also provide minimal disruption where it is not. 

Same change in MySQL and MariaDB