### PR TITLE
Add giset command to set generic dictionary settings

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -648,7 +648,7 @@ proc giset { args } {
                                 putscli "Changed $dct:$key2 from $previous to [ concat $val ] for generic"
                               	#Save new value to SQLite
                                 SQLiteUpdateKeyValue "generic" $dct $key2 $val
-                                remote_command [ concat diset $dct $key2 [ list \{$val\} ]]
+                                remote_command [ concat giset $dct $key2 [ list \{$val\} ]]
                         }}
                     		} else {
                         	putscli "Dictionary \"$dct\" exists but key \"$key2\" doesn't"

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -625,6 +625,41 @@ proc diset { args } {
                 }
 }}}}
 
+proc giset { args } {
+    global rdbms opmode
+    if {[ llength $args ] != 3} {
+        putscli "Error: Invalid number of arguments\nUsage: giset dict key value"
+        putscli "Type \"print generic\" for valid dictionaries and keys" 
+    } else {
+        set dct [ lindex $args 0 ]
+        set key2 [ lindex $args 1 ]
+        set val [ lindex $args 2 ]
+
+                upvar #0 genericdict genericdict
+                if {[dict exists $genericdict $dct ]} {
+                    if {[dict exists $genericdict $dct $key2 ]} {
+                        set previous [ dict get $genericdict $dct $key2 ]
+                        if { $previous eq [ concat $val ] } {
+                            putscli "Value $val for $dct:$key2 is the same as existing value $previous, no change made"
+                        } else {
+                            if { [catch {dict set genericdict $dct $key2 [ concat $val ] } message]} {
+                                putscli "Failed to set Dictionary value: $message"
+                            } else {
+                                putscli "Changed $dct:$key2 from $previous to [ concat $val ] for generic"
+                              	#Save new value to SQLite
+                                SQLiteUpdateKeyValue "generic" $dct $key2 $val
+                                remote_command [ concat diset $dct $key2 [ list \{$val\} ]]
+                        }}
+                    		} else {
+                        	putscli "Dictionary \"$dct\" exists but key \"$key2\" doesn't"
+                        	putscli "Type \"print generic\" for valid dictionaries and keys"
+                    	}
+                } else {
+                    putscli {Usage: giset dict key value}
+                    putscli "Type \"print generic\" for valid dictionaries and keys"
+                }
+}}
+
 proc librarycheck {} {
     upvar #0 dbdict dbdict
     dict for {database attributes} $dbdict {
@@ -724,12 +759,12 @@ proc dbset { args } {
 proc print { args } {
     global _ED rdbms bm virtual_users conpause delayms ntimes suppo optlog unique_log_name no_log_buffer log_timestamps gen_count_ware gen_scale_fact gen_directory gen_num_vu
     if {[ llength $args ] != 1} {
-        puts {Usage: print [db|bm|dict|script|vuconf|vucreated|vustatus|vucomplete|datagen|tcconf]}
+        puts {Usage: print [db|bm|dict|generic|script|vuconf|vucreated|vustatus|vucomplete|datagen|tcconf]}
     } else {
-        set ind [ lsearch {db bm dict script vuconf vucreated vustatus vucomplete datagen tcconf} $args ]
+        set ind [ lsearch {db bm dict generic script vuconf vucreated vustatus vucomplete datagen tcconf} $args ]
         if { $ind eq -1 } {
             puts "Error: invalid option"
-            puts {Usage: print [db|bm|dict|script|vuconf|vucreated|vustatus|vucomplete|datagen|tcconf]}
+            puts {Usage: print [db|bm|dict|generic|script|vuconf|vucreated|vustatus|vucomplete|datagen|tcconf]}
             return
         }
         switch $args {
@@ -773,6 +808,11 @@ proc print { args } {
                         pdict 2 $tmpdictforpt
                 }}
             }
+	    generic {
+                        puts "Generic Dictionary Settings"
+                upvar #0 genericdict genericdict
+                        pdict 2 $genericdict
+	    }
             vuconf {
                 foreach i { "Virtual Users" "User Delay(ms)" "Repeat Delay(ms)" "Iterations" "Show Output" "Log Output" "Unique Log Name" "No Log Buffer" "Log Timestamps" } j { virtual_users conpause delayms ntimes suppo optlog unique_log_name no_log_buffer log_timestamps } {
                     puts "$i = [ set $j ]"

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -8,7 +8,7 @@ proc help { args } {
     }
     set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
+        set helpcmds [ list buildschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript giset jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
     if {[ llength $args ] != 1} {
         puts $helpbanner
         foreach helpcmd $helpcmds { puts "\t$helpcmd" } 
@@ -55,11 +55,12 @@ Type \"help command\" for more details on specific commands below\n"
                     putscli "tcount: generate html chart for TPROC-C transaction count.\n"
                 }
                 print {
-                    putscli {print - Usage: print [db|bm|dict|script|vuconf|vucreated|vustatus|datagen|tcconf]}
+                    putscli {print - Usage: print [db|bm|dict|generic|script|vuconf|vucreated|vustatus|datagen|tcconf]}
                     putscli "prints the current configuration: 
 db: database 
 bm: benchmark
 dict: the dictionary for the current database, i.e. all active variables
+generic: the dictionary for generic settings
 script: the loaded script
 vuconf: the virtual user configuration
 vucreated: the number of virtual users created
@@ -89,6 +90,13 @@ tcconf: the transaction counter configuration"
 Example:
 hammerdb>diset tpcc count_ware 10
 Changed tpcc:count_ware from 1 to 10 for Oracle"
+                }
+                giset {
+                    putscli "giset - Usage: giset dict key value"
+                    putscli "Set the dictionary variables for the generic settings. Use \"print generic\" to see what these variables are and giset to change
+Example:
+hammerdb>giset commandline keepalive_margin 60
+Changed commandline:keepalive_margin from 10 to 60 for generic"
                 }
                 distributescript {
                     putscli "distributescript - Usage: distributescript"


### PR DESCRIPTION
Add giset command to modify generic dictionary settings and print generic to print the current settings out.
Modifications are persisted to the SQLite storage. 
Update has also been made to tclpy fork to keep commands in sync https://github.com/sm-shaw/libtclpy/commit/f53b1fcda14cc15707b100178006e512b1cff928
Examples of usage of both commands as shown.
```
hammerdb>giset commandline keepalive_margin 600
Changed commandline:keepalive_margin from 10 to 600 for generic
```

```
hammerdb>print generic
Generic Dictionary Settings
theme                {
 scaling        = auto
 scaletheme     = auto
 pixelsperpoint = auto
}
sqlitedb             {
 sqlitedb_dir = TMP
}
code_highlight       {
 highlight = true
}
benchmark            {
 rdbms        = Oracle
 bm           = TPC-C
 first_result = NOPM
}
virtual_user_options {
 virtual_users   = 1
 user_delay      = 500
 repeat_delay    = 500
 iterations      = 1
 show_output     = 1
 log_to_temp     = 0
 unique_log_name = 0
 no_log_buffer   = 0
 log_timestamps  = 0
}
autopilot            {
 apmode             = disabled
 autopilot_duration = 10
 autopilot_sequence = 1 2 4 8 12 16 20 24
}
mode                 {
 hostname = localhost
 id       = 0
}
transaction_counter  {
 tc_refresh_rate    = 10
 tc_log_to_temp     = 0
 tc_unique_log_name = 0
 tc_log_timestamps  = 0
 tc_graph_ribbon    = false
}
metrics              {
 agent_hostname = localhost
 agent_id       = 0
}
datageneration       {
 gen_count_ware = 1
 gen_scale_fact = 1
 gen_num_vu     = 1
}
commandline          {
 sqlite_db        = TMP
 keepalive_margin = 600
 jobsoutput       = JSON
 jobs_disable     = 0
}
webservice           {
 ws_port = 8080
}
timeprofile          {
 profiler           = xtprof
 xt_unique_log_name = 0
 xt_gather_timeout  = 10
 xt_job_storage     = 1
}
hdb_version          {
 version = v4.9
}
```