### PR TITLE
Add bcp -u option for SQL Server to trust the server certificate

### DIFF
--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -389,7 +389,6 @@ proc CreateDateScheme { odbc } {
         $odbc evaldirect $sql($i)
     }
 }
-
 # bcp command to copy from file to specified tables
 # -b flag specifies batch size of 500000, -a flag specifies network packet size of 16000
 # network packet size depends on server configuration, default of 4096 is used if 16000 is not allowed
@@ -398,7 +397,21 @@ proc bcpComm { tableName filePath uid pwd server} {
     if {[ string toupper $authentication ] eq "WINDOWS" } {
         exec bcp $tableName IN $filePath -b 500000 -a 16000 -T -S $server -c  -t "\\|"
     } else {
+    upvar #0 tcl_platform tcl_platform
+            if {$tcl_platform(platform) == "windows"} {
+#bcp on Windows uses ODBC driver 17 that does not support the -u option and may need updating when bcp driver changes
         exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -c  -t "\\|"
+        } else {
+#bcp on Linux can use ODBC driver 18 and trust the server certificate with -u option
+    upvar 3 trust_cert trust_cert
+    upvar 3 odbc_driver odbc_driver
+    regexp {ODBC\ Driver\ ([0-9]+)\ for\ SQL\ Server} $odbc_driver all odbc_version
+    if { $trust_cert && $odbc_version >= 18 } {
+        exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -u -c  -t "\\|"
+                } else {
+        exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -c  -t "\\|"
+           }
+        }
     }
 }
 


### PR DESCRIPTION
Adds -u option to bcp based builds when running on Linux with ODBC driver 18 and trust server certificate is checked to avoid `certificate verify failed:self signed certificate` error.
Tests on Windows showed bcp used ODBC 17 so change has not been added to Windows but may need to be in future. 

Noting that the long-term solution is to extend the ODBC interface that HammerDB uses to include bcp based commands https://github.com/TPC-Council/HammerDB/issues/594 as issues such as this are a direct result of calling the external tools i.e. we have already logged in and trusted the server certificate, however using the bcp executable means we need to do this again. 