### PR TITLE
Add support for Microsoft Entra authentication for SQL Server

### DIFF
--- a/config/connectpool/mssqlscpool.xml
+++ b/config/connectpool/mssqlscpool.xml
@@ -7,7 +7,8 @@
         <mssqls_port>1433</mssqls_port>
         <mssqls_azure>false</mssqls_azure>
         <mssqls_authentication>windows</mssqls_authentication>
-        <mssqls_linux_authent>sql</mssqls_linux_authent>
+        <mssqls_msi_object_id>null</mssqls_msi_object_id>
+        <mssqls_linux_authent>sql</mssqls_linux_authent>       
 	<mssqls_odbc_driver>ODBC Driver 18 for SQL Server</mssqls_odbc_driver>
 	<mssqls_linux_odbc>ODBC Driver 18 for SQL Server</mssqls_linux_odbc>
         <mssqls_uid>sa</mssqls_uid>
@@ -23,6 +24,7 @@
         <mssqls_port>1433</mssqls_port>
         <mssqls_azure>false</mssqls_azure>
         <mssqls_authentication>windows</mssqls_authentication>
+        <mssqls_msi_object_id>null</mssqls_msi_object_id>
         <mssqls_linux_authent>sql</mssqls_linux_authent>
 	<mssqls_odbc_driver>ODBC Driver 18 for SQL Server</mssqls_odbc_driver>
 	<mssqls_linux_odbc>ODBC Driver 18 for SQL Server</mssqls_linux_odbc>
@@ -39,6 +41,7 @@
         <mssqls_port>1433</mssqls_port>
         <mssqls_azure>false</mssqls_azure>
         <mssqls_authentication>windows</mssqls_authentication>
+        <mssqls_msi_object_id>null</mssqls_msi_object_id>  
         <mssqls_linux_authent>sql</mssqls_linux_authent>
 	<mssqls_odbc_driver>ODBC Driver 18 for SQL Server</mssqls_odbc_driver>
 	<mssqls_linux_odbc>ODBC Driver 18 for SQL Server</mssqls_linux_odbc>

--- a/config/mssqlserver.xml
+++ b/config/mssqlserver.xml
@@ -7,6 +7,7 @@
         <mssqls_port>1433</mssqls_port>
         <mssqls_azure>false</mssqls_azure>
         <mssqls_authentication>windows</mssqls_authentication>
+        <mssqls_msi_object_id>null</mssqls_msi_object_id>
         <mssqls_linux_authent>sql</mssqls_linux_authent>
 	<mssqls_odbc_driver>ODBC Driver 18 for SQL Server</mssqls_odbc_driver>
 	<mssqls_linux_odbc>ODBC Driver 18 for SQL Server</mssqls_linux_odbc>

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -15,10 +15,10 @@ proc countmssqlsopts { bm } {
     variable mssqloptsfields 
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqloptsfields [ dict create connection { mssqls_linux_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_linux_odbc {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent} ]
+        set mssqloptsfields [ dict create connection { mssqls_linux_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_linux_odbc {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqloptsfields [ dict create connection { mssqls_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_odbc_driver {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication} ]
+        set mssqloptsfields [ dict create connection { mssqls_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_odbc_driver {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
 
     if { [ info exists afval ] } {
@@ -108,54 +108,78 @@ proc countmssqlsopts { bm } {
     grid $Prompt -column 0 -row 8 -sticky e
     set Name $Parent.f1.r1
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
     bind .countopt.f1.r1 <ButtonPress-1> {
         .countopt.f1.e4 configure -state disabled
         .countopt.f1.e5 configure -state disabled
+        .countopt.f1.e5a configure -state disabled
     }
     set Name $Parent.f1.r2
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
     bind .countopt.f1.r2 <ButtonPress-1> {
         .countopt.f1.e4 configure -state normal
         .countopt.f1.e5 configure -state normal
+        .countopt.f1.e5a configure -state disabled
     }
+    set Name $Parent.f1.r3
+    if { $platform eq "lin" } {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
+    } else {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
+    }
+    grid $Name -column 1 -row 10 -sticky w
+    bind .countopt.f1.r3 <ButtonPress-1> {
+        .countopt.f1.e4 configure -state disabled
+        .countopt.f1.e5 configure -state disabled
+        .countopt.f1.e5a configure -state normal
+    }
+
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
-    grid $Prompt -column 0 -row 10 -sticky e
-    grid $Name -column 1 -row 10 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
-    grid $Prompt -column 0 -row 11 -sticky e
-    grid $Name -column 1 -row 11 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 12 -sticky e
+    grid $Name -column 1 -row 12 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
+        $Name configure -state disabled
+    }
+    set Name $Parent.f1.e5a
+    set Prompt $Parent.f1.p5a
+    ttk::label $Prompt -text "MSI Object ID :"   
+    ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "sql")) || ($platform eq "lin" && ($mssqls_linux_authent == "windows"  || $mssqls_linux_authent == "sql" ) )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e6
     set Prompt $Parent.f1.p6
     ttk::label $Prompt -text "Refresh Rate(secs) :"
     ttk::entry $Name -width 30 -textvariable interval
-    grid $Prompt -column 0 -row 12 -sticky e
-    grid $Name -column 1 -row 12 -sticky ew
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky ew
 
     set Name $Parent.f1.e7
     ttk::checkbutton $Name -text "Log Output to Temp" -variable tclog -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 13 -sticky w
+    grid $Name -column 1 -row 15 -sticky w
     bind .countopt.f1.e7 <Button> {
         set opst [ .countopt.f1.e7 cget -state ]
         if {$opst != "disabled" && $tclog == 0} {
@@ -170,14 +194,14 @@ proc countmssqlsopts { bm } {
     }
     set Name $Parent.f1.e8
     ttk::checkbutton $Name -text "Use Unique Log Name" -variable uniquelog -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 14 -sticky w
+    grid $Name -column 1 -row 16 -sticky w
     if {$tclog == 0} {
         $Name configure -state disabled
     }
 
     set Name $Parent.f1.e9
     ttk::checkbutton $Name -text "Log Timestamps" -variable tcstamp -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 15 -sticky w
+    grid $Name -column 1 -row 17 -sticky w
     if {$tclog == 0} {
         $Name configure -state disabled
     }
@@ -205,13 +229,18 @@ proc countmssqlsopts { bm } {
         if { ($interval >= 60) || ($interval <= 0)  } { tk_messageBox -message "Refresh rate must be more than 0 secs and less than 60 secs" 
             dict set genericdict transaction_counter tc_refresh_rate 10
         } else {
+	if { ![ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}|\ynull\y} $mssqls_msi_object_id ] } {
+		tk_messageBox -message "MSI Object ID is not a valid format" 
+		dict set configmssqlserver connection mssqls_msi_object_id "null" 
+                Dict2SQLite "mssqlserver" $configmssqlserver
+	} else {
             dict with genericdict { dict with transaction_counter {
                     set tc_refresh_rate [.countopt.f1.e6 get]
                     set tc_log_to_temp $tclog
                     set tc_unique_log_name $uniquelog
                     set tc_log_timestamps $tcstamp 
             }}
-        }
+        }}
         destroy .countopt
         catch "destroy .tc"
     } -text {OK}
@@ -231,10 +260,10 @@ proc configmssqlstpcc {option} {
     set tpccfields [ dict create tpcc {mssqls_dbase {.tpc.f1.e6 get} mssqls_bucket {.tpc.f1.e8 get} mssqls_total_iterations {.tpc.f1.e14 get} mssqls_rampup {.tpc.f1.e18 get} mssqls_duration {.tpc.f1.e19 get} mssqls_async_client {.tpc.f1.e23 get} mssqls_async_delay {.tpc.f1.e24 get} mssqls_imdb $mssqls_imdb mssqls_durability $mssqls_durability mssqls_count_ware $mssqls_count_ware mssqls_num_vu $mssqls_num_vu mssqls_driver $mssqls_driver mssqls_raiseerror $mssqls_raiseerror mssqls_keyandthink $mssqls_keyandthink mssqls_checkpoint $mssqls_checkpoint mssqls_allwarehouse $mssqls_allwarehouse mssqls_timeprofile $mssqls_timeprofile mssqls_async_scale $mssqls_async_scale mssqls_async_verbose $mssqls_async_verbose mssqls_connect_pool $mssqls_connect_pool mssqls_use_bcp $mssqls_use_bcp} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqlsconn [ dict create connection { mssqls_linux_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_linux_odbc {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent} ]
+        set mssqlsconn [ dict create connection { mssqls_linux_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_linux_odbc {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqlsconn [ dict create connection { mssqls_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_odbc_driver {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication} ]
+        set mssqlsconn [ dict create connection { mssqls_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_odbc_driver {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
     variable mssqlsfields
     set mssqlsfields [ dict merge $mssqlsconn $tpccfields ]
@@ -334,57 +363,80 @@ proc configmssqlstpcc {option} {
     grid $Prompt -column 0 -row 8 -sticky e
     set Name $Parent.f1.r1
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
     bind .tpc.f1.r1 <ButtonPress-1> {
         .tpc.f1.e4 configure -state disabled
         .tpc.f1.e5 configure -state disabled
+        .tpc.f1.e5a configure -state disabled
     }
     set Name $Parent.f1.r2
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
     bind .tpc.f1.r2 <ButtonPress-1> {
         .tpc.f1.e4 configure -state normal
         .tpc.f1.e5 configure -state normal
+        .tpc.f1.e5a configure -state disabled
+    }
+    set Name $Parent.f1.r3
+    if { $platform eq "lin" } {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
+    } else {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
+    }
+    grid $Name -column 1 -row 10 -sticky w
+    bind .tpc.f1.r3 <ButtonPress-1> {
+        .tpc.f1.e4 configure -state disabled
+        .tpc.f1.e5 configure -state disabled
+        .tpc.f1.e5a configure -state normal
     }
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
-    grid $Prompt -column 0 -row 10 -sticky e
-    grid $Name -column 1 -row 10 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
-    grid $Prompt -column 0 -row 11 -sticky e
-    grid $Name -column 1 -row 11 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 12 -sticky e
+    grid $Name -column 1 -row 12 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
+        $Name configure -state disabled
+    }
+     set Name $Parent.f1.e5a
+    set Prompt $Parent.f1.p5a
+    ttk::label $Prompt -text "MSI Object ID :"   
+    ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "sql")) || ($platform eq "lin" && ($mssqls_linux_authent == "windows"  || $mssqls_linux_authent == "sql" ) )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e6
     set Prompt $Parent.f1.p6
     ttk::label $Prompt -text "TPROC-C SQL Server Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mssqls_dbase
-    grid $Prompt -column 0 -row 12 -sticky e
-    grid $Name -column 1 -row 12 -sticky ew
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky ew
     if { $option eq "all" || $option eq "build" } {
         set Prompt $Parent.f1.p7
         ttk::label $Prompt -text "In-Memory OLTP :"
         set Name $Parent.f1.e7
         ttk::checkbutton $Name -text "" -variable mssqls_imdb -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 13 -sticky e
-        grid $Name -column 1 -row 13 -sticky w
+        grid $Prompt -column 0 -row 15 -sticky e
+        grid $Name -column 1 -row 15 -sticky w
         bind .tpc.f1.e7 <ButtonPress-1> {
             if { $mssqls_imdb eq "false" } {
                 foreach field {r5 r6 e8} {
@@ -401,18 +453,18 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p8
         ttk::label $Prompt -text "In-Memory Hash Bucket Multiplier :"   
         ttk::entry $Name  -width 30 -textvariable mssqls_bucket
-        grid $Prompt -column 0 -row 14 -sticky e
-        grid $Name -column 1 -row 14 -sticky ew
+        grid $Prompt -column 0 -row 16 -sticky e
+        grid $Name -column 1 -row 16 -sticky ew
         set Name $Parent.f1.e9
         set Prompt $Parent.f1.p9
         ttk::label $Prompt -text "In-Memory Durability :"
-        grid $Prompt -column 0 -row 15 -sticky e
+        grid $Prompt -column 0 -row 17 -sticky e
         set Name $Parent.f1.r5
         ttk::radiobutton $Name -value "SCHEMA_AND_DATA" -text "SCHEMA_AND_DATA" -variable mssqls_durability
-        grid $Name -column 1 -row 15 -sticky w
+        grid $Name -column 1 -row 17 -sticky w
         set Name $Parent.f1.r6
         ttk::radiobutton $Name -value "SCHEMA_ONLY" -text "SCHEMA_ONLY" -variable mssqls_durability
-        grid $Name -column 1 -row 16 -sticky w
+        grid $Name -column 1 -row 18 -sticky w
         if { $mssqls_imdb eq "true" } {
             foreach field {r5 r6 e8} {
                 catch {.tpc.f1.$field configure -state normal}
@@ -432,8 +484,8 @@ proc configmssqlstpcc {option} {
                 set mssqls_num_vu $mssqls_count_ware
             }
         }
-        grid $Prompt -column 0 -row 17 -sticky e
-        grid $Name -column 1 -row 17 -sticky ew
+        grid $Prompt -column 0 -row 19 -sticky e
+        grid $Name -column 1 -row 19 -sticky ew
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e11
@@ -445,32 +497,32 @@ proc configmssqlstpcc {option} {
         }
         event add <<Any-Button-Any-Key>> <Any-ButtonRelease>
         event add <<Any-Button-Any-Key>> <KeyRelease>
-        grid $Prompt -column 0 -row 18 -sticky e
-        grid $Name -column 1 -row 18 -sticky ew
+        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Name -column 1 -row 20 -sticky ew
 
         set Prompt $Parent.f1.p12
         set Name $Parent.f1.e12     
         ttk::label $Prompt -text "Use BCP Option :"
         ttk::checkbutton $Name -text "" -variable mssqls_use_bcp -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 19 -sticky e
-        grid $Name -column 1 -row 19 -sticky ew
+        grid $Prompt -column 0 -row 21 -sticky e
+        grid $Name -column 1 -row 21 -sticky ew
     }
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {
             set Prompt $Parent.f1.h3
             ttk::label $Prompt -image [ create_image driveroptlo icons ]
-            grid $Prompt -column 0 -row 20 -sticky e
+            grid $Prompt -column 0 -row 22 -sticky e
             set Prompt $Parent.f1.h4
             ttk::label $Prompt -text "Driver Options"
-            grid $Prompt -column 1 -row 20 -sticky w
+            grid $Prompt -column 1 -row 22 -sticky w
         }
         set Prompt $Parent.f1.p12
         ttk::label $Prompt -text "TPROC-C Driver Script :" -image [ create_image hdbicon icons ] -compound left
-        grid $Prompt -column 0 -row 21 -sticky e
-        set Name $Parent.f1.r3
+        grid $Prompt -column 0 -row 23 -sticky e
+        set Name $Parent.f1.r4
         ttk::radiobutton $Name -value "test" -text "Test Driver Script" -variable mssqls_driver
-        grid $Name -column 1 -row 21 -sticky w
-        bind .tpc.f1.r3 <ButtonPress-1> {
+        grid $Name -column 1 -row 23 -sticky w
+        bind .tpc.f1.r4 <ButtonPress-1> {
             set mssqls_checkpoint "false"
             set mssqls_allwarehouse "false"
             set mssqls_timeprofile "false"
@@ -486,10 +538,10 @@ proc configmssqlstpcc {option} {
             .tpc.f1.e24 configure -state disabled
             .tpc.f1.e25 configure -state disabled
         }
-        set Name $Parent.f1.r4
+        set Name $Parent.f1.r5
         ttk::radiobutton $Name -value "timed" -text "Timed Driver Script" -variable mssqls_driver
-        grid $Name -column 1 -row 22 -sticky w
-        bind .tpc.f1.r4 <ButtonPress-1> {
+        grid $Name -column 1 -row 24 -sticky w
+        bind .tpc.f1.r5 <ButtonPress-1> {
             .tpc.f1.e17 configure -state normal
             .tpc.f1.e18 configure -state normal
             .tpc.f1.e19 configure -state normal
@@ -506,14 +558,14 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p14
         ttk::label $Prompt -text "Total Transactions per User :"
         ttk::entry $Name -width 30 -textvariable mssqls_total_iterations
-        grid $Prompt -column 0 -row 23 -sticky e
-        grid $Name -column 1 -row 23 -sticky ew
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky ew
         set Prompt $Parent.f1.p15
         ttk::label $Prompt -text "Exit on SQL Server Error :"
         set Name $Parent.f1.e15
         ttk::checkbutton $Name -text "" -variable mssqls_raiseerror -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 24 -sticky e
-        grid $Name -column 1 -row 24 -sticky w
+        grid $Prompt -column 0 -row 26 -sticky e
+        grid $Name -column 1 -row 26 -sticky w
         set Prompt $Parent.f1.p16
         ttk::label $Prompt -text "Keying and Thinking Time :"
         set Name $Parent.f1.e16
@@ -529,14 +581,14 @@ proc configmssqlstpcc {option} {
                 }
             }
         }
-        grid $Prompt -column 0 -row 25 -sticky e
-        grid $Name -column 1 -row 25 -sticky w
+        grid $Prompt -column 0 -row 27 -sticky e
+        grid $Name -column 1 -row 27 -sticky w
         set Prompt $Parent.f1.p17
         ttk::label $Prompt -text "Checkpoint when complete :"
         set Name $Parent.f1.e17
         ttk::checkbutton $Name -text "" -variable mssqls_checkpoint -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 26 -sticky e
-        grid $Name -column 1 -row 26 -sticky w
+        grid $Prompt -column 0 -row 28 -sticky e
+        grid $Name -column 1 -row 28 -sticky w
         if {$mssqls_driver == "test" } {
             $Name configure -state disabled
         }
@@ -544,8 +596,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p18
         ttk::label $Prompt -text "Minutes of Rampup Time :"
         ttk::entry $Name -width 30 -textvariable mssqls_rampup
-        grid $Prompt -column 0 -row 27 -sticky e
-        grid $Name -column 1 -row 27 -sticky ew
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky ew
         if {$mssqls_driver == "test" } {
             $Name configure -state disabled
         }
@@ -553,8 +605,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p19
         ttk::label $Prompt -text "Minutes for Test Duration :"
         ttk::entry $Name -width 30 -textvariable mssqls_duration
-        grid $Prompt -column 0 -row 28 -sticky e
-        grid $Name -column 1 -row 28 -sticky ew
+        grid $Prompt -column 0 -row 30 -sticky e
+        grid $Name -column 1 -row 30 -sticky ew
         if {$mssqls_driver == "test" } {
             $Name configure -state disabled
         }
@@ -562,8 +614,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p20
         ttk::label $Prompt -text "Use All Warehouses :"
         ttk::checkbutton $Name -text "" -variable mssqls_allwarehouse -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 29 -sticky e
-        grid $Name -column 1 -row 29 -sticky ew
+        grid $Prompt -column 0 -row 31 -sticky e
+        grid $Name -column 1 -row 31 -sticky ew
         if {$mssqls_driver == "test" } {
             $Name configure -state disabled
         }
@@ -571,8 +623,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p21
         ttk::label $Prompt -text "Time Profile :"
         ttk::checkbutton $Name -text "" -variable mssqls_timeprofile -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 30 -sticky e
-        grid $Name -column 1 -row 30 -sticky ew
+        grid $Prompt -column 0 -row 32 -sticky e
+        grid $Name -column 1 -row 32 -sticky ew
         if {$mssqls_driver == "test" } {
             $Name configure -state disabled
         }
@@ -580,8 +632,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p22
         ttk::label $Prompt -text "Asynchronous Scaling :"
         ttk::checkbutton $Name -text "" -variable mssqls_async_scale -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 31 -sticky e
-        grid $Name -column 1 -row 31 -sticky ew
+        grid $Prompt -column 0 -row 33 -sticky e
+        grid $Name -column 1 -row 33 -sticky ew
         if {$mssqls_driver == "test" } {
             set mssqls_async_scale "false"
             $Name configure -state disabled
@@ -605,8 +657,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p23
         ttk::label $Prompt -text "Asynch Clients per Virtual User :"
         ttk::entry $Name -width 30 -textvariable mssqls_async_client
-        grid $Prompt -column 0 -row 32 -sticky e
-        grid $Name -column 1 -row 32 -sticky ew
+        grid $Prompt -column 0 -row 34 -sticky e
+        grid $Name -column 1 -row 34 -sticky ew
         if {$mssqls_driver == "test" || $mssqls_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -614,8 +666,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p24
         ttk::label $Prompt -text "Asynch Client Login Delay :"
         ttk::entry $Name -width 30 -textvariable mssqls_async_delay
-        grid $Prompt -column 0 -row 33 -sticky e
-        grid $Name -column 1 -row 33 -sticky ew
+        grid $Prompt -column 0 -row 35 -sticky e
+        grid $Name -column 1 -row 35 -sticky ew
         if {$mssqls_driver == "test" || $mssqls_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -623,8 +675,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p25
         ttk::label $Prompt -text "Asynchronous Verbose :"
         ttk::checkbutton $Name -text "" -variable mssqls_async_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 34 -sticky e
-        grid $Name -column 1 -row 34 -sticky ew
+        grid $Prompt -column 0 -row 36 -sticky e
+        grid $Name -column 1 -row 36 -sticky ew
         if {$mssqls_driver == "test" || $mssqls_async_scale == "false" } {
             set mssqls_async_verbose "false"
             $Name configure -state disabled
@@ -633,8 +685,8 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p26
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mssqls_connect_pool -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 35 -sticky e
-        grid $Name -column 1 -row 35 -sticky ew
+        grid $Prompt -column 0 -row 37 -sticky e
+        grid $Name -column 1 -row 37 -sticky ew
     }
     #This is the Cancel button variables stay as before
     set Name $Parent.b2
@@ -648,6 +700,10 @@ proc configmssqlstpcc {option} {
     switch $option {
         "drive" {
             ttk::button $Name -command {
+	        if { ![ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}|\ynull\y} $mssqls_msi_object_id ] } {
+		tk_messageBox -message "MSI Object ID is not a valid format" 
+		set mssqls_msi_object_id "null" 
+	        }
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpcc
                 Dict2SQLite "mssqlserver" $configmssqlserver
                 unset mssqlsfields
@@ -657,6 +713,10 @@ proc configmssqlstpcc {option} {
         }
         "default" {
             ttk::button $Name -command {
+	        if { ![ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}|\ynull\y} $mssqls_msi_object_id ] } {
+		tk_messageBox -message "MSI Object ID is not a valid format" 
+		set mssqls_msi_object_id "null" 
+	        }
                 set mssqls_count_ware [ verify_warehouse $mssqls_count_ware 100000 ]
                 set mssqls_num_vu [ verify_build_threads $mssqls_num_vu $mssqls_count_ware 1024 ]
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpcc
@@ -684,10 +744,10 @@ proc configmssqlstpch {option} {
 
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqlsconn [ dict create connection { mssqls_linux_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_linux_odbc {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent} ]
+        set mssqlsconn [ dict create connection { mssqls_linux_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_linux_odbc {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqlsconn [ dict create connection { mssqls_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_odbc_driver {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication} ]
+        set mssqlsconn [ dict create connection { mssqls_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_odbc_driver {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
     variable mssqlsfields
     set mssqlsfields [ dict merge $mssqlsconn $tpchfields ]
@@ -786,72 +846,93 @@ proc configmssqlstpch {option} {
     grid $Prompt -column 0 -row 8 -sticky e
     set Name $Parent.f1.r1
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "windows" -text "Windows Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
     bind .mssqlstpch.f1.r1 <ButtonPress-1> {
         .mssqlstpch.f1.e4 configure -state disabled
         .mssqlstpch.f1.e5 configure -state disabled
-        
+        .mssqlstpch.f1.e5a configure -state disabled
     }
     set Name $Parent.f1.r2
     if { $platform eq "lin" } {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_linux_authent
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
-        ttk::radiobutton $Name -value "sql" -text "SQL Server Authentication" -variable mssqls_authentication
+        ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
     bind .mssqlstpch.f1.r2 <ButtonPress-1> {
         .mssqlstpch.f1.e4 configure -state normal
         .mssqlstpch.f1.e5 configure -state normal
-        .mssqlstpch.f1.e10 configure -state normal
+        .mssqlstpch.f1.e5a configure -state disabled
+    }
+    set Name $Parent.f1.r3
+    if { $platform eq "lin" } {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
+    } else {
+        ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
+    }
+    grid $Name -column 1 -row 10 -sticky w
+    bind .mssqlstpch.f1.r3 <ButtonPress-1> {
+        .mssqlstpch.f1.e4 configure -state disabled
+        .mssqlstpch.f1.e5 configure -state disabled
+        .mssqlstpch.f1.e5a configure -state normal
     }
     set Name $Parent.f1.e4
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
-    grid $Prompt -column 0 -row 10 -sticky e
-    grid $Name -column 1 -row 10 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky ew
+      if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e5
     set Prompt $Parent.f1.p5
     ttk::label $Prompt -text "SQL Server User Password :"
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
-    grid $Prompt -column 0 -row 11 -sticky e
-    grid $Name -column 1 -row 11 -sticky ew
-    if {($platform eq "win" && $mssqls_authentication == "windows") || ($platform eq "lin" && $mssqls_linux_authent == "windows") } {
+    grid $Prompt -column 0 -row 12 -sticky e
+    grid $Name -column 1 -row 12 -sticky ew
+      if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
+        $Name configure -state disabled
+    }
+    set Name $Parent.f1.e5a
+    set Prompt $Parent.f1.p5a
+    ttk::label $Prompt -text "MSI Object ID :"   
+    ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky ew
+    if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "sql")) || ($platform eq "lin" && ($mssqls_linux_authent == "windows"  || $mssqls_linux_authent == "sql" ) )} {
         $Name configure -state disabled
     }
     set Name $Parent.f1.e6
     set Prompt $Parent.f1.p6
     ttk::label $Prompt -text "TPROC-H SQL Server Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mssqls_tpch_dbase
-    grid $Prompt -column 0 -row 12 -sticky e
-    grid $Name -column 1 -row 12 -sticky ew
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky ew
     set Name $Parent.f1.e6a
     set Prompt $Parent.f1.p6a
     ttk::label $Prompt -text "MAXDOP :"
     ttk::entry $Name -width 30 -textvariable mssqls_maxdop
-    grid $Prompt -column 0 -row 13 -sticky e
-    grid $Name -column 1 -row 13 -columnspan 4 -sticky ew
+    grid $Prompt -column 0 -row 15 -sticky e
+    grid $Name -column 1 -row 15 -columnspan 4 -sticky ew
     if { $option eq "all" || $option eq "build" } {
         set Prompt $Parent.f1.p7
         ttk::label $Prompt -text "Clustered Columnstore :"
         set Name $Parent.f1.e7
         ttk::checkbutton $Name -text "" -variable mssqls_colstore -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 14 -sticky e
-        grid $Name -column 1 -row 14 -sticky w
+        grid $Prompt -column 0 -row 16 -sticky e
+        grid $Name -column 1 -row 16 -sticky w
         set Name $Parent.f1.e8
         set Prompt $Parent.f1.p8 
         ttk::label $Prompt -text "Scale Factor :"
-        grid $Prompt -column 0 -row 15 -sticky e
+        grid $Prompt -column 0 -row 17 -sticky e
         set Name $Parent.f1.f2
         ttk::frame $Name -width 30
-        grid $Name -column 1 -row 15 -sticky ew
+        grid $Name -column 1 -row 17 -sticky ew
         set rcnt 1
         foreach item {1} {
             set Name $Parent.f1.f2.r$rcnt
@@ -884,30 +965,30 @@ proc configmssqlstpch {option} {
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e9
         ttk::spinbox $Name -from 1 -to 512 -textvariable mssqls_num_tpch_threads
-        grid $Prompt -column 0 -row 16 -sticky e
-        grid $Name -column 1 -row 16 -sticky ew
+        grid $Prompt -column 0 -row 18 -sticky e
+        grid $Name -column 1 -row 18 -sticky ew
 
         set Prompt $Parent.f1.p10
         set Name $Parent.f1.e10
         ttk::label $Prompt -text "Use BCP Option:"
         ttk::checkbutton $Name -text "" -variable mssqls_tpch_use_bcp -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 17 -sticky e
-        grid $Name -column 1 -row 17 -sticky w
+        grid $Prompt -column 0 -row 19 -sticky e
+        grid $Name -column 1 -row 19 -sticky w
 
 
         set Prompt $Parent.f1.p11
         set Name $Parent.f1.e11
         ttk::label $Prompt -text "Partition Orders and Lineitems:"
         ttk::checkbutton $Name -text "" -variable mssqls_tpch_partition_orders_and_lineitems -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 18 -sticky e
-        grid $Name -column 1 -row 18 -sticky w
+        grid $Prompt -column 0 -row 20 -sticky e
+        grid $Name -column 1 -row 20 -sticky w
         
         set Prompt $Parent.f1.p12
         set Name $Parent.f1.e12
         ttk::label $Prompt -text "Create Advanced Statistics:"
         ttk::checkbutton $Name -text "" -variable mssqls_tpch_advanced_stats -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 19 -sticky e
-        grid $Name -column 1 -row 19 -sticky w
+        grid $Prompt -column 0 -row 21 -sticky e
+        grid $Name -column 1 -row 21 -sticky w
 
         
     }
@@ -915,35 +996,35 @@ proc configmssqlstpch {option} {
         if { $option eq "all" } {
             set Prompt $Parent.f1.h3
             ttk::label $Prompt -image [ create_image driveroptlo icons ]
-            grid $Prompt -column 0 -row 18 -sticky e
+            grid $Prompt -column 0 -row 22 -sticky e
             set Prompt $Parent.f1.h4
             ttk::label $Prompt -text "Driver Options"
-            grid $Prompt -column 1 -row 18 -sticky w
+            grid $Prompt -column 1 -row 22 -sticky w
         }
         set Name $Parent.f1.e10
         set Prompt $Parent.f1.p10
         ttk::label $Prompt -text "Total Query Sets per User :"
         ttk::entry $Name -width 30 -textvariable mssqls_total_querysets
-        grid $Prompt -column 0 -row 19 -sticky e
-        grid $Name -column 1 -row 19  -columnspan 4 -sticky ew
+        grid $Prompt -column 0 -row 23 -sticky e
+        grid $Name -column 1 -row 23 -columnspan 4 -sticky ew
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Exit on SQL Server Error :"
         set Name $Parent.f1.e11
         ttk::checkbutton $Name -text "" -variable mssqls_raise_query_error -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 20 -sticky e
-        grid $Name -column 1 -row 20 -sticky w
+        grid $Prompt -column 0 -row 24 -sticky e
+        grid $Name -column 1 -row 24 -sticky w
         set Prompt $Parent.f1.p12
         ttk::label $Prompt -text "Verbose Output :"
         set Name $Parent.f1.e12
         ttk::checkbutton $Name -text "" -variable mssqls_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 21 -sticky e
-        grid $Name -column 1 -row 21 -sticky w
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky w
         set Prompt $Parent.f1.p13
         ttk::label $Prompt -text "Refresh Function :"
         set Name $Parent.f1.e13
         ttk::checkbutton $Name -text "" -variable mssqls_refresh_on -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 22 -sticky e
-        grid $Name -column 1 -row 22 -sticky w
+        grid $Prompt -column 0 -row 26 -sticky e
+        grid $Name -column 1 -row 26 -sticky w
         bind $Parent.f1.e13 <Button> {
             if {$mssqls_refresh_on eq "true"} { 
                 set mssqls_refresh_verbose "false"
@@ -960,8 +1041,8 @@ proc configmssqlstpch {option} {
         set Prompt $Parent.f1.p14
         ttk::label $Prompt -text "Number of Update Sets :"
         ttk::entry $Name -width 30 -textvariable mssqls_update_sets
-        grid $Prompt -column 0 -row 23 -sticky e
-        grid $Name -column 1 -row 23  -columnspan 4 -sticky ew
+        grid $Prompt -column 0 -row 27 -sticky e
+        grid $Name -column 1 -row 27  -columnspan 4 -sticky ew
         if {$mssqls_refresh_on == "false" } {
             $Name configure -state disabled
         }
@@ -969,8 +1050,8 @@ proc configmssqlstpch {option} {
         set Prompt $Parent.f1.p15
         ttk::label $Prompt -text "Trickle Refresh Delay(ms) :"
         ttk::entry $Name -width 30 -textvariable mssqls_trickle_refresh
-        grid $Prompt -column 0 -row 24 -sticky e
-        grid $Name -column 1 -row 24  -columnspan 4 -sticky ew
+        grid $Prompt -column 0 -row 28 -sticky e
+        grid $Name -column 1 -row 28  -columnspan 4 -sticky ew
         if {$mssqls_refresh_on == "false" } {
             $Name configure -state disabled
         }
@@ -978,8 +1059,8 @@ proc configmssqlstpch {option} {
         ttk::label $Prompt -text "Refresh Verbose :"
         set Name $Parent.f1.e16
         ttk::checkbutton $Name -text "" -variable mssqls_refresh_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 25 -sticky e
-        grid $Name -column 1 -row 25 -sticky w
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky w
         if {$mssqls_refresh_on == "false" } {
             $Name configure -state disabled
         }
@@ -994,6 +1075,10 @@ proc configmssqlstpch {option} {
     switch $option {
         "drive" {
             ttk::button $Name -command {
+	        if { ![ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}|\ynull\y} $mssqls_msi_object_id ] } {
+		tk_messageBox -message "MSI Object ID is not a valid format" 
+		set mssqls_msi_object_id "null" 
+	        }
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpch
                 Dict2SQLite "mssqlserver" $configmssqlserver
                 unset mssqlsfields
@@ -1003,6 +1088,10 @@ proc configmssqlstpch {option} {
         }
         "default" {
             ttk::button $Name -command {
+		if { ![ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}|\ynull\y} $mssqls_msi_object_id ] } {
+		tk_messageBox -message "MSI Object ID is not a valid format" 
+		set mssqls_msi_object_id "null" 
+	        }
                 set mssqls_num_tpch_threads [ verify_build_threads $mssqls_num_tpch_threads 512 512 ]
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpch
                 Dict2SQLite "mssqlserver" $configmssqlserver

--- a/src/mssqlserver/mssqlsotc.tcl
+++ b/src/mssqlserver/mssqlsotc.tcl
@@ -10,26 +10,34 @@ proc tcount_mssqls {bm interval masterthread} {
     }
     #Setup Transaction Counter Thread
     set tc_threadID [thread::create {
-        proc read_more { MASTER library version mssqls_server mssqls_port mssqls_authentication mssqls_odbc_driver mssqls_uid mssqls_pass mssqls_tcp mssqls_azure mssqls_encrypt_connection mssqls_trust_server_cert db interval old tce bm } {
+        proc read_more { MASTER library version mssqls_server mssqls_port mssqls_authentication mssqls_odbc_driver mssqls_uid mssqls_pass mssqls_tcp mssqls_azure mssqls_encrypt_connection mssqls_trust_server_cert msi_object_id db interval old tce bm } {
             set timeout 0
             set iconflag 0
-	    proc connect_string { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert} {
-    		if { $tcp eq "true" } { set server tcp:$server,$port }
-    		if {[ string toupper $authentication ] eq "WINDOWS" } {
-        	set connection "DRIVER=$odbc_driver;SERVER=$server;TRUSTED_CONNECTION=YES"
-    		} else {
-        		if {[ string toupper $authentication ] eq "SQL" } {
-            		set connection "DRIVER=$odbc_driver;SERVER=$server;UID=$uid;PWD=$pwd"
-        		} else {
-            		puts stderr "Error: neither WINDOWS or SQL Authentication has been specified"
-            		set connection "DRIVER=$odbc_driver;SERVER=$server"
-        		}
-    		}
-    		if { $azure eq "true" } { append connection ";" "DATABASE=$db" }
-    		if { $encrypt eq "true" } { append connection ";" "ENCRYPT=yes" } else { append connection ";" "ENCRYPT=no" }
-    		if { $trust_cert eq "true" } { append connection ";" "TRUSTSERVERCERTIFICATE=yes" }
-    		return $connection
-	  }
+            proc connect_string { server port odbc_driver authentication uid pwd tcp azure db encrypt trust_cert msi_object_id} {
+                 if { $tcp eq "true" } { set server tcp:$server,$port }
+                 if {[ string toupper $authentication ] eq "WINDOWS" } {
+                     set connection "DRIVER=$odbc_driver;SERVER=$server;TRUSTED_CONNECTION=YES"
+               } else {
+                 if {[ string toupper $authentication ] eq "SQL" } {
+                     set connection "DRIVER=$odbc_driver;SERVER=$server;UID=$uid;PWD=$pwd"
+               } else {
+                 if {[ string toupper $authentication ] eq "ENTRA" } {
+                 if {[ regexp {[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}} $msi_object_id ] } {
+                     set connection "DRIVER=$odbc_driver;SERVER=$server;AUTHENTICATION=ActiveDirectoryMsi;UID=$msi_object_id"
+	       } else {
+                     set connection "DRIVER=$odbc_driver;SERVER=$server;AUTHENTICATION=ActiveDirectoryInteractive"
+	       }
+               } else {
+                     puts stderr "Error: neither WINDOWS, ENTRA or SQL Authentication has been specified"
+                     set connection "DRIVER=$odbc_driver;SERVER=$server"
+               }
+              }
+             }
+                if { $azure eq "true" } { append connection ";" "DATABASE=$db" }
+                if { $encrypt eq "true" } { append connection ";" "ENCRYPT=yes" } else { append connection ";" "ENCRYPT=no" }
+                if { $trust_cert eq "true" } { append connection ";" "TRUSTSERVERCERTIFICATE=yes" }
+                return $connection
+             }
             if { $interval <= 0 } { set interval 10 } 
             set gcol "yellow"
             if { ![ info exists tcdata ] } { set tcdata {} }
@@ -60,7 +68,7 @@ proc tcount_mssqls {bm interval masterthread} {
             } else {
                 namespace import tcountcommon::*
             }
-            set connection [ connect_string $mssqls_server $mssqls_port $mssqls_odbc_driver $mssqls_authentication $mssqls_uid $mssqls_pass $mssqls_tcp $mssqls_azure $db $mssqls_encrypt_connection $mssqls_trust_server_cert ]
+            set connection [ connect_string $mssqls_server $mssqls_port $mssqls_odbc_driver $mssqls_authentication $mssqls_uid $mssqls_pass $mssqls_tcp $mssqls_azure $db $mssqls_encrypt_connection $mssqls_trust_server_cert $msi_object_id ]
             if [catch {tdbc::odbc::connection create tc_odbc $connection} message ] {
                 tsv::set application tc_errmsg "connection failed $message"
                 eval [subst {thread::send $MASTER show_tc_errmsg}]
@@ -152,5 +160,5 @@ proc tcount_mssqls {bm interval masterthread} {
     }
     set old 0
     #Call Transaction Counter to start read_more loop
-    eval [ subst {thread::send -async $tc_threadID { read_more $masterthread $library $version {$mssqls_server} $mssqls_port $mssqls_authentication {$mssqls_odbc_driver} $mssqls_uid [ quotemeta $mssqls_pass ] $mssqls_tcp $mssqls_azure $mssqls_encrypt_connection $mssqls_trust_server_cert $db $interval $old tce $bm }}]
+    eval [ subst {thread::send -async $tc_threadID { read_more $masterthread $library $version {$mssqls_server} $mssqls_port $mssqls_authentication {$mssqls_odbc_driver} $mssqls_uid [ quotemeta $mssqls_pass ] $mssqls_tcp $mssqls_azure $mssqls_encrypt_connection $mssqls_trust_server_cert $mssqls_msi_object_id $db $interval $old tce $bm }}]
 } 


### PR DESCRIPTION
Adds support for Microsoft Entra authentication for SQL Server workloads as discussed in Issue https://github.com/TPC-Council/HammerDB/issues/662

Note that as discussed in the issue, I have not tested this directly and have no means to do so, so fully reliant on feedback to verify that the correct functionality has been added. Windows and SQL authentication have been re-tested to make sure the added functionality does not impact the existing ones.

One question that is worth verifying is what happens when using interactive authentication if we have multiple virtual users? We can have hundreds or thousands (with asynchronous connections) - will all virtual users produce an interactive prompt? 

To test, it is recommended to build from source on windows. This is very easy and just takes 1 command to build.  Firstly, make sure you have visual studio 2022 installed. 

Then download the zip file from here https://github.com/sm-shaw/HammerDB/tree/662 under the code tab. 

Extract this into a directory of your choice and if you only want to test SQL Server edit the setup file as shown:

`C:\HammerDB-662\HammerDB-662\Build\Bawt-2.1.0\Setup`

edit HammerDB-Windows.bawt to comment out unneeded database interfaces

```
# Compiled Tcl Database interface packages.
#Setup oratcl            oratcl-4.6.7z                  oratcl_NMake.bawt	
#Setup mariatcl          mariatcl-0.1.7z                mariatcl_NMake.bawt
#Setup mysqltcl          mysqltcl-3.052.7z              mysqltcl_NMake.bawt
#Setup pgtcl             pgtcl-2.1.1.7z                 pgtcl_NMake.bawt	
#Setup db2tcl            db2tcl-2.0.1.7z                db2tcl_NMake.bawt
```
Then cd to the Bawt directory with a command prompt

`cd C:\HammerDB-662\HammerDB-662\Build\Bawt-2.1.0`

Set your python directory (or comment this out as well in the setup file)
`
set PYTHONHOME=C:\Users\UserName\AppData\Local\Programs\Python\Python310`

and then run the build

`Build-Windows.bat x64 vs2022+gcc Setup\HammerDB-Windows.bawt update`

Note that compilation time on Windows is impacted a lot by Windows defender and temporarily turning off realtime protection will improve the compile time. 

When complete the GUI will show that all packages built successfully. 

<img width="617" alt="bawt1" src="https://github.com/TPC-Council/HammerDB/assets/38044085/390bba02-b1fe-4380-9a79-2e1ee2a23126">

Then a zip file (and directory) with the latest build for testing will be in this directory. 

`C:\HammerDB-662\HammerDB-662\Build\BawtBuild\vs2022\x64\Release\Distribution`