### PR TITLE
Add check to vurun for pre-existing threads

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -1271,6 +1271,11 @@ proc deleteschema {} {
 }
 
 proc vurun {} {
+global threadscreated
+if { ![ info exists threadscreated ] && [expr [ llength [ threadnames_without_tcthread ] ] - 1 ] > 0} {
+        putscli "Error: Cannot call vurun with Virtual Users already active"
+	return
+	}
     global _ED opmode jobid
 
     set jobid [guid]


### PR DESCRIPTION
Fixes CLI error:
`Error: can't read "threadscreated(0)": no such variable`
and replaces with message:
`Error: Cannot call vurun with Virtual Users already active`

Fix checks if threadscreated() array exists (unset by vudestroy) but thread names check is greater than 0 meaning threads remain running. If this is the case vurun returns and does not run. 
In most cases this will be because keepalive_margin is shorter than the time for a thread to finish and can be resolved by increasing keepalive_margin. 

Example with fix:
```
Vuser 1:TEST RESULT : System achieved 12527 NOPM from 29070 MariaDB TPM
Vuser 1:Gathering timing data from Active Virtual Users...
29280 MariaDB tpm
Vuser 2:FINISHED SUCCESS
Vuser 1:Calculating timings...
Vuser 1:Writing timing data to /tmp/hdbxtprofile.log
Vuser 1:Starting purge: history list length 1919
1806 MariaDB tpm
doing vudestory
Transaction Counter thread running with threadid:tid0x7f85213ea700
Stopping Transaction Counter
Virtual Users remain running in background or shutting down, retry
Transaction Counter Started
doing vuset
Error: Virtual Users exist, destroy with vudestroy before changing settings
doing vucreate
Error: Virtual Users exist, destroy with vudestroy before creating
Transaction Counter thread running with threadid:tid0x7f85213ea700
doing vurun
Error: Cannot call vurun with Virtual Users already active
doing vudestory
Transaction Counter thread running with threadid:tid0x7f85213ea700
Stopping Transaction Counter
Virtual Users remain running in background or shutting down, retry
Transaction Counter thread already running with threadid:tid0x7f85213ea700
doing vuset
Error: Virtual Users exist, destroy with vudestroy before changing settings
doing vucreate
Error: Virtual Users exist, destroy with vudestroy before creating
Transaction Counter thread running with threadid:tid0x7f85213ea700
doing vurun
Error: Cannot call vurun with Virtual Users already active
doing vudestory
Transaction Counter thread running
Stopping Transaction Counter
0 MariaDB tpm
Virtual Users remain running in background or shutting down, retry
```