### PR TITLE
Added use_bcp default as true and enabled bcp with windows authentication

### DIFF
--- a/config/mssqlserver.xml
+++ b/config/mssqlserver.xml
@@ -23,7 +23,7 @@
             <mssqls_imdb>false</mssqls_imdb>
             <mssqls_bucket>1</mssqls_bucket>
             <mssqls_durability>SCHEMA_AND_DATA</mssqls_durability>
-            <mssqls_use_bcp>false</mssqls_use_bcp>
+            <mssqls_use_bcp>true</mssqls_use_bcp>
         </schema>
         <driver>
             <mssqls_total_iterations>10000000</mssqls_total_iterations>

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -1282,7 +1282,11 @@ proc gettimestamp { } {
 # -b flag specifies batch size of 500000, -a flag specifies network packet size of 16000
 # network packet size depends on server configuration, default of 4096 is used if 16000 is not allowed
 proc bcpComm { tableName filePath uid pwd server} {
-    exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -c  -t ","
+    if {[ string toupper $authentication ] eq "WINDOWS" } {
+        exec bcp $tableName IN $filePath -b 500000 -a 16000 -T -S $server -c  -t ","
+    } else {
+        exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -c  -t ","
+    }
 }
 
 proc Customer { odbc d_id w_id CUST_PER_DIST } {

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -1282,6 +1282,7 @@ proc gettimestamp { } {
 # -b flag specifies batch size of 500000, -a flag specifies network packet size of 16000
 # network packet size depends on server configuration, default of 4096 is used if 16000 is not allowed
 proc bcpComm { tableName filePath uid pwd server} {
+    upvar 3 authentication authentication
     if {[ string toupper $authentication ] eq "WINDOWS" } {
         exec bcp $tableName IN $filePath -b 500000 -a 16000 -T -S $server -c  -t ","
     } else {

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -342,8 +342,6 @@ proc configmssqlstpcc {option} {
     bind .tpc.f1.r1 <ButtonPress-1> {
         .tpc.f1.e4 configure -state disabled
         .tpc.f1.e5 configure -state disabled
-        .tpc.f1.e12 configure -state disabled
-	set mssqls_use_bcp false
     }
     set Name $Parent.f1.r2
     if { $platform eq "lin" } {
@@ -355,7 +353,6 @@ proc configmssqlstpcc {option} {
     bind .tpc.f1.r2 <ButtonPress-1> {
         .tpc.f1.e4 configure -state normal
         .tpc.f1.e5 configure -state normal
-        .tpc.f1.e12 configure -state normal
     }
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
@@ -456,10 +453,6 @@ proc configmssqlstpcc {option} {
         ttk::checkbutton $Name -text "" -variable mssqls_use_bcp -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 19 -sticky e
         grid $Name -column 1 -row 19 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
-        $Name configure -state disabled
-	set mssqls_use_bcp false
-    }
     }
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {


### PR DESCRIPTION
The use_bcp option was by default set to false because bcp did not work through windows authentication. Bcp statement is now modified based on authentication type, with the -T flag used in place of a specified username and password when the connection is through windows authentication. This ensures that the bcp command will use the Windows logged in user's credentials. 