### PR TITLE
Version bump to 4.9

### DIFF
--- a/Docker/base/Dockerfile
+++ b/Docker/base/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip gnupg apt-utils libaio1 iputils-ping vim netcat libxft-dev libcairo2-dev xauth python3 && \
     rm -rf  /var/lib/apt/lists/*
 
-# Install configure HammerDB-v4.7
-ARG HAMMERDB_VERSION=4.8
+# Install configure HammerDB-v4.9
+ARG HAMMERDB_VERSION=4.9
 RUN wget https://github.com/TPC-Council/HammerDB/releases/download/v$HAMMERDB_VERSION/HammerDB-$HAMMERDB_VERSION-Linux.tar.gz -O - | \
     tar -xvzf - -C /home/ && \
     ln -s /home/HammerDB-$HAMMERDB_VERSION /home/hammerdb


### PR DESCRIPTION
Updating the HammerDB version to 4.9 for Docker builds.