### PR TITLE
Skip blank lines in binds in recent Oracle trace files

### DIFF
--- a/src/generic/gencnv.tcl
+++ b/src/generic/gencnv.tcl
@@ -188,6 +188,7 @@ proc convert_to_oratcl { } {
             } 
             if {!([string match {BINDS*} $line])} {
                 if {![regexp {^[[:space:]]} $line match]}  {
+		if { [ string is space $line ] } { continue }
                     unset -nocomplain execlist($in_bind)
                     if {$nbinds > 0} {
                         if {[array exists bindexec]} {


### PR DESCRIPTION
Fix for Issue #590 where converting Oracle trace files does not find bind variables - test on Oracle 19c