### PR TITLE
Add optional purge and write back for MariaDB TPROC-C

### DIFF
--- a/config/mariadb.xml
+++ b/config/mariadb.xml
@@ -40,6 +40,7 @@
             <maria_async_verbose>false</maria_async_verbose>
             <maria_async_delay>1000</maria_async_delay>
             <maria_connect_pool>false</maria_connect_pool>
+            <maria_purge>false</maria_purge>
         </driver>
     </tpcc>
     <tpch>

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -2031,6 +2031,7 @@ set user \"$maria_user\" ;# Maria user
 set password \"$maria_pass\" ;# Password for the Maria user
 set db \"$maria_dbase\" ;# Database containing the TPC Schema
 set prepare \"$maria_prepared\" ;# Use prepared statements
+set purge \"$maria_purge\" ;# Purge undo when complete
 #EDITABLE OPTIONS##################################################
 "
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
@@ -2094,6 +2095,132 @@ proc ConnectToMaria { host port socket ssl_options user password db } {
     }
 }
 
+proc purge { maria_handler verbose } {
+            set pgmin_version "10.7.0"
+            set version [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]
+            if { [ package vcompare $version $pgmin_version ]  eq -1 } {
+            puts "Minimum MariaDB version for dynamic innodb_purge_threads is $pgmin_version, not purging"
+	    return
+            }
+	    if {[catch {set history_list_length [ list [ maria::sel $maria_handler "select variable_value from information_schema.global_status where variable_name = 'INNODB_HISTORY_LIST_LENGTH'" -list ]]}]} {
+		set history_list_length 0
+	    }
+	    puts "Starting purge: history list length $history_list_length"
+	    if { [ string is entier $history_list_length ] && $history_list_length > 0 } {
+	    if { $verbose } { puts "wait for transactions to settle before doing purge" }
+	    set commit_rate 101
+	    set old_com_comm 0
+	    while { $commit_rate > 100 } {
+	    if { $verbose } { puts "transaction rate @ $commit_rate" }
+            if {[catch {set transactions [ list [ maria::sel $maria_handler "show global status where Variable_name = 'Com_commit'" -list ] ]}]} {
+                puts stderr {error, failed to query transaction rate}
+                return
+            } else {
+                regexp {\{\{Com_commit\ ([0-9]+)\}\}} $transactions all com_comm
+                set commit_rate [ expr {$com_comm - $old_com_comm} ]
+		set old_com_comm $com_comm
+            }
+	    after 1000
+    	    }
+	    if { $verbose } { puts "transaction rate settled" }
+	    if { $verbose } { puts "starting purge history list length is $history_list_length" }
+	    if { $verbose } { puts "saving and setting purge settings" }
+            if {[ catch {mariaexec $maria_handler "SET @save_threads=@@innodb_purge_threads"}]} {puts stderr {error, saving purge_threads setting}}
+	    if { $verbose } { puts "saving batch size" }
+            if {[ catch {mariaexec $maria_handler "SET @save_batch=@@innodb_purge_batch_size"}]} {puts stderr {error, saving batch_size setting}}
+	    if { $verbose } { puts "setting purge threads" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_threads=32"}]} {puts stderr {error, setting purge_threads setting}}
+	     if { $verbose } { puts "setting batch size" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_batch_size=5000"}]} {puts stderr {error, setting batch_size setting}}
+	     if { $verbose } { puts "setting lag wait" }
+	     if { $verbose } { puts "waiting for history list length $history_list_length to reach 0" }
+	    set loop_counter 1
+	    set freezecount 0
+	    while { $history_list_length > 0 } {
+            set old_history_list $history_list_length
+	    if {[ catch {set history_list_length [ list [ maria::sel $maria_handler "select variable_value from information_schema.global_status where variable_name = 'INNODB_HISTORY_LIST_LENGTH'" -list ]]}]} {
+                puts stderr {error, failed to query history list}
+		break
+	    } 
+	    after 1000
+	    if { $old_history_list eq $history_list_length } {
+	    if { $verbose } { puts "history list has frozen for $freezecount" }
+	    incr freezecount
+	    if { $freezecount eq 10 } {
+	    puts "history list length $history_list_length has not reduced in 10 seconds, ending purge"
+	    break
+	    	}
+	    }
+	    incr loop_counter
+	    if {[expr {$loop_counter % 300}] eq 0} {
+	    puts "history list length $history_list_length"
+	    		}
+    		}
+	     if { $verbose } { puts "restoring purge settings" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_threads=@save_threads"}]} {puts stderr {error, restoring purge_threads setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_batch_size=@save_batch"}]} {puts stderr {error, restoring batch_size setting}}
+	    set purge_secs [expr { $loop_counter % 60 }]
+	    set purge_hrs  [expr { $loop_counter / 3600}]
+            set purge_mins [expr { ($loop_counter / 60) % 60 }]
+            puts [format "Purge complete in %d hrs:%02d mins:%02d secs" $purge_hrs $purge_mins $purge_secs]
+    	} else {
+		puts "History list is 0 or cannot be queried, not purging"
+	}
+	    if {[catch {set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]}]} {
+		set bp_pages_dirty 0
+	    }
+	    if { [ string is entier $bp_pages_dirty ] && $bp_pages_dirty > 0 } {
+	    puts "Starting write back: dirty buffer pages $bp_pages_dirty"
+	    if { $verbose } { puts "saving and setting write back settings" }
+            if {[ catch {mariaexec $maria_handler "SET @save_pct= @@GLOBAL.innodb_max_dirty_pages_pct"}]} {puts stderr {error, saving max_dirty_pages_pct setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_pct_lwm= @@GLOBAL.innodb_max_dirty_pages_pct_lwm"}]} {puts stderr {error, saving max_dirty_pages_pct_lwm setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_lru_flush_size= @@GLOBAL.innodb_lru_flush_size"}]} {puts stderr {error, saving lru_flush_size setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_lru_scan_depth= @@GLOBAL.innodb_lru_scan_depth"}]} {puts stderr {error, saving lru_scan_depth setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_io_capacity= @@GLOBAL.innodb_io_capacity"}]} {puts stderr {error, saving io_capacity setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_io_capacity_max= @@GLOBAL.innodb_io_capacity_max"}]} {puts stderr {error, saving io_capacity_max setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct=0.0"}]} {puts stderr {error, setting max_dirty_pages_pct setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0"}]} {puts stderr {error, setting max_dirty_pages_pct_lwm setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_flush_size=2048"}]} {puts stderr {error, setting lru_flush_size setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_scan_depth=4096"}]} {puts stderr {error, setting lru_scan_depth setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity=120000"}]} {puts stderr {error, setting io_capacity setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity_max=120000"}]} {puts stderr {error, setting io_capacity_max setting}}
+	    set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]
+	    set loop_counter 1
+	    set freezecount 0
+	    while { $bp_pages_dirty > 0 } {
+            set old_bp_pages_dirty $bp_pages_dirty
+	    set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]
+	    after 1000
+	    if { $old_bp_pages_dirty eq $bp_pages_dirty } {
+	    if { $verbose } { puts "dirty buffer pages has frozen for $freezecount" }
+	    incr freezecount
+	    if { $freezecount eq 10 } {
+	    puts "dirty buffer pages has not reduced in 10 seconds, ending write back"
+	    break
+	    	}
+	    }
+	    incr loop_counter
+	    if {[expr {$loop_counter % 300}] eq 0} {
+	    puts "dirty buffer pages $bp_pages_dirty"
+	    		}
+    		}
+	     if { $verbose } { puts "restoring write back settings" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct=@save_pct"}]} {puts stderr {error, restoring max_dirty_pages_pct setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct_lwm=@save_pct_lwm"}]} {puts stderr {error, restoring max_dirty_pages_pct_lwm setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_flush_size=@save_lru_flush_size"}]} {puts stderr {error, restoring lru_flush_size setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_scan_depth=@save_lru_scan_depth"}]} {puts stderr {error, restoring lru_scan_depth setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity=@save_io_capacity"}]} {puts stderr {error, restoring io_capacity setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity_max=@save_io_capacity_max"}]} {puts stderr {error, restoring io_capacity_max setting}}
+	    set wb_secs [expr { $loop_counter % 60 }]
+	    set wb_hrs  [expr { $loop_counter / 3600}]
+            set wb_mins [expr { ($loop_counter / 60) % 60 }]
+            puts [format "Write back complete in %d hrs:%02d mins:%02d secs" $wb_hrs $wb_mins $wb_secs]
+	    return
+    } else {
+                puts "Dirty buffer pool pages is 0 or cannot be queried, not writing back"
+        }
+}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2153,6 +2280,7 @@ switch $myposition {
             puts [ testresult $nopm $tpm MariaDB ]
             tsv::set application abort 1
             if { $mode eq "Primary" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
+	    if { $purge } { purge $maria_handler false }
             catch { mariaclose $maria_handler }
         } else {
             puts "Operating in Replica Mode, No Snapshots taken..."
@@ -2418,6 +2546,7 @@ set user \"$maria_user\" ;# Maria user
 set password \"$maria_pass\" ;# Password for the Maria user
 set db \"$maria_dbase\" ;# Database containing the TPC Schema
 set prepare \"$maria_prepared\" ;# Use prepared statements
+set purge \"$maria_purge\" ;# Purge undo when complete
 set async_client $maria_async_client;# Number of asynchronous clients per Vuser
 set async_verbose $maria_async_verbose;# Report activity of asynchronous clients
 set async_delay $maria_async_delay;# Delay in ms between logins of asynchronous clients
@@ -2534,6 +2663,132 @@ proc ConnectToMariaAsynch { host port socket ssl_options user password db client
     }
 }
 
+proc purge { maria_handler verbose } {
+            set pgmin_version "10.7.0"
+            set version [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]
+            if { [ package vcompare $version $pgmin_version ]  eq -1 } {
+            puts "Minimum MariaDB version for dynamic innodb_purge_threads is $pgmin_version, not purging"
+	    return
+            }
+	    if {[catch {set history_list_length [ list [ maria::sel $maria_handler "select variable_value from information_schema.global_status where variable_name = 'INNODB_HISTORY_LIST_LENGTH'" -list ]]}]} {
+		set history_list_length 0
+	    }
+	    puts "Starting purge: history list length $history_list_length"
+	    if { [ string is entier $history_list_length ] && $history_list_length > 0 } {
+	    if { $verbose } { puts "wait for transactions to settle before doing purge" }
+	    set commit_rate 101
+	    set old_com_comm 0
+	    while { $commit_rate > 100 } {
+	    if { $verbose } { puts "transaction rate @ $commit_rate" }
+            if {[catch {set transactions [ list [ maria::sel $maria_handler "show global status where Variable_name = 'Com_commit'" -list ] ]}]} {
+                puts stderr {error, failed to query transaction rate}
+                return
+            } else {
+                regexp {\{\{Com_commit\ ([0-9]+)\}\}} $transactions all com_comm
+                set commit_rate [ expr {$com_comm - $old_com_comm} ]
+		set old_com_comm $com_comm
+            }
+	    after 1000
+    	    }
+	    if { $verbose } { puts "transaction rate settled" }
+	    if { $verbose } { puts "starting purge history list length is $history_list_length" }
+	    if { $verbose } { puts "saving and setting purge settings" }
+            if {[ catch {mariaexec $maria_handler "SET @save_threads=@@innodb_purge_threads"}]} {puts stderr {error, saving purge_threads setting}}
+	    if { $verbose } { puts "saving batch size" }
+            if {[ catch {mariaexec $maria_handler "SET @save_batch=@@innodb_purge_batch_size"}]} {puts stderr {error, saving batch_size setting}}
+	    if { $verbose } { puts "setting purge threads" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_threads=32"}]} {puts stderr {error, setting purge_threads setting}}
+	     if { $verbose } { puts "setting batch size" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_batch_size=5000"}]} {puts stderr {error, setting batch_size setting}}
+	     if { $verbose } { puts "setting lag wait" }
+	     if { $verbose } { puts "waiting for history list length $history_list_length to reach 0" }
+	    set loop_counter 1
+	    set freezecount 0
+	    while { $history_list_length > 0 } {
+            set old_history_list $history_list_length
+	    if {[ catch {set history_list_length [ list [ maria::sel $maria_handler "select variable_value from information_schema.global_status where variable_name = 'INNODB_HISTORY_LIST_LENGTH'" -list ]]}]} {
+                puts stderr {error, failed to query history list}
+		break
+	    } 
+	    after 1000
+	    if { $old_history_list eq $history_list_length } {
+	    if { $verbose } { puts "history list has frozen for $freezecount" }
+	    incr freezecount
+	    if { $freezecount eq 10 } {
+	    puts "history list length $history_list_length has not reduced in 10 seconds, ending purge"
+	    break
+	    	}
+	    }
+	    incr loop_counter
+	    if {[expr {$loop_counter % 300}] eq 0} {
+	    puts "history list length $history_list_length"
+	    		}
+    		}
+	     if { $verbose } { puts "restoring purge settings" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_threads=@save_threads"}]} {puts stderr {error, restoring purge_threads setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_purge_batch_size=@save_batch"}]} {puts stderr {error, restoring batch_size setting}}
+	    set purge_secs [expr { $loop_counter % 60 }]
+	    set purge_hrs  [expr { $loop_counter / 3600}]
+            set purge_mins [expr { ($loop_counter / 60) % 60 }]
+            puts [format "Purge complete in %d hrs:%02d mins:%02d secs" $purge_hrs $purge_mins $purge_secs]
+    	} else {
+		puts "History list is 0 or cannot be queried, not purging"
+	}
+	    if {[catch {set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]}]} {
+		set bp_pages_dirty 0
+	    }
+	    if { [ string is entier $bp_pages_dirty ] && $bp_pages_dirty > 0 } {
+	    puts "Starting write back: dirty buffer pages $bp_pages_dirty"
+	    if { $verbose } { puts "saving and setting write back settings" }
+            if {[ catch {mariaexec $maria_handler "SET @save_pct= @@GLOBAL.innodb_max_dirty_pages_pct"}]} {puts stderr {error, saving max_dirty_pages_pct setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_pct_lwm= @@GLOBAL.innodb_max_dirty_pages_pct_lwm"}]} {puts stderr {error, saving max_dirty_pages_pct_lwm setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_lru_flush_size= @@GLOBAL.innodb_lru_flush_size"}]} {puts stderr {error, saving lru_flush_size setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_lru_scan_depth= @@GLOBAL.innodb_lru_scan_depth"}]} {puts stderr {error, saving lru_scan_depth setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_io_capacity= @@GLOBAL.innodb_io_capacity"}]} {puts stderr {error, saving io_capacity setting}}
+            if {[ catch {mariaexec $maria_handler "SET @save_io_capacity_max= @@GLOBAL.innodb_io_capacity_max"}]} {puts stderr {error, saving io_capacity_max setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct=0.0"}]} {puts stderr {error, setting max_dirty_pages_pct setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0"}]} {puts stderr {error, setting max_dirty_pages_pct_lwm setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_flush_size=2048"}]} {puts stderr {error, setting lru_flush_size setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_scan_depth=4096"}]} {puts stderr {error, setting lru_scan_depth setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity=120000"}]} {puts stderr {error, setting io_capacity setting}}
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity_max=120000"}]} {puts stderr {error, setting io_capacity_max setting}}
+	    set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]
+	    set loop_counter 1
+	    set freezecount 0
+	    while { $bp_pages_dirty > 0 } {
+            set old_bp_pages_dirty $bp_pages_dirty
+	    set bp_pages_dirty [ list [ maria::sel $maria_handler "SELECT variable_value FROM information_schema.global_status WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY'" -list ]]
+	    after 1000
+	    if { $old_bp_pages_dirty eq $bp_pages_dirty } {
+	    if { $verbose } { puts "dirty buffer pages has frozen for $freezecount" }
+	    incr freezecount
+	    if { $freezecount eq 10 } {
+	    puts "dirty buffer pages has not reduced in 10 seconds, ending write back"
+	    break
+	    	}
+	    }
+	    incr loop_counter
+	    if {[expr {$loop_counter % 300}] eq 0} {
+	    puts "dirty buffer pages $bp_pages_dirty"
+	    		}
+    		}
+	     if { $verbose } { puts "restoring write back settings" }
+             if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct=@save_pct"}]} {puts stderr {error, restoring max_dirty_pages_pct setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_max_dirty_pages_pct_lwm=@save_pct_lwm"}]} {puts stderr {error, restoring max_dirty_pages_pct_lwm setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_flush_size=@save_lru_flush_size"}]} {puts stderr {error, restoring lru_flush_size setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_lru_scan_depth=@save_lru_scan_depth"}]} {puts stderr {error, restoring lru_scan_depth setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity=@save_io_capacity"}]} {puts stderr {error, restoring io_capacity setting}}
+            if {[ catch {mariaexec $maria_handler "SET GLOBAL innodb_io_capacity_max=@save_io_capacity_max"}]} {puts stderr {error, restoring io_capacity_max setting}}
+	    set wb_secs [expr { $loop_counter % 60 }]
+	    set wb_hrs  [expr { $loop_counter / 3600}]
+            set wb_mins [expr { ($loop_counter / 60) % 60 }]
+            puts [format "Write back complete in %d hrs:%02d mins:%02d secs" $wb_hrs $wb_mins $wb_secs]
+	    return
+    } else {
+                puts "Dirty buffer pool pages is 0 or cannot be queried, not writing back"
+        }
+}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2593,6 +2848,7 @@ switch $myposition {
             puts [ testresult $nopm $tpm MariaDB ]
             tsv::set application abort 1
             if { $mode eq "Primary" } { eval [subst {thread::send -async $MASTER { remote_command ed_kill_vusers }}] }
+	    if { $purge } { purge $maria_handler false }
             catch { mariaclose $maria_handler }
         } else {
             puts "Operating in Replica Mode, No Snapshots taken..."

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -2150,6 +2150,8 @@ proc purge { maria_handler verbose } {
 	    puts "history list length $history_list_length has not reduced in 10 seconds, ending purge"
 	    break
 	    	}
+	    } else {
+	    set freezecount 0
 	    }
 	    incr loop_counter
 	    if {[expr {$loop_counter % 300}] eq 0} {
@@ -2198,6 +2200,8 @@ proc purge { maria_handler verbose } {
 	    puts "dirty buffer pages has not reduced in 10 seconds, ending write back"
 	    break
 	    	}
+	    } else {
+	    set freezecount 0
 	    }
 	    incr loop_counter
 	    if {[expr {$loop_counter % 300}] eq 0} {
@@ -2718,6 +2722,8 @@ proc purge { maria_handler verbose } {
 	    puts "history list length $history_list_length has not reduced in 10 seconds, ending purge"
 	    break
 	    	}
+	    } else {
+	    set freezecount 0
 	    }
 	    incr loop_counter
 	    if {[expr {$loop_counter % 300}] eq 0} {
@@ -2766,6 +2772,8 @@ proc purge { maria_handler verbose } {
 	    puts "dirty buffer pages has not reduced in 10 seconds, ending write back"
 	    break
 	    	}
+	    } else {
+	    set freezecount 0
 	    }
 	    incr loop_counter
 	    if {[expr {$loop_counter % 300}] eq 0} {

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -384,7 +384,7 @@ proc configmariatpcc {option} {
 
     #set variables to values in dict
     setlocaltpccvars $configmariadb
-    set tpccfields [ dict create tpcc {maria_user {.tpc.f1.e3 get} maria_pass {.tpc.f1.e4 get} maria_dbase {.tpc.f1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_no_stored_procs $maria_no_stored_procs maria_connect_pool $maria_connect_pool maria_history_pk $maria_history_pk} ]
+    set tpccfields [ dict create tpcc {maria_user {.tpc.f1.e3 get} maria_pass {.tpc.f1.e4 get} maria_dbase {.tpc.f1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_no_stored_procs $maria_no_stored_procs maria_connect_pool $maria_connect_pool maria_history_pk $maria_history_pk maria_purge $maria_purge} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
     set mariaconn [ dict create connection {maria_host {.tpc.f1.e1 get} maria_port {.tpc.f1.e2 get} maria_socket {.tpc.f1.e2a get} maria_ssl_ca {.tpc.f1.e2d get} maria_ssl_cert {.tpc.f1.e2e get} maria_ssl_key {.tpc.f1.e2f get} maria_ssl_cipher {.tpc.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} ]
@@ -747,12 +747,19 @@ proc configmariatpcc {option} {
         .tpc.f1.e16b configure -state disabled
         }
 
+	set Prompt $Parent.f1.p16c
+        ttk::label $Prompt -text "Purge when complete :"
+        set Name $Parent.f1.e16c
+        ttk::checkbutton $Name -text "" -variable maria_purge -onvalue "true" -offvalue "false"
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky w
+
         set Name $Parent.f1.e17
         set Prompt $Parent.f1.p17
         ttk::label $Prompt -text "Minutes of Rampup Time :"
         ttk::entry $Name -width 30 -textvariable maria_rampup
-        grid $Prompt -column 0 -row 29 -sticky e
-        grid $Name -column 1 -row 29 -sticky ew
+        grid $Prompt -column 0 -row 30 -sticky e
+        grid $Name -column 1 -row 30 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -762,8 +769,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p18
         ttk::label $Prompt -text "Minutes for Test Duration :"
         ttk::entry $Name -width 30 -textvariable maria_duration
-        grid $Prompt -column 0 -row 30 -sticky e
-        grid $Name -column 1 -row 30 -sticky ew
+        grid $Prompt -column 0 -row 31 -sticky e
+        grid $Name -column 1 -row 31 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -773,8 +780,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p19
         ttk::label $Prompt -text "Use All Warehouses :"
         ttk::checkbutton $Name -text "" -variable maria_allwarehouse -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 31 -sticky e
-        grid $Name -column 1 -row 31 -sticky ew
+        grid $Prompt -column 0 -row 32 -sticky e
+        grid $Name -column 1 -row 32 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -784,8 +791,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p20
         ttk::label $Prompt -text "Time Profile :"
         ttk::checkbutton $Name -text "" -variable maria_timeprofile -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 32 -sticky e
-        grid $Name -column 1 -row 32 -sticky ew
+        grid $Prompt -column 0 -row 33 -sticky e
+        grid $Name -column 1 -row 33 -sticky ew
 
         if {$maria_driver == "test" } {
             $Name configure -state disabled
@@ -795,8 +802,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p21
         ttk::label $Prompt -text "Asynchronous Scaling :"
         ttk::checkbutton $Name -text "" -variable maria_async_scale -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 33 -sticky e
-        grid $Name -column 1 -row 33 -sticky ew
+        grid $Prompt -column 0 -row 34 -sticky e
+        grid $Name -column 1 -row 34 -sticky ew
 
         if {$maria_driver == "test" } {
             set maria_async_scale "false"
@@ -823,8 +830,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p22
         ttk::label $Prompt -text "Asynch Clients per Virtual User :"
         ttk::entry $Name -width 30 -textvariable maria_async_client
-        grid $Prompt -column 0 -row 34 -sticky e
-        grid $Name -column 1 -row 34 -sticky ew
+        grid $Prompt -column 0 -row 35 -sticky e
+        grid $Name -column 1 -row 35 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             $Name configure -state disabled
@@ -834,8 +841,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p23
         ttk::label $Prompt -text "Asynch Client Login Delay :"
         ttk::entry $Name -width 30 -textvariable maria_async_delay
-        grid $Prompt -column 0 -row 35 -sticky e
-        grid $Name -column 1 -row 35 -sticky ew
+        grid $Prompt -column 0 -row 36 -sticky e
+        grid $Name -column 1 -row 36 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             $Name configure -state disabled
@@ -845,8 +852,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p24
         ttk::label $Prompt -text "Asynchronous Verbose :"
         ttk::checkbutton $Name -text "" -variable maria_async_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 36 -sticky e
-        grid $Name -column 1 -row 36 -sticky ew
+        grid $Prompt -column 0 -row 37 -sticky e
+        grid $Name -column 1 -row 37 -sticky ew
 
         if {$maria_driver == "test" || $maria_async_scale == "false" } {
             set maria_async_verbose "false"
@@ -857,8 +864,8 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p25
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable maria_connect_pool -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 37 -sticky e
-        grid $Name -column 1 -row 37 -sticky ew
+        grid $Prompt -column 0 -row 38 -sticky e
+        grid $Name -column 1 -row 38 -sticky ew
 
 	    if {$maria_connect_pool == "true" } {
         set maria_prepared "true"


### PR DESCRIPTION
Only compatible with MariaDB 10.7.1 and above where purge_threads are dynamic. 
Functionality is not possible to add to MySQL at the present time as innodb_purge_threads is a read only variable and functionality is dependent on setting purge_threads temporarily to a high value to accelerate the purge process. 

In the CLI the time for purge and write back with require a higher setting of keepalive_time. Plan to add a gdset command to set generic dict settings dynamically rather than only through XML to achieve this. 

Tested for both sync and async options

![purge](https://github.com/TPC-Council/HammerDB/assets/38044085/654fe275-596c-41e2-b57d-cbb3b879ad9c)
![purge2](https://github.com/TPC-Council/HammerDB/assets/38044085/07147f78-1915-4638-8b92-dbfb3a117474)
