### PR TITLE
Increase default CLI timeouts

### DIFF
--- a/config/generic.xml
+++ b/config/generic.xml
@@ -63,7 +63,7 @@
     </datageneration>
     <commandline>
 	<sqlite_db>TMP</sqlite_db> 
-        <keepalive_margin>10</keepalive_margin>
+        <keepalive_margin>60</keepalive_margin>
         <jobsoutput>JSON</jobsoutput>
         <jobs_disable>0</jobs_disable>
     </commandline>
@@ -73,7 +73,7 @@
     <timeprofile>
            <profiler>xtprof</profiler>
            <xt_unique_log_name>0</xt_unique_log_name>
-           <xt_gather_timeout>10</xt_gather_timeout>
+           <xt_gather_timeout>60</xt_gather_timeout>
            <xt_job_storage>1</xt_job_storage>
     </timeprofile>
 </hammerdb>


### PR DESCRIPTION
Resolves issue #667 by increasing default CLI timeout values from 10 to 60 seconds. 
Values can be increased or decreased by new giset command at the next release. 