### PR TITLE
Add schema and consistency checks for all databases for TPROC-C and TPROC-H

### DIFF
--- a/images/icons.tcl
+++ b/images/icons.tcl
@@ -513,6 +513,35 @@ gpnhAQ1w+2ZZwBLYmf0ZGDMfHYFLroK9QDRpDUQHGUWLwNUCGmCTaS8ZiJoTUGhSmSkdoAIGY4ii
 J6CWs6AAW/o7CN78s2vsgOnFtKMpuwZOdoAKmIDtB/Mg6wmiLfTAwUEK13MwEOwtaHTASgZaAUfR
 g8lRyEO3Q/StBGfO6qU77O1P8pfXeAfACjlJ4tupCQAAAABJRU5ErkJggg==
 }
+
+dict set icons thumbup {
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC6HpUWHRSYXcgcHJvZmlsZSB0eXBl
+IGV4aWYAAHja7ZZdstwoDIXfWUWWgCSExHIwP1XZwSw/B+z27b43M0lq5mWq2pQNFliSzyfTHcZf
+32f4hoNKjiGpeS45RxyppMIVA4/nUfaVYtrX6yY+Bi/2cE8wTIJezlur1/oKu3488IhBx6s9+DXD
+fjmi2/E+ZEVe4/6cJOx82ildjso4B7m4Pad6XI7atXCncp3pTuvs1n14MRhU6opAwjyEJO6rnxnI
+OpNU9IQri/Ia0bZIQIebyxkEeXm9W8D4LNCLyI9R+Kz+PfokPtfLLp+0zJdGGPx0gvSTXe4w/BxY
+7oz4dcL44eqryHN2n3Ocb1dThqL5qqgt9kOhtfCA5LIfy2iGUzG23QqaxxobkPfY4oHWqBCDygyU
+qFOlSWP3jRpSTDwYqTFzY9k2F+PCbRNLq9FkkyJdHPwajyACM9+50I5bdrxGjsidsJQJzgiP/G0L
+/zT5Jy3M2ZZEFP3WCnnxqmukscitK1YBCM2Lm26BH+3CH5/qB6UKgrpldrxgjcfp4lD6qC3ZnAXr
+FP35CVGwfjmARIitSAaVnihmEqVMqAc2IujoAFSROb4TPkCAVLkjSU4imYOx84qNZ4z2WlbOvMzY
+mwBCJYuBTZEKWCkp6seSo4aqiiZVzWrqQYvWLDllzTlbXptcNbFkatnM3IpVF0+unt3cvXgtXAR7
+oJZcrHgppVYOFYEqfFWsr7AcfMiRDj3yYYcf5agN5dNS05abNW+l1c5dOraJnrt176XXQWFgpxhp
+6MjDho8y6kStTZlp6szTps8y603tovql/QE1uqjxJrXW2U0N1mD2cEFrO9HFDMQ4EYjbIoCC5sUs
+OqXEi9xiFgvjo1BGkrrYhE6LGBCmQayTbnYf5H6LW1D/LW78K3JhofsvyAWg+8rtJ9T6+p1rm9j5
+FS5No+Dra9DBa8DvWVyDf9u/Hb0dvR29Hb0dvR29Hf3vHQn+OpTwAwxwm/2zVSPkAAABhmlDQ1BJ
+Q0MgcHJvZmlsZQAAeJx9kT1Iw1AUhU9bpVIqDnZQcchQnSyIioqTVqEIFUKt0KqDyUv/oElDkuLi
+KLgWHPxZrDq4OOvq4CoIgj8gzg5Oii5S4n1JoUWMFx7v47x7Du/dB/jrZaaaHaOAqllGKhEXMtlV
+IfgKH/oRwgymJGbqc6KYhGd93VM31V2MZ3n3/VndSs5kgE8gnmW6YRFvEE9uWjrnfeIIK0oK8Tnx
+iEEXJH7kuuzyG+eCw36eGTHSqXniCLFQaGO5jVnRUIkniKOKqlG+P+OywnmLs1qusuY9+QvDOW1l
+meu0BpHAIpYgQoCMKkoow0KMdo0UEyk6j3v4Bxy/SC6ZXCUwciygAhWS4wf/g9+zNfPjY25SOA50
+vtj2xxAQ3AUaNdv+PrbtxgkQeAautJa/UgemP0mvtbToEdCzDVxctzR5D7jcAfqedMmQHClAy5/P
+A+9n9E1ZoPcWCK25c2ue4/QBSNOskjfAwSEwXKDsdY93d7XP7d+e5vx+AOg2ctaGhDJWAAAABmJL
+R0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH6AEZCwMO5nKTzwAAAKRJ
+REFUOMulkjEKwjAYhb9IoSA4OFjo7hFcvUwQD9HBe3gGoVMRHdx0Em/RTejcrV1+SgnNT9O8JS/h
+5SO8/MZai6IUeAMtcJwKJOg6AQeg9gVWyuU1cBF/XwI4A5n4RyhgAxSj/ScEsAWuwG50tvcBEqAT
+b2RtJnLuC35SrtqBpnxOiZqqWEAZA/gDzxhAOXeQfLrFAL7Ay50D44RMCHHpLwzqAUBwEx8B9wFx
+AAAAAElFTkSuQmCCi
+}
 return [ set icons ]
 }
 
@@ -845,6 +874,36 @@ YjFwD7ncffc3bmr56axgWUADTN+IAkrgKPcbMGSCDsA9l8EpQpLRFqgNZIi6GngooAF2mfKCQJJz
 AFwyclNLCVwkuo0WgE3UBaACesADFCZ1PetomCBY58XGuAfGN92uJe0KuGoDE2AEDh+c+ygzSCqh
 A84G4kzNXiDoFHSRdBopTW/AL3ptoi3FZ5xn+sI8drokf/mNT0IHPSwVihKdAAAAAElFTkSuQmCC
 }
+
+dict set icons thumbup {
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC9XpUWHRSYXcgcHJvZmlsZSB0eXBl
+IGV4aWYAAHja7ZddltwoDIXfWUWWgCSExHIwmHNmB7P8XPBPV3V3ks5MHvJQ5hiwACHfT6a6w/7v
+PyN8w0Ulp5DUPJecI65UUuGKjsfjKqummFZ9PsSr82QP9wDDJGjleLR6zq+w69uCaw/anu3BzxH2
+09Hl+XQoc2dGpz8GCTsfdkqno7IfnVzcHkPd+GjbOXGFct5iy/XtZD6HR0MyqNQVs4R5F5K4aj8i
+kHknqWgJNYvy7NGyWEBDcqkIQZ5e7xYwPgr0JPLVC+/Vv3vvxOd62uWdlvnUCJ1PB0g/F39J/LCx
+3BHx84Dp5eqjyGN0H2M/3q6mDEXzmVExXOrMNZi4QXJZyzKK4Vb0bZWC4rHGBjg9trihNCrEEHkE
+StSp0qB9tY0aQky8s6FlbizL5mJcuC1iaRYabFKki4Nf4z2IwMx3LLT2LWu/Ro6dO2EqE5wRlvyw
+hJ8N/k4JY7QpEUW/tUJcPDMXYUxys8YsAKFxctMl8FVO/PEhf5CqIKhLZscL1rgdLjalt9ySxVkw
+T9EeXwUF66cDSIS9FcEg7RPFTKKUKRqzEUFHB6CKyPGd8AYCpModQXISyRyMnefeWGO05rJy5mnG
+2QQQKlkMbIpUwEpJkT+WHDlUVTSpalZTD1q0Zskpa87Z8jzkqoklU8tm5lasunhy9ezm7sVr4SI4
+A7XkYsVLKbVyqNiowlfF/ArLxptsadMtb7b5VrbakD4tNW25WfNWWu3cpeOY6Llb91563SnsOCn2
+tOued9t9L3sdyLUhIw0dedjwUUa9qZ1UP5TfoEYnNV6k5jy7qcEazC4XNI8TncxAjBOBuE0CSGie
+zKJTSjzJTWaxMD4KZQSpk03oNIkBYdqJddDN7o3cl7gF9S9x41+RCxPdnyAXgO4jt0+o9fk71xax
+4yucmkbB19elstfA24AII6U4H/Hr9h/bEP+ng5ejl6OXo5ejl6OXo5ejv8OR4A8I/CMbvgOtAp48
+s9kJRwAAAYVpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNQFIVPW0tFKw52UBHMUJ0siIo4ahWKUCHU
+Cq06mLz0D5o0JCkujoJrwcGfxaqDi7OuDq6CIPgD4uzgpOgiJd6XFFrEeOHxPs675/DefYC/Xmaq
+2TEOqJplpBJxIZNdFUKv8GEA3QhiWGKmPieKSXjW1z11U93FeJZ335/Vo+RMBvgE4lmmGxbxBvH0
+pqVz3ieOsKKkEJ8Tjxl0QeJHrssuv3EuOOznmREjnZonjhALhTaW25gVDZV4ijiqqBrl+zMuK5y3
+OKvlKmvek78wnNNWlrlOawgJLGIJIgTIqKKEMizEaNdIMZGi87iHf9Dxi+SSyVUCI8cCKlAhOX7w
+P/g9WzM/OeEmheNA8MW2P0aA0C7QqNn297FtN06AwDNwpbX8lTow80l6raVFj4DebeDiuqXJe8Dl
+DtD/pEuG5EgBWv58Hng/o2/KAn23QNeaO7fmOU4fgDTNKnkDHBwCowXKXvd4d2f73P7tac7vByq0
+corZE69qAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH6AEZ
+CwcMbBA35wAAAKNJREFUOMulkjEKgzAYhb+IUCg4dKjg7hG6epvSO7RD79EzCE5S7NBNJ+kt3Aqd
+u9nlp0gwP8a8JS/h5SO8/GY8o2kDtMAXKOYCMbqOwAEYXIFIubwFruLvawAnIBXf+AIS4DLZdz6A
+HXAD9pOz3AWIgVG8kfUzk7Nf8JJy1Q40ZUtK1FSHAqoQwBt4hACqpYPkUhkC6IGnPQfGChkf4tpf
++OsHjfoTcXtQkNoAAAAASUVORK5CYII=i
+}
+
 return [ set icons ]
 }
 
@@ -3461,6 +3520,63 @@ dict set iconssvg deletesvg {
      d="M2 0l-2 3 2 3h6v-6h-6zm1.5.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
 </svg>
 }
+dict set iconssvg thumbupsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="thumb-up-g.svg"
+   id="svg865"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata871">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs869" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg865"
+     inkscape:window-maximized="0"
+     inkscape:window-y="63"
+     inkscape:window-x="57"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview867"
+     inkscape:window-height="863"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#626262;fill-opacity:1"
+     id="path863"
+     d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z" />
+</svg>
+}
 return [ set iconssvg ]
 }
 
@@ -5664,6 +5780,63 @@ dict set iconssvg deletesvg {
      id="path20"
      transform="translate(0 1)"
      d="M2 0l-2 3 2 3h6v-6h-6zm1.5.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
+</svg>
+}
+dict set iconssvg thumbupsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="thumb-up-o.svg"
+   id="svg865"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata871">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs869" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg865"
+     inkscape:window-maximized="0"
+     inkscape:window-y="63"
+     inkscape:window-x="57"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview867"
+     inkscape:window-height="863"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ff7900;fill-opacity:1"
+     id="path863"
+     d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z" />
 </svg>
 }
 return [ set iconssvg ]

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -932,6 +932,8 @@ namespace eval jobs {
           set jobtype "Schema Build"
         } elseif { [ string match "*Do you want to delete*" $output ] } {
           set jobtype "Schema Delete"
+        } elseif { [ string match "*Do you want to check*" $output ] } {
+          set jobtype "Schema Check"
         } else {
           set jobtype "Benchmark Run"
         }

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1332,7 +1332,7 @@ proc check_tpch { dbase user password scale_factor } {
         }
 	#Consistency check
         puts "Check consistency"
-	   set stmnt_handle1 [ db2_select_direct $db_handle "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(trunc(trunc(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)) part_res FROM orders, lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" ]
+	   set stmnt_handle1 [ db2_select_direct $db_handle "SELECT * FROM (SELECT o_orderkey, decimal(decimal(o_totalprice,20,2) - decimal(SUM(trunc(trunc(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)),20,2),20,1) part_res FROM orders, lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" ]
             set output [ db2_fetchrow $stmnt_handle1 ]
             if { $output != "" } {
 		    puts "output is $output"

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -8,7 +8,7 @@ proc help { args } {
     }
     set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript giset jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
+        set helpcmds [ list buildschema checkschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript giset jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
     if {[ llength $args ] != 1} {
         puts $helpbanner
         foreach helpcmd $helpcmds { puts "\t$helpcmd" } 
@@ -113,6 +113,10 @@ Changed commandline:keepalive_margin from 10 to 60 for generic"
                 buildschema {
                     putscli "buildschema - Usage: buildschema"
                     putscli "Runs the schema build for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Build command in the graphical interface." 
+                }
+                checkschema {
+                    putscli "checkschema - Usage: checkschema"
+                    putscli "Runs the schema consistency check for the database and benchmark selected with dbset and variables selected with diset. Equivalent to the Check command in the graphical interface." 
                 }
                 deleteschema {
                     putscli "deleteschema - Usage: deleteschema"

--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -226,6 +226,10 @@ proc load_virtual {}  {
     if { $result != -1 }  {
         set virtual_users $maxvuser
 	} else {
+    set result [ lsearch [ lindex [ split [ join [ stacktrace ] ] ] ] "check_schema" ]
+    if { $result != -1 }  {
+        set virtual_users $maxvuser
+	} else {
         #Find if workload test or timed set when script is loaded as lprefix
         set maxvuser $virtual_users
         if { $lprefix eq "loadtimed" } {
@@ -233,12 +237,15 @@ proc load_virtual {}  {
             set suppo 1
         } else { ; }        
 	}
+      }
     } 
     #Moved to running of virtual users
     #disable_enable_options_menu disable
     set Name .ed_mainFrame.buttons.datagen 
     $Name configure -state disabled
     set Name .ed_mainFrame.buttons.boxes 
+    $Name configure -state disabled
+    set Name .ed_mainFrame.buttons.thumbup 
     $Name configure -state disabled
     set Name .ed_mainFrame.buttons.delete 
     $Name configure -state disabled
@@ -542,6 +549,8 @@ proc ed_kill_vusers {args} {
     set Name .ed_mainFrame.buttons.datagen 
     $Name configure -state normal
     set Name .ed_mainFrame.buttons.boxes 
+    $Name configure -state normal
+    set Name .ed_mainFrame.buttons.thumbup 
     $Name configure -state normal
     set Name .ed_mainFrame.buttons.delete 
     $Name configure -state normal

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1652,7 +1652,7 @@ set library $library
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
 if [catch {package require $library} message] { error "Failed to load $library - $message" }
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
-if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+if [catch {package require tpchcommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpchcommon::* }
 
 proc chk_socket { host socket } {
     if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1614,3 +1614,153 @@ proc drop_schema { host port socket ssl_options user password dbase } {
     } else { return }
 }
 
+proc check_mariatpch {} {
+    global maxvuser suppo ntimes threadscreated _ED maria_ssl_options
+    upvar #0 dbdict dbdict
+
+    if {[dict exists $dbdict maria library ]} {
+        set library [ dict get $dbdict maria library ]
+    } else {
+        set library "mariatcl" 
+    }
+
+    upvar #0 configmariadb configmariadb
+    #set variables to values in dict
+    setlocaltpchvars $configmariadb
+    #If the options menu has been run under the GUI maria_ssl_options is set
+    #If build is run under the GUI, CLI or WS maria_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb } 
+    if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { 
+        set maria_connector "$maria_host:$maria_port" 
+    }
+
+    if {[ tk_messageBox -title "Check Schema" -icon question -message "Do you want to check the [ string toupper $maria_tpch_dbase ] TPROC-H schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_tpch_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-H check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread for schema check: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
+if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMaria { host port socket ssl_options user password } {
+    global mariastatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+	set use_socket "true"
+	append connectstring " -socket $socket"
+	 } else {
+	set use_socket "false"
+	append connectstring " -host $host -port $port"
+	}
+	foreach key [ dict keys $ssl_options ] {
+	append connectstring " $key [ dict get $ssl_options $key ] "
+	}
+	append connectstring " -user $user -password $password"
+	set login_command "mariaconnect [ dict get $connectstring ]"
+	#eval the login command
+        if [catch {set maria_handler [eval $login_command]}] {
+		if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+    } else {
+            puts "the tcp connection to $host:$port could not be established"
+    }
+        set connected "false"
+        } else {
+        set connected "true"
+        }
+    if {$connected} {
+        maria::autocommit $maria_handler 0
+	catch {set ssl_status [ maria::sel $maria_handler "show session status like 'ssl_cipher'" -list ]}
+	if { [ info exists ssl_status ] } {
+	puts [ join $ssl_status ]
+	}
+        return $maria_handler
+    } else {
+        error $mariastatus(message)
+        return
+    }
+}
+
+proc check_tpch { host port socket ssl_options user password dbase scale_factor } {
+    global mariastatus
+    puts "Checking $dbase TPROC-H schema"
+    set tables [ dict create supplier [ expr {$scale_factor * 10000} ] customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 ]
+    set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
+   #Check 1 Database Exists
+    puts "Check database"
+        set db_exists [ maria::sel $maria_handler "select schema_name from information_schema.schemata where schema_name = '$dbase'" -flatlist  ]
+	if { [ string length $db_exists ] > 0 } {
+        mariause $maria_handler $dbase
+        set table_exists [ maria::sel $maria_handler "show tables" -flatlist  ]
+	if {[ llength $table_exists ] == 0 } {
+	error "TPROC-H Schema check failed $dbase schema is empty"
+	} else {
+	#Check 2 Tables Exist
+	puts "Check tables and indices"
+	foreach table [dict keys $tables] {
+	set match [ lsearch $table_exists $table ]
+	if { $match == -1 } {
+	error "TPROC-H Schema check failed $dbase schema is missing table $table"
+	} else {
+	if { $table eq "supplier" } {
+	#Check 3 scale factor in schema is the same as dict setting
+        set count [  maria::sel $maria_handler "select count(*) from supplier" -flatlist ]
+	if { $count } {
+        set actual_scale_factor [ expr {$count / 10000} ]
+        if { $actual_scale_factor != $scale_factor } {
+	error "TPROC-H Schema check failed $dbase schema scale factor $actual_scale_factor does not equal dict scale factor if $scale_factor"
+        }
+        }
+	}
+        #Check 4 Tables are indexed
+    	set is_indexed [  maria::sel $maria_handler "show index from $table" -flatlist ]
+        if { [ llength $is_indexed ] eq 0 } {
+	error "TPROC-H Schema check failed $dbase schema on table $table no indices"
+	}
+	#Check 5 Tables are populated
+	set expected_rows [ dict get $tables $table ]
+        set row_count [  maria::sel $maria_handler "select count(*) from $table" -flatlist ]
+        if { $row_count < $expected_rows } {
+	error "TPROC-H Schema check failed $dbase schema on table $table row count of $row_count is less than expected count of $expected_rows"
+	} 
+	}
+	}
+        #Consistency check
+	puts "Check consistency"
+    	set checkconsistency [  maria::sel $maria_handler "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(truncate(truncate(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)) part_res FROM orders, lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" -flatlist ]
+	if {[ llength $checkconsistency ] > 0} {
+	error "TPROC-H Schema check failed $dbase schema consistency check failed"
+	} 
+	}
+	#Consistency check completed
+        puts "$dbase TPROC-H Schema has been checked successfully."
+	} else {
+	error "Schema check failed $dbase TPROC-H schema does not exist"
+	}
+    mariaclose $maria_handler
+    return
+}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_tpch_user [ quotemeta $maria_tpch_pass ] $maria_tpch_dbase $maria_scale_fact"
+    } else { return }
+}

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -3239,3 +3239,191 @@ proc drop_schema { host port socket ssl_options user password dbase } {
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_user [ quotemeta $maria_pass ] $maria_dbase"
     } else { return }
 }
+
+proc check_mariatpcc {} {
+    global maxvuser suppo ntimes threadscreated _ED maria_ssl_options
+    upvar #0 dbdict dbdict
+
+    if {[dict exists $dbdict maria library ]} {
+        set library [ dict get $dbdict maria library ]
+    } else {
+        set library "mariatcl" 
+    }
+
+    upvar #0 configmariadb configmariadb
+    #set variables to values in dict
+    setlocaltpccvars $configmariadb
+    #If the options menu has been run under the GUI maria_ssl_options is set
+    #If build is run under the GUI, CLI or WS maria_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists maria_ssl_options ] { check_maria_ssl $configmariadb } 
+    if { ![string match windows $::tcl_platform(platform)] && ($maria_host eq "127.0.0.1" || [ string tolower $maria_host ] eq "localhost") && [ string tolower $maria_socket ] != "null" } { set maria_connector "$maria_host:$maria_socket" } else { 
+        set maria_connector "$maria_host:$maria_port" 
+    }
+
+    if {[ tk_messageBox -title "Check Schema" -icon question -message "Do you want to check the [ string toupper $maria_dbase ] TPROC-C schema\n in host [string toupper $maria_connector] under user [ string toupper $maria_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-C check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread for schema check: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
+if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMaria { host port socket ssl_options user password } {
+    global mariastatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+	set use_socket "true"
+	append connectstring " -socket $socket"
+	 } else {
+	set use_socket "false"
+	append connectstring " -host $host -port $port"
+	}
+	foreach key [ dict keys $ssl_options ] {
+	append connectstring " $key [ dict get $ssl_options $key ] "
+	}
+	append connectstring " -user $user -password $password"
+	set login_command "mariaconnect [ dict get $connectstring ]"
+	#eval the login command
+        if [catch {set maria_handler [eval $login_command]}] {
+		if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+    } else {
+            puts "the tcp connection to $host:$port could not be established"
+    }
+        set connected "false"
+        } else {
+        set connected "true"
+        }
+    if {$connected} {
+        maria::autocommit $maria_handler 0
+	catch {set ssl_status [ maria::sel $maria_handler "show session status like 'ssl_cipher'" -list ]}
+	if { [ info exists ssl_status ] } {
+	puts [ join $ssl_status ]
+	}
+        return $maria_handler
+    } else {
+        error $mariastatus(message)
+        return
+    }
+}
+
+proc check_tpcc { host port socket ssl_options user password dbase count_ware } {
+    global mariastatus
+    puts "Checking $dbase TPROC-C schema"
+    set tables [ dict create warehouse $count_ware customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000 * 0.90} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] ]
+    set sps [ list delivery neword ostat payment slev ]
+    set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password ]
+   #Check 1 Database Exists
+    puts "Check database"
+        set db_exists [ maria::sel $maria_handler "select schema_name from information_schema.schemata where schema_name = '$dbase'" -flatlist  ]
+	if { [ string length $db_exists ] > 0 } {
+            mariause $maria_handler $dbase
+        set table_exists [ maria::sel $maria_handler "show tables" -flatlist  ]
+	if {[ llength $table_exists ] == 0 } {
+	error "TPROC-C Schema check failed $dbase schema is empty"
+	} else {
+	#Check 2 Tables Exist
+	puts "Check tables and indices"
+	foreach table [dict keys $tables] {
+	set match [ lsearch $table_exists $table ]
+	if { $match == -1 } {
+	error "TPROC-C Schema check failed $dbase schema is missing table $table"
+	} else {
+	if { $table eq "warehouse" } {
+	#Check 3 Warehouse count in schema is the same as dict setting
+        set w_id_input [  maria::sel $maria_handler "select max(w_id) from warehouse" -flatlist ]
+	if { $count_ware != $w_id_input } {
+	error "TPROC-C Schema check failed $dbase schema warehouse count $w_id_input does not equal dict warehouse count of $count_ware"
+	}
+	}
+        #Check 4 Tables are indexed
+    	set is_indexed [  maria::sel $maria_handler "show index from $table" -flatlist ]
+        if { [ llength $is_indexed ] eq 0 } {
+	if { $table != "history" } {
+	error "TPROC-C Schema check failed $dbase schema on table $table no indices"
+		}
+	}
+	#Check 5 Tables are populated
+	set expected_rows [ dict get $tables $table ]
+        set row_count [  maria::sel $maria_handler "select count(*) from $table" -flatlist ]
+        if { $row_count < $expected_rows } {
+	error "TPROC-C Schema check failed $dbase schema on table $table row count of $row_count is less than expected count of $expected_rows"
+	} 
+	}
+	}
+        }
+        #Check 6 Stored Procedures Exist
+	puts "Check procedures"
+	foreach sp $sps {
+        set sp_exists [ maria::sel $maria_handler "show create procedure $sp" -flatlist  ]
+        if {  [ llength $sp_exists ] == 0 } {
+	error "TPROC-C Schema check failed $dbase schema is missing stored procedure $sp"
+	} 
+	}
+        #Create temporary sample table
+	mariaexec $maria_handler "create or replace temporary table `temp_w` (`t_w_id` smallint null)"
+	if { $w_id_input <= 10 } {
+	for  {set i 1} {$i <= $w_id_input} { incr i} {
+ 	mariaexec $maria_handler "insert into temp_w values ($i)"
+	}
+	} else {
+	foreach statement {{insert into temp_w values (1)} {insert into temp_w values ([expr {0.1 * $w_id_input}])} {insert into temp_w values ([expr {0.2 * $w_id_input}])} {insert into temp_w values ([expr {0.3 * $w_id_input}])} {insert into temp_w values ([expr {0.4 * $w_id_input}])} {insert into temp_w values ([expr {0.5 * $w_id_input}])} {insert into temp_w values ([expr {0.6 * $w_id_input}])} {insert into temp_w values ([expr {0.7 * $w_id_input}])} {insert into temp_w values ([expr {0.8 * $w_id_input}])} {insert into temp_w values ([expr {0.9 * $w_id_input}])} {insert into temp_w values ($w_id_input)}} {
+	mariaexec $maria_handler [ subst $statement ]
+	}
+	}
+	   #Consistency check 1
+	puts "Check consistency 1"
+	set rows [ maria::sel $maria_handler "select d_w_id, (w_ytd - sum(d_ytd)) diff from warehouse, district where d_w_id=w_id group by d_w_id, w_ytd having (w_ytd - sum(d_ytd)) != 0" -flatlist ]
+	if {[ llength $rows ] > 0} {
+	error "TPROC-C Schema check failed $dbase schema consistency check 1 failed"
+	} 
+	   #Consistency check 2
+	puts "Check consistency 2"
+	set rows [ maria::sel $maria_handler "select * from (select d_w_id, d_id, max(o_id) AS ORDER_MAX, (d_next_o_id - 1) AS ORDER_NEXT from district, orders where d_w_id = o_w_id and d_id = o_d_id and d_w_id in (select t_w_id from temp_w) group by d_w_id, d_id, (d_next_o_id - 1)) dt where dt.ORDER_NEXT != dt.ORDER_MAX" -flatlist ]
+	if {[ llength $rows ] > 0} {
+	error "TPROC-C Schema check failed $dbase schema consistency check 2 failed"
+	} 
+	   #Consistency check 3
+	puts "Check consistency 3"
+	set rows [ maria::sel $maria_handler "select * from (select count(*) as nocount, (max(no_o_id) - min(no_o_id) + 1) as total from new_order group by no_w_id, no_d_id) dt where nocount != total" -flatlist ]
+	if {[ llength $rows ] > 0} {
+	error "TPROC-C Schema check failed $dbase schema consistency check 3 failed"
+	} 
+	   #Consistency check 4
+	puts "Check consistency 4"
+	set rows [ maria::sel $maria_handler "select * from (select o_w_id, o_d_id, sum(o_ol_cnt) as ol_sum from orders, temp_w where o_w_id = t_w_id group by o_w_id, o_d_id) consist1, (select ol_w_id, ol_d_id, count(*) as ol_count from order_line, temp_w where ol_w_id = t_w_id group by ol_w_id, ol_d_id) consist2 where o_w_id = ol_w_id and o_d_id = ol_d_id and ol_sum != ol_count" -flatlist ]
+	if {[ llength $rows ] > 0} {
+	error "TPROC-C Schema check failed $dbase schema consistency check 4 failed"
+	} 
+	mariaexec $maria_handler "drop table `temp_w`"
+        puts "$dbase TPROC-C Schema has been checked successfully."
+	} else {
+	error "Schema check failed $dbase TPROC-C schema does not exist"
+	}
+    mariaclose $maria_handler
+    return
+}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpcc $maria_host $maria_port $maria_socket {$maria_ssl_options} $maria_user [ quotemeta $maria_pass ] $maria_dbase $maria_count_ware"
+    } else { return }
+}

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -2136,7 +2136,7 @@ proc connect_string { server port odbc_driver authentication uid pwd tcp azure d
 
 proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert scale_factor } {
 	puts "Checking $db TPROC-H schema"
-    set tables [ dict create supplier [ expr {$scale_factor * 10000} ] customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
+    set tables [ dict create supplier [ expr {$scale_factor * 10000} ] customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 ]
     set connection [ connect_string $server $port $odbc_driver $authentication $uid $pwd $tcp $azure tempdb $encrypt $trust_cert ]
     if [catch {tdbc::odbc::connection create odbc $connection} message ] {
         error "Connection to $connection could not be established : $message"

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -2143,6 +2143,7 @@ proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db en
     } else {
 	    if {!$azure} {odbc evaldirect "use tempdb"}
 	    #Check 1 Database Exists
+        puts "Check database"
     set rows [ odbc allrows "IF DB_ID('$db') is not null SELECT 1 AS res ELSE SELECT 0 AS res" ]
     set db_exists [ lindex {*}$rows 1 ]
     if { $db_exists } {
@@ -2153,6 +2154,7 @@ proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db en
 	error "TPROC-H Schema check failed $db schema is empty"
 	} else {
 	    #Check 2 Tables Exist
+	puts "Check tables and indices"
 	foreach table [dict keys $tables] {
     	set rows [ odbc allrows "IF OBJECT_ID (N'$table', N'U') IS NOT NULL SELECT 1 AS res ELSE SELECT 0 AS res" ]
         set table_exists [ lindex {*}$rows 1 ]
@@ -2185,6 +2187,7 @@ proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db en
 	}
 }
 	   #Consistency check
+	puts "Check consistency"
 	set rows [ odbc allrows "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(round(round(l_extendedprice * (1 - l_discount),2,1) * (1 + l_tax),2,1)) part_res FROM orders, lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" ]
 	if {[ llength $rows ] > 0} {
 	error "TPROC-H Schema check failed $db schema consistency check failed"

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -2136,7 +2136,7 @@ proc connect_string { server port odbc_driver authentication uid pwd tcp azure d
 
 proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert scale_factor } {
 	puts "Checking $db TPROC-H schema"
-    set tables [ dict create customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
+    set tables [ dict create supplier [ expr {$scale_factor * 10000} ] customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
     set connection [ connect_string $server $port $odbc_driver $authentication $uid $pwd $tcp $azure tempdb $encrypt $trust_cert ]
     if [catch {tdbc::odbc::connection create odbc $connection} message ] {
         error "Connection to $connection could not be established : $message"

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -2078,3 +2078,128 @@ return
 	 .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpch {$mssqls_server} $mssqls_port {$mssqls_odbc_driver} $mssqls_authentication $mssqls_uid [ quotemeta $mssqls_pass ] $mssqls_tcp $mssqls_azure $mssqls_tpch_dbase $mssqls_encrypt_connection $mssqls_trust_server_cert"
     } else { return }
 }
+
+proc check_mssqlstpch {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict mssqlserver library ]} {
+        set library [ dict get $dbdict mssqlserver library ]
+    } else { set library "tdbc::odbc 1.0.6" }
+    if { [ llength $library ] > 1 } { 
+        set version [ lindex $library 1 ]
+        set library [ lindex $library 0 ]
+    }
+    upvar #0 configmssqlserver configmssqlserver
+    #set variables to values in dict
+    setlocaltpchvars $configmssqlserver
+    if {![string match windows $::tcl_platform(platform)]} {
+        set mssqls_server $mssqls_linux_server
+        set mssqls_odbc_driver $mssqls_linux_odbc
+        set mssqls_authentication $mssqls_linux_authent
+    }
+    if {[ tk_messageBox -title "Check Schema" -icon question -message "Do you want to check the [ string toupper $mssqls_tpch_dbase ] TPROC-H schema\nin host [string toupper $mssqls_server ]?" -type yesno ] == yes} { 
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-H check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to created thread for schema check: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+set version $version
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library $version} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc connect_string { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert} {
+    if { $tcp eq "true" } { set server tcp:$server,$port }
+    if {[ string toupper $authentication ] eq "WINDOWS" } {
+        set connection "DRIVER=$odbc_driver;SERVER=$server;TRUSTED_CONNECTION=YES"
+    } else {
+        if {[ string toupper $authentication ] eq "SQL" } {
+            set connection "DRIVER=$odbc_driver;SERVER=$server;UID=$uid;PWD=$pwd"
+        } else {
+            puts stderr "Error: neither WINDOWS or SQL Authentication has been specified"
+            set connection "DRIVER=$odbc_driver;SERVER=$server"
+        }
+    }
+    if { $azure eq "true" } { append connection ";" "DATABASE=$db" }
+    if { $encrypt eq "true" } { append connection ";" "ENCRYPT=yes" } else { append connection ";" "ENCRYPT=no" }
+    if { $trust_cert eq "true" } { append connection ";" "TRUSTSERVERCERTIFICATE=yes" }
+    return $connection
+}
+
+proc check_tpch { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert scale_factor } {
+	puts "Checking $db TPROC-H schema"
+    set tables [ dict create customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
+    set connection [ connect_string $server $port $odbc_driver $authentication $uid $pwd $tcp $azure tempdb $encrypt $trust_cert ]
+    if [catch {tdbc::odbc::connection create odbc $connection} message ] {
+        error "Connection to $connection could not be established : $message"
+    } else {
+	    if {!$azure} {odbc evaldirect "use tempdb"}
+	    #Check 1 Database Exists
+    set rows [ odbc allrows "IF DB_ID('$db') is not null SELECT 1 AS res ELSE SELECT 0 AS res" ]
+    set db_exists [ lindex {*}$rows 1 ]
+    if { $db_exists } {
+        if {!$azure} {odbc evaldirect "use $db"}
+        set rows [ odbc allrows "select COUNT(*) from sys.tables" ]
+        set table_count [ lindex {*}$rows 1 ]
+        if { $table_count == 0 } {
+	error "TPROC-H Schema check failed $db schema is empty"
+	} else {
+	    #Check 2 Tables Exist
+	foreach table [dict keys $tables] {
+    	set rows [ odbc allrows "IF OBJECT_ID (N'$table', N'U') IS NOT NULL SELECT 1 AS res ELSE SELECT 0 AS res" ]
+        set table_exists [ lindex {*}$rows 1 ]
+        if { $table_exists == 0 } {
+	error "TPROC-H Schema check failed $db schema is missing table $table"
+	} else {
+	if { $table eq "supplier" } {
+	    #Check 3 scale factor in schema is the same as dict setting
+    set rows [ odbc allrows "SELECT count(*) FROM SUPPLIER" ]
+    set count [ lindex {*}$rows 1 ]
+    if { $count } {
+        set actual_scale_factor [ expr {$count / 10000} ]
+        if { $actual_scale_factor != $scale_factor } {
+	error "TPROC-H Schema check failed $db schema scale factor $actual_scale_factor does not equal dict scale factor if $scale_factor"
+        }
+    }
+    }
+	    #Check 4 Tables are indexed
+    	set rows [ odbc allrows "SP_HELPINDEX '$table'" ]
+        if { [ llength $rows ] eq 0 } {
+	error "TPROC-H Schema check failed $db schema on table $table no indicies"
+	}
+	    #Check 5 Tables are populated
+	set expected_rows [ dict get $tables $table ]
+        set rows [ odbc allrows "select count(*) from $table" ]
+        set row_count [ lindex {*}$rows 1 ]
+        if { $row_count < $expected_rows } {
+	error "TPROC-H Schema check failed $db schema on table $table row count of $row_count is less than expected count of $expected_rows"
+	} 
+	}
+}
+	   #Consistency check
+	set rows [ odbc allrows "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(round(round(l_extendedprice * (1 - l_discount),2,1) * (1 + l_tax),2,1)) part_res FROM orders, lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" ]
+	if {[ llength $rows ] > 0} {
+	error "TPROC-H Schema check failed $db schema consistency check failed"
+	} 
+}
+	#Consistency check completed
+	puts "$db TPROC-H schema has been checked successfully"
+	} else {
+	error "Schema check failed $db TPROC-H schema does not exist"
+	}
+	odbc close
+	return
+	}
+	}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch {$mssqls_server} $mssqls_port {$mssqls_odbc_driver} $mssqls_authentication $mssqls_uid [ quotemeta $mssqls_pass ] $mssqls_tcp $mssqls_azure $mssqls_tpch_dbase $mssqls_encrypt_connection $mssqls_trust_server_cert $mssqls_scale_fact"
+    } else { return }
+}

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -3630,7 +3630,7 @@ proc connect_string { server port odbc_driver authentication uid pwd tcp azure d
 
 proc check_tpcc { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert count_ware } {
 	puts "Checking $db TPROC-C schema"
-    set tables [ dict create customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000 * 0.90} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] warehouse $count_ware ]
+    set tables [ dict create warehouse $count_ware customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000 * 0.90} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] ]
     set sps [ list delivery neword ostat payment slev ]
     set connection [ connect_string $server $port $odbc_driver $authentication $uid $pwd $tcp $azure tempdb $encrypt $trust_cert ]
     if [catch {tdbc::odbc::connection create odbc $connection} message ] {

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -1643,7 +1643,7 @@ set library $library
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
 if [catch {package require $library} message] { error "Failed to load $library - $message" }
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
-if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+if [catch {package require tpchcommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpchcommon::* }
 
 proc chk_socket { host socket } {
     if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -1604,3 +1604,154 @@ proc drop_schema { host port socket ssl_options user password dbase } {
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_tpch_user [ quotemeta $mysql_tpch_pass ] $mysql_tpch_dbase"
     } else { return }
 }
+
+proc check_mysqltpch {} {
+    global maxvuser suppo ntimes threadscreated _ED mysql_ssl_options
+    upvar #0 dbdict dbdict
+
+    if {[dict exists $dbdict mysql library ]} {
+        set library [ dict get $dbdict mysql library ]
+    } else {
+        set library "mysqltcl" 
+    }
+
+    upvar #0 configmysql configmysql
+    #set variables to values in dict
+    setlocaltpchvars $configmysql
+    #If the options menu has been run under the GUI mysql_ssl_options is set
+    #If build is run under the GUI, CLI or WS mysql_ssl_options is not set
+    #Set it now if it doesn't exist
+    if ![ info exists mysql_ssl_options ] { check_mysql_ssl $configmysql } 
+    if { ![string match windows $::tcl_platform(platform)] && ($mysql_host eq "127.0.0.1" || [ string tolower $mysql_host ] eq "localhost") && [ string tolower $mysql_socket ] != "null" } { set mysql_connector "$mysql_host:$mysql_socket" } else { 
+        set mysql_connector "$mysql_host:$mysql_port" 
+    }
+
+    if {[ tk_messageBox -title "Check Schema" -icon question -message "Do you want to check the [ string toupper $mysql_tpch_dbase ] TPROC-H schema\n in host [string toupper $mysql_connector] under user [ string toupper $mysql_tpch_user ]?" -type yesno ] == yes} {
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-H check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread for schema check: $message"
+            return
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
+if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc chk_socket { host socket } {
+    if { ![string match windows $::tcl_platform(platform)] && ($host eq "127.0.0.1" || [ string tolower $host ] eq "localhost") && [ string tolower $socket ] != "null" } {
+        return "TRUE"
+    } else {
+        return "FALSE"
+    }
+}
+
+proc ConnectToMySQL { host port socket ssl_options user password } {
+    global mysqlstatus
+    #ssl_options is variable length so build a connectstring
+    if { [ chk_socket $host $socket ] eq "TRUE" } {
+	set use_socket "true"
+	append connectstring " -socket $socket"
+	 } else {
+	set use_socket "false"
+	append connectstring " -host $host -port $port"
+	}
+	foreach key [ dict keys $ssl_options ] {
+	append connectstring " $key [ dict get $ssl_options $key ] "
+	}
+	append connectstring " -user $user -password $password"
+	set login_command "mysqlconnect [ dict get $connectstring ]"
+	#eval the login command
+        if [catch {set mysql_handler [eval $login_command]}] {
+		if $use_socket {
+            puts "the local socket connection to $socket could not be established"
+    } else {
+            puts "the tcp connection to $host:$port could not be established"
+    }
+        set connected "false"
+        } else {
+        set connected "true"
+        }
+    if {$connected} {
+        mysql::autocommit $mysql_handler 0
+	catch {set ssl_status [ mysql::sel $mysql_handler "show session status like 'ssl_cipher'" -list ]}
+	if { [ info exists ssl_status ] } {
+	puts [ join $ssl_status ]
+	}
+        return $mysql_handler
+    } else {
+        error $mysqlstatus(message)
+        return
+    }
+}
+
+proc check_tpch { host port socket ssl_options user password dbase scale_factor } {
+    global mysqlstatus
+    puts "Checking $dbase TPROC-H schema"
+    set tables [ dict create  SUPPLIER [ expr {$scale_factor * 10000} ] CUSTOMER [ expr {$scale_factor * 150000} ] LINEITEM [ expr {$scale_factor * 6000000 * 0.99} ] NATION 25 ORDERS [ expr {$scale_factor * 1500000} ] PART [ expr {$scale_factor * 200000} ] PARTSUPP [ expr {$scale_factor * 800000} ] REGION 5 ]
+    set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password ]
+   #Check 1 Database Exists
+    puts "Check database"
+        set db_exists [ mysql::sel $mysql_handler "select schema_name from information_schema.schemata where schema_name = '$dbase'" -flatlist  ]
+	if { [ string length $db_exists ] > 0 } {
+        mysqluse $mysql_handler $dbase
+        set table_exists [ mysql::sel $mysql_handler "show tables" -flatlist  ]
+	if {[ llength $table_exists ] == 0 } {
+	error "TPROC-H Schema check failed $dbase schema is empty"
+	} else {
+	#Check 2 Tables Exist
+	puts "Check tables and indices"
+	foreach table [dict keys $tables] {
+	set match [ lsearch $table_exists $table ]
+	if { $match == -1 } {
+	error "TPROC-H Schema check failed $dbase schema is missing table $table"
+	} else {
+	if { $table eq "supplier" } {
+	#Check 3 scale factor in schema is the same as dict setting
+        set count [  mysql::sel $mysql_handler "select count(*) from supplier" -flatlist ]
+	if { $count } {
+        set actual_scale_factor [ expr {$count / 10000} ]
+        if { $actual_scale_factor != $scale_factor } {
+	error "TPROC-H Schema check failed $dbase schema scale factor $actual_scale_factor does not equal dict scale factor if $scale_factor"
+        }
+        }
+	}
+        #Check 4 Tables are indexed
+    	set is_indexed [  mysql::sel $mysql_handler "show index from $table" -flatlist ]
+        if { [ llength $is_indexed ] eq 0 } {
+	error "TPROC-H Schema check failed $dbase schema on table $table no indices"
+	}
+	#Check 5 Tables are populated
+	set expected_rows [ dict get $tables $table ]
+        set row_count [  mysql::sel $mysql_handler "select count(*) from $table" -flatlist ]
+        if { $row_count < $expected_rows } {
+	error "TPROC-H Schema check failed $dbase schema on table $table row count of $row_count is less than expected count of $expected_rows"
+	} 
+	}
+	}
+        #Consistency check
+	puts "Check consistency"
+    	set checkconsistency [  mysql::sel $mysql_handler "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(truncate(truncate(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)) part_res FROM ORDERS, LINEITEM WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0" -flatlist ]
+	if {[ llength $checkconsistency ] > 0} {
+	error "TPROC-H Schema check failed $dbase schema consistency check failed"
+	} 
+	}
+	#Consistency check completed
+        puts "$dbase TPROC-H Schema has been checked successfully."
+	} else {
+	error "Schema check failed $dbase TPROC-H schema does not exist"
+	}
+    mysqlclose $mysql_handler
+    return
+}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch $mysql_host $mysql_port $mysql_socket {$mysql_ssl_options} $mysql_tpch_user [ quotemeta $mysql_tpch_pass ] $mysql_tpch_dbase $mysql_scale_fact"
+    } else { return }
+}

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1771,12 +1771,15 @@ proc check_tpch { system_user system_password instance tpch_user scale_factor } 
     set connect $system_user/$system_password@$instance
     set lda [ oralogon $connect ]
     set curn [oraopen $lda ]
+	      #Check 1 Schema Exists
+    puts "Check schema"
     set checkuserexists "SELECT created FROM all_users WHERE username = upper('$tpch_user')"
     set userexists [ standsql $curn $checkuserexists ]
     if {[ string length $userexists ] == 0} {
     error "TPROC-H Schema check failed $tpch_user does not exist"
     } else {
 	      #Check 2 Tables Exist
+	puts "Check tables and indices"
         foreach table [dict keys $tables] {
 	set checktableexists "select status from all_tables where owner = upper('$tpch_user') and table_name = upper('$table')"
     	set table_exists [ standsql $curn $checktableexists ]
@@ -1810,6 +1813,7 @@ proc check_tpch { system_user system_password instance tpch_user scale_factor } 
         }
         }
 	   #Consistency check
+	puts "Check consistency"
         set checkconsistency "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(trunc(trunc(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)) part_res FROM $tpch_user.orders, $tpch_user.lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0"
 	set row_count [ standsql $curn $checkconsistency ]
         if {[ llength $row_count ] > 0} {

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1723,3 +1723,105 @@ proc drop_tpch { system_user system_password instance tpch_user } {
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpch $system_user [ quotemeta $system_password ] $instance $tpch_user"
     } else { return }
 }
+
+proc check_oratpch {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict oracle library ]} {
+        set library [ dict get $dbdict oracle library ]
+    } else { set library "Oratcl" } 
+    upvar #0 configoracle configoracle
+    setlocaltpchvars $configoracle
+        set check_message "Do you want to check the [ string toupper $tpch_user ] Oracle TPROC-H schema\nin the instance [string toupper $instance]?" 
+    if {[ tk_messageBox -title "Check Schema" -icon question -message $check_message -type yesno ] == yes} { 
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-H check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread(s) for schema deletion: $message"
+            return 1
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpchcommon} ] { error "Failed to load tpch common functions" } else { namespace import tpchcommon::* }
+
+proc standsql { curn sql } {
+    set ftch ""
+    if {[catch {orasql $curn $sql} message]} {
+	error "SQL statement failed: $sql : $message"
+    } else {
+	orafetch  $curn -datavariable output
+	while { [ oramsg  $curn ] == 0 } {
+	    lappend ftch $output
+	    orafetch  $curn -datavariable output
+	}
+	return $ftch
+    }
+}
+
+proc check_tpch { system_user system_password instance tpch_user scale_factor } {
+    puts "Checking $tpch_user TPROC-H schema"
+     set tables [ dict create customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
+    set connect $system_user/$system_password@$instance
+    set lda [ oralogon $connect ]
+    set curn [oraopen $lda ]
+    set checkuserexists "SELECT created FROM all_users WHERE username = upper('$tpch_user')"
+    set userexists [ standsql $curn $checkuserexists ]
+    if {[ string length $userexists ] == 0} {
+    error "TPROC-H Schema check failed $tpch_user does not exist"
+    } else {
+	      #Check 2 Tables Exist
+        foreach table [dict keys $tables] {
+	set checktableexists "select status from all_tables where owner = upper('$tpch_user') and table_name = upper('$table')"
+    	set table_exists [ standsql $curn $checktableexists ]
+        if { [ string length $table_exists ] == 0 } {
+        error "TPROC-H Schema check failed $tpch_user schema is missing table $table"
+        } else {
+        if { $table eq "supplier" } {
+            #Check 3 Warehouse count in schema is the same as dict setting
+    set countsql "SELECT count(*) from $tpch_user.SUPPLIER"
+    set count [ standsql $curn $countsql ]
+        if { $count } {
+	set actual_scale_factor [ expr {$count / 10000} ]
+        if { $actual_scale_factor != $scale_factor } {
+        error "TPROC-H Schema check failed $tpch_user schema warehouse count $w_id_input does not equal dict warehouse count of $count_ware"
+        }
+        }
+	}
+            #Check 4 Tables are indexed
+	set checkindexexists "select count(*) from all_indexes where owner = upper('$tpch_user') and table_name = upper('$table')"
+        set index_exists [ standsql $curn $checkindexexists ]
+        if { $index_exists == 0 } {
+        error "TPROC-H Schema check failed $tpch_user schema on table $table no indicies"
+        } 
+            #Check 5 Tables are populated
+        set expected_rows [ dict get $tables $table ]
+	set checkrowcount "select num_rows from all_tables where owner = upper('$tpch_user') and table_name = upper('$table')"
+        set row_count [ standsql $curn $checkrowcount ] 
+        if { $row_count < $expected_rows } {
+        error "TPROC-H Schema check failed $tpch_user schema on table $table row count of $row_count is less than expected count of $expected_rows"
+        } 
+        }
+        }
+	   #Consistency check
+        set checkconsistency "SELECT * FROM (SELECT o_orderkey, o_totalprice - SUM(trunc(trunc(l_extendedprice * (1 - l_discount),2) * (1 + l_tax),2)) part_res FROM $tpch_user.orders, $tpch_user.lineitem WHERE o_orderkey=l_orderkey GROUP BY o_orderkey, o_totalprice) temp WHERE not part_res=0"
+	set row_count [ standsql $curn $checkconsistency ]
+        if {[ llength $row_count ] > 0} {
+        error "TPROC-H Schema check failed $db schema consistency check failed"
+        }
+}
+        #All consistency checks have completed
+        puts "$tpch_user TPROC-H schema has been checked successfully"
+        oralogoff $lda
+        return
+}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch $system_user [ quotemeta $system_password ] $instance $tpch_user $scale_fact"
+    } else { return }
+}

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1767,7 +1767,7 @@ proc standsql { curn sql } {
 
 proc check_tpch { system_user system_password instance tpch_user scale_factor } {
     puts "Checking $tpch_user TPROC-H schema"
-     set tables [ dict create customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 supplier [ expr {$scale_factor * 10000} ]]
+     set tables [ dict create supplier [ expr {$scale_factor * 10000} ] customer [ expr {$scale_factor * 150000} ] lineitem [ expr {$scale_factor * 6000000 * 0.99} ] nation 25 orders [ expr {$scale_factor * 1500000} ] part [ expr {$scale_factor * 200000} ] partsupp [ expr {$scale_factor * 800000} ] region 5 ]
     set connect $system_user/$system_password@$instance
     set lda [ oralogon $connect ]
     set curn [oraopen $lda ]

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -3385,7 +3385,7 @@ proc standsql { curn sql } {
 
 proc check_tpcc { system_user system_password instance tpcc_user count_ware } {
     puts "Checking $tpcc_user TPROC-C schema"
-    set tables [ dict create customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000 * 0.90} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] warehouse $count_ware ]
+    set tables [ dict create warehouse $count_ware customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000 * 0.90} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] ]
     set sps [ list delivery neword ostat payment slev ]
     set connect $system_user/$system_password@$instance
     set lda [ oralogon $connect ]

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -93,7 +93,7 @@ proc CreateStoredProcs { lda timesten num_part } {
             FROM customer, warehouse
             WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND
             customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
-            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
+            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id - 1, d_tax INTO no_d_next_o_id, no_d_tax;
             o_id := no_d_next_o_id;
             INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
             INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
@@ -265,7 +265,7 @@ proc CreateStoredProcs { lda timesten num_part } {
             ol_line_number_array(loop_counter) := loop_counter;
             END LOOP;
 
-            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
+            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id - 1, d_tax INTO no_d_next_o_id, no_d_tax;
 
             INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
             INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);
@@ -3339,5 +3339,161 @@ proc drop_tpcc { system_user system_password instance tpcc_user hash_clusters } 
 }
 
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_tpcc $system_user [ quotemeta $system_password ] $instance $tpcc_user $hash_clusters"
+    } else { return }
+}
+
+proc check_oratpcc {} {
+    global maxvuser suppo ntimes threadscreated _ED
+    upvar #0 dbdict dbdict
+    if {[dict exists $dbdict oracle library ]} {
+        set library [ dict get $dbdict oracle library ]
+    } else { set library "Oratcl" } 
+    upvar #0 configoracle configoracle
+    setlocaltpccvars $configoracle
+        set check_message "Do you want to check the [ string toupper $tpcc_user ] Oracle TPROC-C schema\nin the instance [string toupper $instance]?" 
+    if {[ tk_messageBox -title "Check Schema" -icon question -message $check_message -type yesno ] == yes} { 
+        set maxvuser 1
+        set suppo 1
+        set ntimes 1
+        ed_edit_clear
+        set _ED(packagekeyname) "TPROC-C check"
+        if { [catch {load_virtual} message]} {
+            puts "Failed to create thread(s) for schema deletion: $message"
+            return 1
+        }
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "#!/usr/local/bin/tclsh8.6
+#LOAD LIBRARIES AND MODULES
+set library $library
+"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {if [catch {package require $library} message] { error "Failed to load $library - $message" }
+if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
+if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+
+proc standsql { curn sql } {
+    set ftch ""
+    if {[catch {orasql $curn $sql} message]} {
+	error "SQL statement failed: $sql : $message"
+    } else {
+	orafetch  $curn -datavariable output
+	while { [ oramsg  $curn ] == 0 } {
+	    lappend ftch $output
+	    orafetch  $curn -datavariable output
+	}
+	return $ftch
+    }
+}
+
+proc check_tpcc { system_user system_password instance tpcc_user count_ware } {
+    puts "Checking $tpcc_user TPROC-C schema"
+    set tables [ dict create customer [ expr {$count_ware * 30000} ] district [ expr {$count_ware * 10} ] history [ expr {$count_ware * 30000} ] item 100000 new_order [ expr {$count_ware * 9000} ] order_line [ expr {$count_ware * 300000 * 0.99} ] orders [ expr {$count_ware * 30000} ] stock [ expr {$count_ware * 100000} ] warehouse $count_ware ]
+    set sps [ list delivery neword ostat payment slev ]
+    set connect $system_user/$system_password@$instance
+    set lda [ oralogon $connect ]
+    set curn [oraopen $lda ]
+    set checkuserexists "SELECT created FROM all_users WHERE username = upper('$tpcc_user')"
+    set userexists [ standsql $curn $checkuserexists ]
+    if {[ string length $userexists ] == 0} {
+    error "TPROC-C Schema check failed $tpcc_user does not exist"
+    } else {
+	      #Check 2 Tables Exist
+        foreach table [dict keys $tables] {
+	set checktableexists "select status from all_tables where owner = upper('$tpcc_user') and table_name = upper('$table')"
+    	set table_exists [ standsql $curn $checktableexists ]
+        if { [ string length $table_exists ] == 0 } {
+        error "TPROC-C Schema check failed $tpcc_user schema is missing table $table"
+        } else {
+        if { $table eq "warehouse" } {
+            #Check 3 Warehouse count in schema is the same as dict setting
+	set checkmaxwid "select max(w_id) from $tpcc_user.$table"
+    	set w_id_input [ standsql $curn $checkmaxwid ]
+        if { $count_ware != $w_id_input } {
+        error "TPROC-C Schema check failed $tpcc_user schema warehouse count $w_id_input does not equal dict warehouse count of $count_ware"
+        }
+        }
+            #Check 4 Tables are indexed
+	set checkindexexists "select count(*) from all_indexes where owner = upper('$tpcc_user') and table_name = upper('$table')"
+        set index_exists [ standsql $curn $checkindexexists ]
+        if { $index_exists == 0 } {
+	    #History has no index for Oracle
+	if { $table != "history" } {
+        error "TPROC-C Schema check failed $tpcc_user schema on table $table no indicies"
+	}
+        } 
+            #Check 5 Tables are populated
+        set expected_rows [ dict get $tables $table ]
+	set checkrowcount "select num_rows from all_tables where owner = upper('$tpcc_user') and table_name = upper('$table')"
+        set row_count [ standsql $curn $checkrowcount ] 
+        if { $row_count < $expected_rows } {
+        error "TPROC-C Schema check failed $tpcc_user schema on table $table row count of $row_count is less than expected count of $expected_rows"
+        } 
+        }
+        }
+	   #Check 6 Stored Procedures Exist
+        foreach sp $sps {
+	set checkspexists "select max(line) from all_source where owner = upper('$tpcc_user') and name = upper('$sp')"
+	set sp_exists [ standsql $curn $checkspexists ]
+        if { ![ string is entier $sp_exists ] } {
+        error "TPROC-C Schema check failed $db schema is missing stored procedure $sp"
+        }
+        }
+	   #Create temporary sample table
+	#
+	set checktemptableexists "select status from all_tables where table_name = 'TEMP_W'"
+    	set table_exists [ standsql $curn $checktemptableexists ]
+        if { [ string length $table_exists ] == 0 } {
+	    set createtemptab "CREATE GLOBAL TEMPORARY TABLE TEMP_W (T_W_ID NUMBER(6, 0)) ON COMMIT DELETE ROWS"
+            if {[ catch {orasql $curn $createtemptab} message ] } {
+            error "TPROC-C Schema check failed $tpcc_user schema creating temporary table $message"
+            } else {
+		    if { $w_id_input <= 10 } {
+        for  {set i 1} {$i <= $w_id_input} { incr i} {
+		oraparse $curn "insert into temp_w values ($i)"
+		oraexec $curn
+        }
+        } else {
+        foreach statement {{insert into temp_w values (1)} {insert into temp_w values ([expr {0.1 * $w_id_input}])} {insert into temp_w values ([expr {0.2 * $w_id_input}])} {insert into temp_w values ([expr {0.3 * $w_id_input}])} {insert into temp_w values ([expr {0.4 * $w_id_input}])} {insert into temp_w values ([expr {0.5 * $w_id_input}])} {insert into temp_w values ([expr {0.6 * $w_id_input}])} {insert into temp_w values ([expr {0.7 * $w_id_input}])} {insert into temp_w values ([expr {0.8 * $w_id_input}])} {insert into temp_w values ([expr {0.9 * $w_id_input}])} {insert into temp_w values ($w_id_input)}} {
+        oraparse $curn [ subst $statement ]
+	oraexec $curn
+}
+}
+} 
+}
+          #Consistency check 1
+        set consist1 "select d_w_id, (w_ytd - sum(d_ytd)) diff from $tpcc_user.warehouse, $tpcc_user.district where d_w_id=w_id group by d_w_id, w_ytd having (w_ytd - sum(d_ytd)) != 0" 
+	set rows [ standsql $curn $consist1 ]
+        if {[ llength $rows ] > 0} {
+        error "TPROC-C Schema check failed $tpcc_user schema consistency check 1 failed $rows"
+        }
+           #Consistency check 2
+        set consist2 "select * from (select d_w_id, d_id, max(o_id) AS ORDER_MAX, (d_next_o_id - 1) AS ORDER_NEXT from $tpcc_user.district, $tpcc_user.orders where d_w_id = o_w_id and d_id = o_d_id and d_w_id in (select t_w_id from temp_w) group by d_w_id, d_id, (d_next_o_id - 1)) dt where dt.ORDER_NEXT != dt.ORDER_MAX"
+	set rows [ standsql $curn $consist2 ]
+        if {[ llength $rows ] > 0} {
+		puts "$rows"
+        #error "TPROC-C Schema check failed $tpcc_user schema consistency check 2 failed"
+        } 
+           #Consistency check 3
+        set consist3 "select * from (select count(*) as nocount, (max(no_o_id) - min(no_o_id) + 1) as total from $tpcc_user.new_order group by no_w_id, no_d_id) dt where nocount != total"
+	set rows [ standsql $curn $consist3 ]
+        if {[ llength $rows ] > 0} {
+        #error "TPROC-C Schema check failed $tpcc_user schema consistency check 3 failed"
+        }
+           #Consistency check 4
+        set consist4 "select * from (select o_w_id, o_d_id, sum(o_ol_cnt) as ol_sum from $tpcc_user.orders, temp_w where o_w_id = t_w_id group by o_w_id, o_d_id) consist1, (select ol_w_id, ol_d_id, count(*) as ol_count from $tpcc_user.order_line, temp_w where ol_w_id = t_w_id group by ol_w_id, ol_d_id) consist2 where o_w_id = ol_w_id and o_d_id = ol_d_id and ol_sum != ol_count"
+	set rows [ standsql $curn $consist4 ]
+        if {[ llength $rows ] > 0} {
+        error "TPROC-C Schema check failed $tpcc_user schema consistency check 4 failed"
+        }
+   #Drop temporary sample table
+        set droptable "drop table temp_w"
+        oraparse $curn $droptable
+	oraexec $curn
+        #All consistency checks have completed
+        puts "$tpcc_user TPROC-C schema has been checked successfully"
+        oralogoff $lda
+        return
+}
+}
+}
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpcc $system_user [ quotemeta $system_password ] $instance $tpcc_user $count_ware"
     } else { return }
 }

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -1608,7 +1608,7 @@ set library $library
         .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {
 if [catch {package require $library} message] { error "Failed to load $library - $message" }
 if [catch {::tcl::tm::path add modules} ] { error "Failed to find modules directory" }
-if [catch {package require tpcccommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpcccommon::* }
+if [catch {package require tpchcommon} ] { error "Failed to load tpcc common functions" } else { namespace import tpchcommon::* }
 
 proc ConnectToPostgres { host port sslmode user password dbname } {
     global tcl_platform


### PR DESCRIPTION
As described in #659 PR adds another GUI option and checkschema CLI command to run the following tests to validate the schema and also to verify that the data is consistent after running a test. All databases have been checked to verify that this is the case in a default scenario. 

TPROC-C
#Check 1 Database Exist
#Check 2 Tables Exist
#Check 3 Warehouse count in schema is the same as dict setting
#Check 4 Tables are indexed
#Check 5 Tables are populated
#Check 6 Stored Procedures Exist
#Consistency check 1
#Consistency check 2
#Consistency check 3
#Consistency check 4

TPROC-H
#Check 1 Database Exist
#Check 2 Tables Exist
#Check 3 supplier count in schema is the same as dict setting
#Check 4 Tables are indexed
#Check 5 Tables are populated
#Consistency check