### PR TITLE
Change GUI properties dailogs to tabbed

### DIFF
--- a/src/db2/db2opt.tcl
+++ b/src/db2/db2opt.tcl
@@ -13,9 +13,9 @@ proc countdb2opts { bm } {
     setlocaltcountvars $configdb2 1
     variable db2optsfields
     if { $bm eq "TPC-C" } {
-        set db2optsfields [ dict create connection {db2_def_user {.countopt.f1.e1 get} db2_def_pass {.countopt.f1.e2 get} db2_def_dbase {.countopt.f1.e3 get}} tpcc {db2_user {.countopt.f1.e1 get} db2_pass {.countopt.f1.e2 get} db2_dbase {.countopt.f1.e3 get}} ]
+        set db2optsfields [ dict create connection {db2_def_user {.countopt.c1.e1 get} db2_def_pass {.countopt.c1.e2 get} db2_def_dbase {.countopt.c1.e3 get}} tpcc {db2_user {.countopt.c1.e1 get} db2_pass {.countopt.c1.e2 get} db2_dbase {.countopt.c1.e3 get}} ]
     } else {
-        set db2optsfields [ dict create connection {db2_def_user {.countopt.f1.e1 get} db2_def_pass {.countopt.f1.e2 get} db2_def_dbase {.countopt.f1.e3 get}} tpch {db2_tpch_user {.countopt.f1.e1 get} db2_tpch_pass {.countopt.f1.e2 get} db2_tpch_dbase {.countopt.f1.e3 get}} ]
+        set db2optsfields [ dict create connection {db2_def_user {.countopt.c1.e1 get} db2_def_pass {.countopt.c1.e2 get} db2_def_dbase {.countopt.c1.e3 get}} tpch {db2_tpch_user {.countopt.c1.e1 get} db2_tpch_pass {.countopt.c1.e2 get} db2_tpch_dbase {.countopt.c1.e3 get}} ]
     }
 
     if { [ info exists afval ] } {
@@ -39,29 +39,28 @@ proc countdb2opts { bm } {
     wm withdraw .countopt
     wm title .countopt {Db2 TX Counter Options}
     set Parent .countopt
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "TPROC-C Db2 User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable $tmp_db2_user
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "TPROC-C Db2 User Password :" -image [ create_image hdbicon icons ] -compound left 
     ttk::entry $Name -show * -width 30 -textvariable $tmp_db2_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "TPROC-C Db2 Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable $tmp_db2_dbase
     grid $Prompt -column 0 -row 3 -sticky e
@@ -102,7 +101,7 @@ proc countdb2opts { bm } {
         $Name configure -state disabled
     }
 
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -170,7 +169,7 @@ proc configdb2tpcc {option} {
     setlocaltpccvars $configdb2
     #set matching fields in dialog to temporary dict
     variable db2fields
-    set db2fields [ dict create connection {db2_def_user {.tpc.f1.e1 get} db2_def_pass {.tpc.f1.e2 get} db2_def_dbase {.tpc.f1.e3 get}} tpcc {db2_user {.tpc.f1.e1 get} db2_pass {.tpc.f1.e2 get} db2_dbase {.tpc.f1.e3 get} db2_def_tab {.tpc.f1.e4 get} db2_tab_list {.tpc.f1.e5 get} db2_total_iterations {.tpc.f1.e14 get} db2_rampup {.tpc.f1.e17 get} db2_duration {.tpc.f1.e18 get} db2_monreport {.tpc.f1.e19 get} db2_async_client {.tpc.f1.e23 get} db2_async_delay {.tpc.f1.e24 get} db2_count_ware $db2_count_ware db2_num_vu $db2_num_vu db2_partition $db2_partition db2_driver $db2_driver db2_raiseerror $db2_raiseerror db2_keyandthink $db2_keyandthink db2_allwarehouse $db2_allwarehouse db2_timeprofile $db2_timeprofile db2_async_scale $db2_async_scale db2_async_verbose $db2_async_verbose db2_connect_pool $db2_connect_pool} ]
+    set db2fields [ dict create connection {db2_def_user {.tpc.c1.e1 get} db2_def_pass {.tpc.c1.e2 get} db2_def_dbase {.tpc.c1.e3 get}} tpcc {db2_user {.tpc.c1.e1 get} db2_pass {.tpc.c1.e2 get} db2_dbase {.tpc.c1.e3 get} db2_def_tab {.tpc.f1.e4 get} db2_tab_list {.tpc.f1.e5 get} db2_total_iterations {.tpc.f1.e14 get} db2_rampup {.tpc.f1.e17 get} db2_duration {.tpc.f1.e18 get} db2_monreport {.tpc.f1.e19 get} db2_async_client {.tpc.f1.e23 get} db2_async_delay {.tpc.f1.e24 get} db2_count_ware $db2_count_ware db2_num_vu $db2_num_vu db2_partition $db2_partition db2_driver $db2_driver db2_raiseerror $db2_raiseerror db2_keyandthink $db2_keyandthink db2_allwarehouse $db2_allwarehouse db2_timeprofile $db2_timeprofile db2_async_scale $db2_async_scale db2_async_verbose $db2_async_verbose db2_connect_pool $db2_connect_pool} ]
     set whlist [ get_warehouse_list_for_spinbox ]
     catch "destroy .tpc"
     ttk::toplevel .tpc
@@ -182,38 +181,34 @@ proc configdb2tpcc {option} {
         "drive" {  wm title .tpc {Db2 TPROC-C Driver Options} }
     }
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "TPROC-C Db2 User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable db2_user
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "TPROC-C Db2 User Password :" -image [ create_image hdbicon icons ] -compound left 
     ttk::entry $Name -show * -width 30 -textvariable db2_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "TPROC-C Db2 Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable db2_dbase
     grid $Prompt -column 0 -row 3 -sticky e
@@ -227,7 +222,7 @@ proc configdb2tpcc {option} {
         grid $Name -column 1 -row 4 -sticky ew
         set Name $Parent.f1.e5
         set Prompt $Parent.f1.p5
-        ttk::label $Prompt -text "TPROC-C Db2 Tablespace List (Space Separated Values) :" -image [ create_image hdbicon icons ] -compound left
+        ttk::label $Prompt -text "TPROC-C Db2 Tablespace List :" -image [ create_image hdbicon icons ] -compound left
         ttk::entry $Name -width 30 -textvariable db2_tab_list
         if { $db2_partition eq "false" } {
             .tpc.f1.e5 configure -state disabled
@@ -473,8 +468,8 @@ proc configdb2tpcc {option} {
             set db2_async_verbose "false"
             $Name configure -state disabled
         }
-        set Name $Parent.f1.e26
-        set Prompt $Parent.f1.p26
+        set Name $Parent.c1.e26
+        set Prompt $Parent.c1.p26
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable db2_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 26 -sticky e
@@ -525,7 +520,7 @@ proc configdb2tpch {option} {
     setlocaltpchvars $configdb2
     #set matching fields in dialog to temporary dict
     variable db2fields
-    set db2fields [ dict create connection {db2_def_user {.db2tpch.f1.e1 get} db2_def_pass {.db2tpch.f1.e2 get} db2_def_dbase {.db2tpch.f1.e3 get}} tpch {db2_tpch_user {.db2tpch.f1.e1 get} db2_tpch_pass {.db2tpch.f1.e2 get} db2_tpch_dbase {.db2tpch.f1.e3 get} db2_tpch_def_tab {.db2tpch.f1.e4 get} db2_total_querysets {.db2tpch.f1.e9 get} db2_degree_of_parallel {.db2tpch.f1.e12 get} db2_update_sets {.db2tpch.f1.e14 get} db2_trickle_refresh {.db2tpch.f1.e15 get} db2_scale_fact $db2_scale_fact db2_num_tpch_threads $db2_num_tpch_threads db2_tpch_organizeby $db2_tpch_organizeby db2_raise_query_error $db2_raise_query_error db2_verbose $db2_verbose db2_refresh_on $db2_refresh_on db2_refresh_verbose $db2_refresh_verbose} ]
+    set db2fields [ dict create connection {db2_def_user {.db2tpch.c1.e1 get} db2_def_pass {.db2tpch.c1.e2 get} db2_def_dbase {.db2tpch.c1.e3 get}} tpch {db2_tpch_user {.db2tpch.c1.e1 get} db2_tpch_pass {.db2tpch.c1.e2 get} db2_tpch_dbase {.db2tpch.c1.e3 get} db2_tpch_def_tab {.db2tpch.f1.e4 get} db2_total_querysets {.db2tpch.f1.e9 get} db2_degree_of_parallel {.db2tpch.f1.e12 get} db2_update_sets {.db2tpch.f1.e14 get} db2_trickle_refresh {.db2tpch.f1.e15 get} db2_scale_fact $db2_scale_fact db2_num_tpch_threads $db2_num_tpch_threads db2_tpch_organizeby $db2_tpch_organizeby db2_raise_query_error $db2_raise_query_error db2_verbose $db2_verbose db2_refresh_on $db2_refresh_on db2_refresh_verbose $db2_refresh_verbose} ]
     catch "destroy .db2tpch"
     ttk::toplevel .db2tpch
     wm transient .db2tpch .ed_mainFrame
@@ -536,38 +531,34 @@ proc configdb2tpch {option} {
         "drive" {  wm title .db2tpch {Db2 TPROC-H Driver Options} }
     }
     set Parent .db2tpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "TPROC-H Db2 User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable db2_tpch_user
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "TPROC-H Db2 User Password :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -show * -width 30 -textvariable db2_tpch_pass
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "TPROC-H Db2 Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable db2_tpch_dbase
     grid $Prompt -column 0 -row 3 -sticky e

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -90,18 +90,18 @@ proc countmariaopts { bm } {
     if { $bm eq "TPC-C" } {
    if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mariaoptsfields [ dict create connection {maria_host {.countopt.f1.e1 get} maria_port {.countopt.f1.e2 get} maria_socket {.countopt.f1.e2a get} maria_ssl_ca {.countopt.f1.e2d get} maria_ssl_cert {.countopt.f1.e2e get} maria_ssl_key {.countopt.f1.e2f get} maria_ssl_cipher {.countopt.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} tpcc {maria_user {.countopt.f1.e3 get} maria_pass {.countopt.f1.e4 get}} ]
+        set mariaoptsfields [ dict create connection {maria_host {.countopt.c1.e1 get} maria_port {.countopt.c1.e2 get} maria_socket {.countopt.c1.e2a get} maria_ssl_ca {.countopt.c1.e2d get} maria_ssl_cert {.countopt.c1.e2e get} maria_ssl_key {.countopt.c1.e2f get} maria_ssl_cipher {.countopt.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} tpcc {maria_user {.countopt.c1.e3 get} maria_pass {.countopt.c1.e4 get}} ]
         } else {
         set platform "win"
-        set mariaoptsfields [ dict create connection {maria_host {.countopt.f1.e1 get} maria_port {.countopt.f1.e2 get} maria_socket {.countopt.f1.e2a get} maria_ssl_ca {.countopt.f1.e2d get} maria_ssl_cert {.countopt.f1.e2e get} maria_ssl_key {.countopt.f1.e2f get} maria_ssl_cipher {.countopt.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} tpcc {maria_user {.countopt.f1.e3 get} maria_pass {.countopt.f1.e4 get}} ]
+        set mariaoptsfields [ dict create connection {maria_host {.countopt.c1.e1 get} maria_port {.countopt.c1.e2 get} maria_socket {.countopt.c1.e2a get} maria_ssl_ca {.countopt.c1.e2d get} maria_ssl_cert {.countopt.c1.e2e get} maria_ssl_key {.countopt.c1.e2f get} maria_ssl_cipher {.countopt.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} tpcc {maria_user {.countopt.c1.e3 get} maria_pass {.countopt.c1.e4 get}} ]
         }
     } else {
    if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mariaoptsfields [ dict create connection {maria_host {.countopt.f1.e1 get} maria_port {.countopt.f1.e2 get} maria_socket {.countopt.f1.e2a get} maria_ssl_ca {.countopt.f1.e2d get} maria_ssl_cert {.countopt.f1.e2e get} maria_ssl_key {.countopt.f1.e2f get} maria_ssl_cipher {.countopt.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} tpch {maria_tpch_user {.countopt.f1.e3 get} maria_tpch_pass {.countopt.f1.e4 get}} ]
+        set mariaoptsfields [ dict create connection {maria_host {.countopt.c1.e1 get} maria_port {.countopt.c1.e2 get} maria_socket {.countopt.c1.e2a get} maria_ssl_ca {.countopt.c1.e2d get} maria_ssl_cert {.countopt.c1.e2e get} maria_ssl_key {.countopt.c1.e2f get} maria_ssl_cipher {.countopt.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} tpch {maria_tpch_user {.countopt.c1.e3 get} maria_tpch_pass {.countopt.c1.e4 get}} ]
         } else {
         set platform "win"
-        set mariaoptsfields [ dict create connection {maria_host {.countopt.f1.e1 get} maria_port {.countopt.f1.e2 get} maria_socket {.countopt.f1.e2a get} maria_ssl_ca {.countopt.f1.e2d get} maria_ssl_cert {.countopt.f1.e2e get} maria_ssl_key {.countopt.f1.e2f get} maria_ssl_cipher {.countopt.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} tpch {maria_tpch_user {.countopt.f1.e3 get} maria_tpch_pass {.countopt.f1.e4 get}} ]
+        set mariaoptsfields [ dict create connection {maria_host {.countopt.c1.e1 get} maria_port {.countopt.c1.e2 get} maria_socket {.countopt.c1.e2a get} maria_ssl_ca {.countopt.c1.e2d get} maria_ssl_cert {.countopt.c1.e2e get} maria_ssl_key {.countopt.c1.e2f get} maria_ssl_cipher {.countopt.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} tpch {maria_tpch_user {.countopt.c1.e3 get} maria_tpch_pass {.countopt.c1.e4 get}} ]
         }
     }
     if { [ info exists afval ] } {
@@ -115,29 +115,28 @@ proc countmariaopts { bm } {
     wm withdraw .countopt
     wm title .countopt {MariaDB TX Counter Options}
     set Parent .countopt
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MariaDB Host :"
     ttk::entry $Name -width 30 -textvariable maria_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MariaDB Port :"   
     ttk::entry $Name  -width 30 -textvariable maria_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MariaDB Socket :"   
     ttk::entry $Name  -width 30 -textvariable maria_socket
     grid $Prompt -column 0 -row 3 -sticky e
@@ -145,63 +144,67 @@ proc countmariaopts { bm } {
 
     if {[string match windows $::tcl_platform(platform)]} {
         set maria_socket "null"
-        .countopt.f1.e2a configure -state disabled
+        .countopt.c1.e2a configure -state disabled
     }
 
-    set Name $Parent.f1.e2b
-        set Prompt $Parent.f1.p2b
+    set Name $Parent.c1.e2b
+        set Prompt $Parent.c1.p2b
         ttk::label $Prompt -text "Enable SSL :"
         ttk::checkbutton $Name -text "" -variable maria_ssl -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 4 -sticky e
         grid $Name -column 1 -row 4 -sticky w
 
-         bind .countopt.f1.e2b <Any-ButtonRelease> {
+         bind .countopt.c1.e2b <Any-ButtonRelease> {
             if { $maria_ssl eq "true" } {
-                .countopt.f1.e2ba configure -state disabled
-                .countopt.f1.e2bb configure -state disabled
-                .countopt.f1.e2c configure -state disabled
-                .countopt.f1.e2d configure -state disabled
-                .countopt.f1.e2e configure -state disabled
-                .countopt.f1.e2f configure -state disabled
-                .countopt.f1.e2g configure -state disabled
+                .countopt.c1.e2ba configure -state disabled
+                .countopt.c1.e2bb configure -state disabled
+                .countopt.c1.e2c configure -state disabled
+                .countopt.c1.e2d configure -state disabled
+                .countopt.c1.e2e configure -state disabled
+                .countopt.c1.e2f configure -state disabled
+                .countopt.c1.e2g configure -state disabled
             } else {
-                .countopt.f1.e2ba configure -state normal
-                .countopt.f1.e2bb configure -state normal
-                .countopt.f1.e2c configure -state normal
-                .countopt.f1.e2d configure -state normal
+                .countopt.c1.e2ba configure -state normal
+                .countopt.c1.e2bb configure -state normal
+                .countopt.c1.e2c configure -state normal
+                .countopt.c1.e2d configure -state normal
                 if { $maria_ssl_two_way eq "true" } {
-                .countopt.f1.e2e configure -state normal
-                .countopt.f1.e2f configure -state normal
+                .countopt.c1.e2e configure -state normal
+                .countopt.c1.e2f configure -state normal
                         }
-                .countopt.f1.e2g configure -state normal
+                .countopt.c1.e2g configure -state normal
                 }
             }
 
-	    set Name $Parent.f1.e2ba
+	    set Name $Parent.c1.e2ba
         ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 5 -sticky w
         if { $maria_ssl eq "false" } {
-                .countopt.f1.e2ba configure -state disabled
+                .countopt.c1.e2ba configure -state disabled
         }
-        bind .countopt.f1.e2ba <ButtonPress-1> {
-                .countopt.f1.e2e configure -state disabled
-                .countopt.f1.e2f configure -state disabled
+        bind .countopt.c1.e2ba <ButtonPress-1> {
+        if { $maria_ssl eq "true" } {
+                .countopt.c1.e2e configure -state disabled
+                .countopt.c1.e2f configure -state disabled
+	   }
         }
 
-        set Name $Parent.f1.e2bb
+        set Name $Parent.c1.e2bb
         ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 6 -sticky w
         if { $maria_ssl eq "false" } {
-                .countopt.f1.e2bb configure -state disabled
+                .countopt.c1.e2bb configure -state disabled
         }
 
-        bind .countopt.f1.e2bb <ButtonPress-1> {
-                .countopt.f1.e2e configure -state normal
-                .countopt.f1.e2f configure -state normal
+        bind .countopt.c1.e2bb <ButtonPress-1> {
+        if { $maria_ssl eq "true" } {
+                .countopt.c1.e2e configure -state normal
+                .countopt.c1.e2f configure -state normal
+	   }
         }
 
-	set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+	set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
      if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable maria_ssl_linux_capath
@@ -214,8 +217,8 @@ proc countmariaopts { bm } {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -224,8 +227,8 @@ proc countmariaopts { bm } {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+    set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -234,8 +237,8 @@ proc countmariaopts { bm } {
             $Name configure -state disabled
         }
 
-	  set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+	  set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -244,8 +247,8 @@ proc countmariaopts { bm } {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -254,8 +257,8 @@ proc countmariaopts { bm } {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MariaDB User :"
 
     if { $bm eq "TPC-C" } {
@@ -266,8 +269,8 @@ proc countmariaopts { bm } {
 
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MariaDB User Password :"   
 
     if { $bm eq "TPC-C" } {
@@ -314,7 +317,7 @@ proc countmariaopts { bm } {
         $Name configure -state disabled
     }
 
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -384,13 +387,13 @@ proc configmariatpcc {option} {
 
     #set variables to values in dict
     setlocaltpccvars $configmariadb
-    set tpccfields [ dict create tpcc {maria_user {.tpc.f1.e3 get} maria_pass {.tpc.f1.e4 get} maria_dbase {.tpc.f1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_no_stored_procs $maria_no_stored_procs maria_connect_pool $maria_connect_pool maria_history_pk $maria_history_pk maria_purge $maria_purge} ]
+    set tpccfields [ dict create tpcc {maria_user {.tpc.c1.e3 get} maria_pass {.tpc.c1.e4 get} maria_dbase {.tpc.c1.e5 get} maria_storage_engine {.tpc.f1.e6 get} maria_total_iterations {.tpc.f1.e14 get} maria_rampup {.tpc.f1.e17 get} maria_duration {.tpc.f1.e18 get} maria_async_client {.tpc.f1.e22 get} maria_async_delay {.tpc.f1.e23 get} maria_count_ware $maria_count_ware maria_num_vu $maria_num_vu maria_partition $maria_partition maria_driver $maria_driver maria_raiseerror $maria_raiseerror maria_keyandthink $maria_keyandthink maria_allwarehouse $maria_allwarehouse maria_timeprofile $maria_timeprofile maria_async_scale $maria_async_scale maria_async_verbose $maria_async_verbose maria_prepared $maria_prepared maria_no_stored_procs $maria_no_stored_procs maria_connect_pool $maria_connect_pool maria_history_pk $maria_history_pk maria_purge $maria_purge} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-    set mariaconn [ dict create connection {maria_host {.tpc.f1.e1 get} maria_port {.tpc.f1.e2 get} maria_socket {.tpc.f1.e2a get} maria_ssl_ca {.tpc.f1.e2d get} maria_ssl_cert {.tpc.f1.e2e get} maria_ssl_key {.tpc.f1.e2f get} maria_ssl_cipher {.tpc.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} ]
+    set mariaconn [ dict create connection {maria_host {.tpc.c1.e1 get} maria_port {.tpc.c1.e2 get} maria_socket {.tpc.c1.e2a get} maria_ssl_ca {.tpc.c1.e2d get} maria_ssl_cert {.tpc.c1.e2e get} maria_ssl_key {.tpc.c1.e2f get} maria_ssl_cipher {.tpc.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath $maria_ssl_linux_capath} ]
         } else {
         set platform "win"
-    set mariaconn [ dict create connection {maria_host {.tpc.f1.e1 get} maria_port {.tpc.f1.e2 get} maria_socket {.tpc.f1.e2a get} maria_ssl_ca {.tpc.f1.e2d get} maria_ssl_cert {.tpc.f1.e2e get} maria_ssl_key {.tpc.f1.e2f get} maria_ssl_cipher {.tpc.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} ]
+    set mariaconn [ dict create connection {maria_host {.tpc.c1.e1 get} maria_port {.tpc.c1.e2 get} maria_socket {.tpc.c1.e2a get} maria_ssl_ca {.tpc.c1.e2d get} maria_ssl_cert {.tpc.c1.e2e get} maria_ssl_key {.tpc.c1.e2f get} maria_ssl_cipher {.tpc.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} ]
         }
     variable mariafields
     set mariafields [ dict merge $mariaconn $tpccfields ]
@@ -408,40 +411,34 @@ proc configmariatpcc {option} {
     }
 
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
-
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MariaDB Host :"
     ttk::entry $Name -width 30 -textvariable maria_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MariaDB Port :"   
     ttk::entry $Name  -width 30 -textvariable maria_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MariaDB Socket :"
     ttk::entry $Name  -width 30 -textvariable maria_socket
     grid $Prompt -column 0 -row 3 -sticky e
@@ -449,63 +446,67 @@ proc configmariatpcc {option} {
 
     if {[string match windows $::tcl_platform(platform)]} {
 	set maria_socket "null"
-        .tpc.f1.e2a configure -state disabled
+        .tpc.c1.e2a configure -state disabled
     }
 
- 	set Name $Parent.f1.e2b
-        set Prompt $Parent.f1.p2b
+ 	set Name $Parent.c1.e2b
+        set Prompt $Parent.c1.p2b
         ttk::label $Prompt -text "Enable SSL :"
         ttk::checkbutton $Name -text "" -variable maria_ssl -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 4 -sticky e
         grid $Name -column 1 -row 4 -sticky w
 
-	 bind .tpc.f1.e2b <Any-ButtonRelease> {
+	 bind .tpc.c1.e2b <Any-ButtonRelease> {
             if { $maria_ssl eq "true" } {
-                .tpc.f1.e2ba configure -state disabled
-                .tpc.f1.e2bb configure -state disabled
-                .tpc.f1.e2c configure -state disabled
-                .tpc.f1.e2d configure -state disabled
-                .tpc.f1.e2e configure -state disabled
-                .tpc.f1.e2f configure -state disabled
-                .tpc.f1.e2g configure -state disabled
+                .tpc.c1.e2ba configure -state disabled
+                .tpc.c1.e2bb configure -state disabled
+                .tpc.c1.e2c configure -state disabled
+                .tpc.c1.e2d configure -state disabled
+                .tpc.c1.e2e configure -state disabled
+                .tpc.c1.e2f configure -state disabled
+                .tpc.c1.e2g configure -state disabled
             } else {
-                .tpc.f1.e2ba configure -state normal
-                .tpc.f1.e2bb configure -state normal
-                .tpc.f1.e2c configure -state normal
-                .tpc.f1.e2d configure -state normal
+                .tpc.c1.e2ba configure -state normal
+                .tpc.c1.e2bb configure -state normal
+                .tpc.c1.e2c configure -state normal
+                .tpc.c1.e2d configure -state normal
 		if { $maria_ssl_two_way eq "true" } {
-                .tpc.f1.e2e configure -state normal
-                .tpc.f1.e2f configure -state normal
+                .tpc.c1.e2e configure -state normal
+                .tpc.c1.e2f configure -state normal
 			}
-                .tpc.f1.e2g configure -state normal
+                .tpc.c1.e2g configure -state normal
                 }
             }
 
-	set Name $Parent.f1.e2ba
+	set Name $Parent.c1.e2ba
         ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 5 -sticky w
 	if { $maria_ssl eq "false" } {
-                .tpc.f1.e2ba configure -state disabled
+                .tpc.c1.e2ba configure -state disabled
 	}
-        bind .tpc.f1.e2ba <ButtonPress-1> {
-                .tpc.f1.e2e configure -state disabled
-                .tpc.f1.e2f configure -state disabled
+        bind .tpc.c1.e2ba <ButtonPress-1> {
+	if { $maria_ssl eq "true" } {
+                .tpc.c1.e2e configure -state disabled
+                .tpc.c1.e2f configure -state disabled
+	   }
         }
 
-        set Name $Parent.f1.e2bb
+        set Name $Parent.c1.e2bb
         ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 6 -sticky w
 	if { $maria_ssl eq "false" } {
-                .tpc.f1.e2bb configure -state disabled
+                .tpc.c1.e2bb configure -state disabled
 	}
 
-        bind .tpc.f1.e2bb <ButtonPress-1> {
-                .tpc.f1.e2e configure -state normal
-                .tpc.f1.e2f configure -state normal
+        bind .tpc.c1.e2bb <ButtonPress-1> {
+	if { $maria_ssl eq "true" } {
+                .tpc.c1.e2e configure -state normal
+                .tpc.c1.e2f configure -state normal
+	   }
         }
 
-    set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+    set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
      if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable maria_ssl_linux_capath
@@ -518,8 +519,8 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -528,8 +529,8 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+    set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -538,8 +539,8 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+    set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -548,8 +549,8 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -558,20 +559,20 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MariaDB User :"
     ttk::entry $Name  -width 30 -textvariable maria_user
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MariaDB User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable maria_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "TPROC-C MariaDB Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable maria_dbase
     grid $Prompt -column 0 -row 14 -sticky e
@@ -860,8 +861,8 @@ proc configmariatpcc {option} {
             $Name configure -state disabled
         }
 
-        set Name $Parent.f1.e25
-        set Prompt $Parent.f1.p25
+        set Name $Parent.c1.e25
+        set Prompt $Parent.c1.p25
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable maria_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 38 -sticky e
@@ -872,7 +873,7 @@ proc configmariatpcc {option} {
         set maria_no_stored_procs "false"
         }
 
-         bind .tpc.f1.e25 <Any-ButtonRelease> {
+         bind .tpc.c1.e25 <Any-ButtonRelease> {
             if { $maria_connect_pool eq "false" } {
                 set maria_prepared "true"
                 set maria_no_stored_procs "false"
@@ -935,14 +936,14 @@ proc configmariatpch {option} {
 
     #set variables to values in dict
     setlocaltpchvars $configmariadb
-    set tpchfields [ dict create tpch {maria_tpch_user {.mytpch.f1.e3 get} maria_tpch_pass {.mytpch.f1.e4 get} maria_tpch_dbase {.mytpch.f1.e5 get} maria_tpch_storage_engine {.mytpch.f1.e6 get} maria_total_querysets {.mytpch.f1.e9 get} maria_update_sets {.mytpch.f1.e13 get} maria_trickle_refresh {.mytpch.f1.e14 get} maria_scale_fact $maria_scale_fact  maria_num_tpch_threads $maria_num_tpch_threads maria_refresh_on $maria_refresh_on maria_raise_query_error $maria_raise_query_error maria_verbose $maria_verbose maria_refresh_verbose $maria_refresh_verbose maria_cloud_query $maria_cloud_query} ]
+    set tpchfields [ dict create tpch {maria_tpch_user {.mytpch.c1.e3 get} maria_tpch_pass {.mytpch.c1.e4 get} maria_tpch_dbase {.mytpch.c1.e5 get} maria_tpch_storage_engine {.mytpch.f1.e6 get} maria_total_querysets {.mytpch.f1.e9 get} maria_update_sets {.mytpch.f1.e13 get} maria_trickle_refresh {.mytpch.f1.e14 get} maria_scale_fact $maria_scale_fact  maria_num_tpch_threads $maria_num_tpch_threads maria_refresh_on $maria_refresh_on maria_raise_query_error $maria_raise_query_error maria_verbose $maria_verbose maria_refresh_verbose $maria_refresh_verbose maria_cloud_query $maria_cloud_query} ]
     #set matching fields in dialog to temporary dict
        if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-    set mariaconn [ dict create connection {maria_host {.mytpch.f1.e1 get} maria_port {.mytpch.f1.e2 get} maria_socket {.mytpch.f1.e2a get} maria_ssl_ca {.mytpch.f1.e2d get} maria_ssl_cert {.mytpch.f1.e2e get} maria_ssl_key {.mytpch.f1.e2f get} maria_ssl_cipher {.mytpch.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath {$maria_ssl_linux_capath}} ]
+    set mariaconn [ dict create connection {maria_host {.mytpch.c1.e1 get} maria_port {.mytpch.c1.e2 get} maria_socket {.mytpch.c1.e2a get} maria_ssl_ca {.mytpch.c1.e2d get} maria_ssl_cert {.mytpch.c1.e2e get} maria_ssl_key {.mytpch.c1.e2f get} maria_ssl_cipher {.mytpch.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_linux_capath {$maria_ssl_linux_capath}} ]
         } else {
         set platform "win"
-    set mariaconn [ dict create connection {maria_host {.mytpch.f1.e1 get} maria_port {.mytpch.f1.e2 get} maria_socket {.mytpch.f1.e2a get} maria_ssl_ca {.mytpch.f1.e2d get} maria_ssl_cert {.mytpch.f1.e2e get} maria_ssl_key {.mytpch.f1.e2f get} maria_ssl_cipher {.mytpch.f1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} ]
+    set mariaconn [ dict create connection {maria_host {.mytpch.c1.e1 get} maria_port {.mytpch.c1.e2 get} maria_socket {.mytpch.c1.e2a get} maria_ssl_ca {.mytpch.c1.e2d get} maria_ssl_cert {.mytpch.c1.e2e get} maria_ssl_key {.mytpch.c1.e2f get} maria_ssl_cipher {.mytpch.c1.e2g get} maria_ssl $maria_ssl maria_ssl_two_way $maria_ssl_two_way maria_ssl_windows_capath {$maria_ssl_windows_capath}} ]
         }
     variable mariafields
     set mariafields [ dict merge $mariaconn $tpchfields ]
@@ -958,40 +959,34 @@ proc configmariatpch {option} {
     }
 
     set Parent .mytpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
-
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MariaDB Host :"
     ttk::entry $Name -width 30 -textvariable maria_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MariaDB Port :"   
     ttk::entry $Name  -width 30 -textvariable maria_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MariaDB Socket :"
     ttk::entry $Name  -width 30 -textvariable maria_socket
     grid $Prompt -column 0 -row 3 -sticky e
@@ -999,63 +994,67 @@ proc configmariatpch {option} {
 
     if {[string match windows $::tcl_platform(platform)]} {
         set maria_socket "null"
-        .mytpch.f1.e2a configure -state disabled
+        .mytpch.c1.e2a configure -state disabled
     }
 
-     set Name $Parent.f1.e2b
-        set Prompt $Parent.f1.p2b
+     set Name $Parent.c1.e2b
+        set Prompt $Parent.c1.p2b
         ttk::label $Prompt -text "Enable SSL :"
         ttk::checkbutton $Name -text "" -variable maria_ssl -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 4 -sticky e
         grid $Name -column 1 -row 4 -sticky w
 
-         bind .mytpch.f1.e2b <Any-ButtonRelease> {
+         bind .mytpch.c1.e2b <Any-ButtonRelease> {
             if { $maria_ssl eq "true" } {
-                .mytpch.f1.e2ba configure -state disabled
-                .mytpch.f1.e2bb configure -state disabled
-                .mytpch.f1.e2c configure -state disabled
-                .mytpch.f1.e2d configure -state disabled
-                .mytpch.f1.e2e configure -state disabled
-                .mytpch.f1.e2f configure -state disabled
-                .mytpch.f1.e2g configure -state disabled
+                .mytpch.c1.e2ba configure -state disabled
+                .mytpch.c1.e2bb configure -state disabled
+                .mytpch.c1.e2c configure -state disabled
+                .mytpch.c1.e2d configure -state disabled
+                .mytpch.c1.e2e configure -state disabled
+                .mytpch.c1.e2f configure -state disabled
+                .mytpch.c1.e2g configure -state disabled
             } else {
-                .mytpch.f1.e2ba configure -state normal
-                .mytpch.f1.e2bb configure -state normal
-                .mytpch.f1.e2c configure -state normal
-                .mytpch.f1.e2d configure -state normal
+                .mytpch.c1.e2ba configure -state normal
+                .mytpch.c1.e2bb configure -state normal
+                .mytpch.c1.e2c configure -state normal
+                .mytpch.c1.e2d configure -state normal
                 if { $maria_ssl_two_way eq "true" } {
-                .mytpch.f1.e2e configure -state normal
-                .mytpch.f1.e2f configure -state normal
+                .mytpch.c1.e2e configure -state normal
+                .mytpch.c1.e2f configure -state normal
                         }
-                .mytpch.f1.e2g configure -state normal
+                .mytpch.c1.e2g configure -state normal
                 }
             }
 
-  set Name $Parent.f1.e2ba
+  set Name $Parent.c1.e2ba
         ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 5 -sticky w
         if { $maria_ssl eq "false" } {
-                .mytpch.f1.e2ba configure -state disabled
+                .mytpch.c1.e2ba configure -state disabled
         }
-        bind .mytpch.f1.e2ba <ButtonPress-1> {
-                .mytpch.f1.e2e configure -state disabled
-                .mytpch.f1.e2f configure -state disabled
+        bind .mytpch.c1.e2ba <ButtonPress-1> {
+	if { $maria_ssl eq "true" } {
+                .mytpch.c1.e2e configure -state disabled
+                .mytpch.c1.e2f configure -state disabled
+	}
         }
 
-        set Name $Parent.f1.e2bb
+        set Name $Parent.c1.e2bb
         ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable maria_ssl_two_way
         grid $Name -column 1 -row 6 -sticky w
         if { $maria_ssl eq "false" } {
-                .mytpch.f1.e2bb configure -state disabled
+                .mytpch.c1.e2bb configure -state disabled
         }
 
-        bind .mytpch.f1.e2bb <ButtonPress-1> {
-                .mytpch.f1.e2e configure -state normal
-                .mytpch.f1.e2f configure -state normal
+        bind .mytpch.c1.e2bb <ButtonPress-1> {
+	if { $maria_ssl eq "true" } {
+                .mytpch.c1.e2e configure -state normal
+                .mytpch.c1.e2f configure -state normal
+	}
         }
 
-	set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+	set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
      if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable maria_ssl_linux_capath
@@ -1068,8 +1067,8 @@ proc configmariatpch {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -1078,8 +1077,8 @@ proc configmariatpch {option} {
             $Name configure -state disabled
         }
 
- set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+ set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -1088,8 +1087,8 @@ proc configmariatpch {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+    set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -1098,8 +1097,8 @@ proc configmariatpch {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable maria_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -1108,20 +1107,20 @@ proc configmariatpch {option} {
             $Name configure -state disabled
         }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MariaDB User :"
     ttk::entry $Name  -width 30 -textvariable maria_tpch_user
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MariaDB User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable maria_tpch_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "TPROC-H MariaDB Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable maria_tpch_dbase
     grid $Prompt -column 0 -row 14 -sticky e

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -15,10 +15,10 @@ proc countmssqlsopts { bm } {
     variable mssqloptsfields 
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqloptsfields [ dict create connection { mssqls_linux_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_linux_odbc {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqloptsfields [ dict create connection { mssqls_linux_server {.countopt.c1.e1 get} mssqls_port {.countopt.c1.e2 get} mssqls_linux_odbc {.countopt.c1.e3 get} mssqls_uid {.countopt.c1.e4 get} mssqls_pass {.countopt.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqloptsfields [ dict create connection { mssqls_server {.countopt.f1.e1 get} mssqls_port {.countopt.f1.e2 get} mssqls_odbc_driver {.countopt.f1.e3 get} mssqls_uid {.countopt.f1.e4 get} mssqls_pass {.countopt.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqloptsfields [ dict create connection { mssqls_server {.countopt.c1.e1 get} mssqls_port {.countopt.c1.e2 get} mssqls_odbc_driver {.countopt.c1.e3 get} mssqls_uid {.countopt.c1.e4 get} mssqls_pass {.countopt.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
 
     if { [ info exists afval ] } {
@@ -32,17 +32,16 @@ proc countmssqlsopts { bm } {
     wm withdraw .countopt
     wm title .countopt {SQL Server TX Counter Options}
     set Parent .countopt
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "SQL Server :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mssqls_linux_server
@@ -51,50 +50,50 @@ proc countmssqlsopts { bm } {
     }
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Prompt $Parent.f1.p1a
+    set Prompt $Parent.c1.p1a
     ttk::label $Prompt -text "TCP :"
-    set Name $Parent.f1.e1a
+    set Name $Parent.c1.e1a
     ttk::checkbutton $Name -text "" -variable mssqls_tcp -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky w
-    bind .countopt.f1.e1a <ButtonPress-1> {
+    bind .countopt.c1.e1a <ButtonPress-1> {
         if { $mssqls_tcp eq "false" } {
-            catch {.countopt.f1.e2 configure -state normal}
+            catch {.countopt.c1.e2 configure -state normal}
         } else {
-            catch {.countopt.f1.e2 configure -state disabled}
+            catch {.countopt.c1.e2 configure -state disabled}
         }
     }
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "SQL Server Port :"   
     ttk::entry $Name  -width 30 -textvariable mssqls_port
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     if { $mssqls_tcp eq "true" } {
-        catch {.countopt.f1.e2 configure -state normal}
+        catch {.countopt.c1.e2 configure -state normal}
     } else {
-        catch {.countopt.f1.e2 configure -state disabled}
+        catch {.countopt.c1.e2 configure -state disabled}
     }
-    set Prompt $Parent.f1.p2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "Azure :"
-    set Name $Parent.f1.e2a
+    set Name $Parent.c1.e2a
     ttk::checkbutton $Name -text "" -variable mssqls_azure -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky w
-    set Prompt $Parent.f1.p2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Encrypt Connection :"
-    set Name $Parent.f1.e2b
+    set Name $Parent.c1.e2b
     ttk::checkbutton $Name -text "" -variable mssqls_encrypt_connection -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky w
-    set Prompt $Parent.f1.p2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "Trust Server Certificate :"
-    set Name $Parent.f1.e2c
+    set Name $Parent.c1.e2c
     ttk::checkbutton $Name -text "" -variable mssqls_trust_server_cert -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky w
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "SQL Server ODBC Driver :"   
     if { $platform eq "lin" } {
         ttk::entry $Name  -width 30 -textvariable mssqls_linux_odbc
@@ -103,48 +102,48 @@ proc countmssqlsopts { bm } {
     }
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
-    set Prompt $Parent.f1.pa
+    set Prompt $Parent.c1.pa
     ttk::label $Prompt -text "Authentication :"
     grid $Prompt -column 0 -row 8 -sticky e
-    set Name $Parent.f1.r1
+    set Name $Parent.c1.r1
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
-    bind .countopt.f1.r1 <ButtonPress-1> {
-        .countopt.f1.e4 configure -state disabled
-        .countopt.f1.e5 configure -state disabled
-        .countopt.f1.e5a configure -state disabled
+    bind .countopt.c1.r1 <ButtonPress-1> {
+        .countopt.c1.e4 configure -state disabled
+        .countopt.c1.e5 configure -state disabled
+        .countopt.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r2
+    set Name $Parent.c1.r2
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
-    bind .countopt.f1.r2 <ButtonPress-1> {
-        .countopt.f1.e4 configure -state normal
-        .countopt.f1.e5 configure -state normal
-        .countopt.f1.e5a configure -state disabled
+    bind .countopt.c1.r2 <ButtonPress-1> {
+        .countopt.c1.e4 configure -state normal
+        .countopt.c1.e5 configure -state normal
+        .countopt.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r3
+    set Name $Parent.c1.r3
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 10 -sticky w
-    bind .countopt.f1.r3 <ButtonPress-1> {
-        .countopt.f1.e4 configure -state disabled
-        .countopt.f1.e5 configure -state disabled
-        .countopt.f1.e5a configure -state normal
+    bind .countopt.c1.r3 <ButtonPress-1> {
+        .countopt.c1.e4 configure -state disabled
+        .countopt.c1.e5 configure -state disabled
+        .countopt.c1.e5a configure -state normal
     }
 
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
     grid $Prompt -column 0 -row 11 -sticky e
@@ -152,8 +151,8 @@ proc countmssqlsopts { bm } {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 12 -sticky e
@@ -161,8 +160,8 @@ proc countmssqlsopts { bm } {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e5a
-    set Prompt $Parent.f1.p5a
+    set Name $Parent.c1.e5a
+    set Prompt $Parent.c1.p5a
     ttk::label $Prompt -text "MSI Object ID :"   
     ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
     grid $Prompt -column 0 -row 13 -sticky e
@@ -206,7 +205,7 @@ proc countmssqlsopts { bm } {
         $Name configure -state disabled
     }
 
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -260,10 +259,10 @@ proc configmssqlstpcc {option} {
     set tpccfields [ dict create tpcc {mssqls_dbase {.tpc.f1.e6 get} mssqls_bucket {.tpc.f1.e8 get} mssqls_total_iterations {.tpc.f1.e14 get} mssqls_rampup {.tpc.f1.e18 get} mssqls_duration {.tpc.f1.e19 get} mssqls_async_client {.tpc.f1.e23 get} mssqls_async_delay {.tpc.f1.e24 get} mssqls_imdb $mssqls_imdb mssqls_durability $mssqls_durability mssqls_count_ware $mssqls_count_ware mssqls_num_vu $mssqls_num_vu mssqls_driver $mssqls_driver mssqls_raiseerror $mssqls_raiseerror mssqls_keyandthink $mssqls_keyandthink mssqls_checkpoint $mssqls_checkpoint mssqls_allwarehouse $mssqls_allwarehouse mssqls_timeprofile $mssqls_timeprofile mssqls_async_scale $mssqls_async_scale mssqls_async_verbose $mssqls_async_verbose mssqls_connect_pool $mssqls_connect_pool mssqls_use_bcp $mssqls_use_bcp} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqlsconn [ dict create connection { mssqls_linux_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_linux_odbc {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqlsconn [ dict create connection { mssqls_linux_server {.tpc.c1.e1 get} mssqls_port {.tpc.c1.e2 get} mssqls_linux_odbc {.tpc.c1.e3 get} mssqls_uid {.tpc.c1.e4 get} mssqls_pass {.tpc.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqlsconn [ dict create connection { mssqls_server {.tpc.f1.e1 get} mssqls_port {.tpc.f1.e2 get} mssqls_odbc_driver {.tpc.f1.e3 get} mssqls_uid {.tpc.f1.e4 get} mssqls_pass {.tpc.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqlsconn [ dict create connection { mssqls_server {.tpc.c1.e1 get} mssqls_port {.tpc.c1.e2 get} mssqls_odbc_driver {.tpc.c1.e3 get} mssqls_uid {.tpc.c1.e4 get} mssqls_pass {.tpc.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
     variable mssqlsfields
     set mssqlsfields [ dict merge $mssqlsconn $tpccfields ]
@@ -278,26 +277,22 @@ proc configmssqlstpcc {option} {
         "drive" { wm title .tpc {Microsoft SQL Server TPROC-C Driver Options} }
     }
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "SQL Server :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mssqls_linux_server
@@ -306,50 +301,50 @@ proc configmssqlstpcc {option} {
     }
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Prompt $Parent.f1.p1a
+    set Prompt $Parent.c1.p1a
     ttk::label $Prompt -text "TCP :"
-    set Name $Parent.f1.e1a
+    set Name $Parent.c1.e1a
     ttk::checkbutton $Name -text "" -variable mssqls_tcp -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky w
-    bind .tpc.f1.e1a <ButtonPress-1> {
+    bind .tpc.c1.e1a <ButtonPress-1> {
         if { $mssqls_tcp eq "false" } {
-            catch {.tpc.f1.e2 configure -state normal}
+            catch {.tpc.c1.e2 configure -state normal}
         } else {
-            catch {.tpc.f1.e2 configure -state disabled}
+            catch {.tpc.c1.e2 configure -state disabled}
         }
     }
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "SQL Server Port :"   
     ttk::entry $Name  -width 30 -textvariable mssqls_port
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     if { $mssqls_tcp eq "true" } {
-        catch {.tpc.f1.e2 configure -state normal}
+        catch {.tpc.c1.e2 configure -state normal}
     } else {
-        catch {.tpc.f1.e2 configure -state disabled}
+        catch {.tpc.c1.e2 configure -state disabled}
     }
-    set Prompt $Parent.f1.p2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "Azure :"
-    set Name $Parent.f1.e2a
+    set Name $Parent.c1.e2a
     ttk::checkbutton $Name -text "" -variable mssqls_azure -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky w
-    set Prompt $Parent.f1.p2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Encrypt Connection :"
-    set Name $Parent.f1.e2b
+    set Name $Parent.c1.e2b
     ttk::checkbutton $Name -text "" -variable mssqls_encrypt_connection -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky w
-    set Prompt $Parent.f1.p2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "Trust Server Certificate :"
-    set Name $Parent.f1.e2c
+    set Name $Parent.c1.e2c
     ttk::checkbutton $Name -text "" -variable mssqls_trust_server_cert -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky w
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "SQL Server ODBC Driver :"   
     if { $platform eq "lin" } {
         ttk::entry $Name  -width 30 -textvariable mssqls_linux_odbc
@@ -358,47 +353,47 @@ proc configmssqlstpcc {option} {
     }
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
-    set Prompt $Parent.f1.pa
+    set Prompt $Parent.c1.pa
     ttk::label $Prompt -text "Authentication :"
     grid $Prompt -column 0 -row 8 -sticky e
-    set Name $Parent.f1.r1
+    set Name $Parent.c1.r1
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
-    bind .tpc.f1.r1 <ButtonPress-1> {
-        .tpc.f1.e4 configure -state disabled
-        .tpc.f1.e5 configure -state disabled
-        .tpc.f1.e5a configure -state disabled
+    bind .tpc.c1.r1 <ButtonPress-1> {
+        .tpc.c1.e4 configure -state disabled
+        .tpc.c1.e5 configure -state disabled
+        .tpc.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r2
+    set Name $Parent.c1.r2
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
-    bind .tpc.f1.r2 <ButtonPress-1> {
-        .tpc.f1.e4 configure -state normal
-        .tpc.f1.e5 configure -state normal
-        .tpc.f1.e5a configure -state disabled
+    bind .tpc.c1.r2 <ButtonPress-1> {
+        .tpc.c1.e4 configure -state normal
+        .tpc.c1.e5 configure -state normal
+        .tpc.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r3
+    set Name $Parent.c1.r3
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 10 -sticky w
-    bind .tpc.f1.r3 <ButtonPress-1> {
-        .tpc.f1.e4 configure -state disabled
-        .tpc.f1.e5 configure -state disabled
-        .tpc.f1.e5a configure -state normal
+    bind .tpc.c1.r3 <ButtonPress-1> {
+        .tpc.c1.e4 configure -state disabled
+        .tpc.c1.e5 configure -state disabled
+        .tpc.c1.e5a configure -state normal
     }
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
     grid $Prompt -column 0 -row 11 -sticky e
@@ -406,8 +401,8 @@ proc configmssqlstpcc {option} {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "SQL Server User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 12 -sticky e
@@ -415,8 +410,8 @@ proc configmssqlstpcc {option} {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-     set Name $Parent.f1.e5a
-    set Prompt $Parent.f1.p5a
+     set Name $Parent.c1.e5a
+    set Prompt $Parent.c1.p5a
     ttk::label $Prompt -text "MSI Object ID :"   
     ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
     grid $Prompt -column 0 -row 13 -sticky e
@@ -424,8 +419,8 @@ proc configmssqlstpcc {option} {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "sql")) || ($platform eq "lin" && ($mssqls_linux_authent == "windows"  || $mssqls_linux_authent == "sql" ) )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e6
-    set Prompt $Parent.f1.p6
+    set Name $Parent.c1.e6
+    set Prompt $Parent.c1.p6
     ttk::label $Prompt -text "TPROC-C SQL Server Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mssqls_dbase
     grid $Prompt -column 0 -row 14 -sticky e
@@ -681,8 +676,8 @@ proc configmssqlstpcc {option} {
             set mssqls_async_verbose "false"
             $Name configure -state disabled
         }
-        set Name $Parent.f1.e26
-        set Prompt $Parent.f1.p26
+        set Name $Parent.c1.e26
+        set Prompt $Parent.c1.p26
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mssqls_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 37 -sticky e
@@ -744,10 +739,10 @@ proc configmssqlstpch {option} {
 
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mssqlsconn [ dict create connection { mssqls_linux_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_linux_odbc {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqlsconn [ dict create connection { mssqls_linux_server {.mssqlstpch.c1.e1 get} mssqls_port {.mssqlstpch.c1.e2 get} mssqls_linux_odbc {.mssqlstpch.c1.e3 get} mssqls_uid {.mssqlstpch.c1.e4 get} mssqls_pass {.mssqlstpch.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_linux_authent $mssqls_linux_authent mssqls_msi_object_id $mssqls_msi_object_id} ]
     } else {
         set platform "win"
-        set mssqlsconn [ dict create connection { mssqls_server {.mssqlstpch.f1.e1 get} mssqls_port {.mssqlstpch.f1.e2 get} mssqls_odbc_driver {.mssqlstpch.f1.e3 get} mssqls_uid {.mssqlstpch.f1.e4 get} mssqls_pass {.mssqlstpch.f1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
+        set mssqlsconn [ dict create connection { mssqls_server {.mssqlstpch.c1.e1 get} mssqls_port {.mssqlstpch.c1.e2 get} mssqls_odbc_driver {.mssqlstpch.c1.e3 get} mssqls_uid {.mssqlstpch.c1.e4 get} mssqls_pass {.mssqlstpch.c1.e5 get} mssqls_tcp $mssqls_tcp mssqls_azure $mssqls_azure mssqls_encrypt_connection $mssqls_encrypt_connection mssqls_trust_server_cert $mssqls_trust_server_cert mssqls_authentication $mssqls_authentication mssqls_msi_object_id $mssqls_msi_object_id} ]
     }
     variable mssqlsfields
     set mssqlsfields [ dict merge $mssqlsconn $tpchfields ]
@@ -761,26 +756,22 @@ proc configmssqlstpch {option} {
         "drive" {  wm title .mssqlstpch {SQL Server TPROC-H Driver Options} }
     }
     set Parent .mssqlstpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "SQL Server :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mssqls_linux_server
@@ -789,50 +780,50 @@ proc configmssqlstpch {option} {
     }
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Prompt $Parent.f1.p1a
+    set Prompt $Parent.c1.p1a
     ttk::label $Prompt -text "TCP :"
-    set Name $Parent.f1.e1a
+    set Name $Parent.c1.e1a
     ttk::checkbutton $Name -text "" -variable mssqls_tcp -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky w
-    bind .mssqlstpch.f1.e1a <ButtonPress-1> {
+    bind .mssqlstpch.c1.e1a <ButtonPress-1> {
         if { $mssqls_tcp eq "false" } {
-            catch {.mssqlstpch.f1.e2 configure -state normal}
+            catch {.mssqlstpch.c1.e2 configure -state normal}
         } else {
-            catch {.mssqlstpch.f1.e2 configure -state disabled}
+            catch {.mssqlstpch.c1.e2 configure -state disabled}
         }
     }
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "SQL Server Port :"
     ttk::entry $Name  -width 30 -textvariable mssqls_port
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     if { $mssqls_tcp eq "true" } {
-        catch {.mssqlstpch.f1.e2 configure -state normal}
+        catch {.mssqlstpch.c1.e2 configure -state normal}
     } else {
-        catch {.mssqlstpch.f1.e2 configure -state disabled}
+        catch {.mssqlstpch.c1.e2 configure -state disabled}
     }
-    set Prompt $Parent.f1.p2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "Azure :"
-    set Name $Parent.f1.e2a
+    set Name $Parent.c1.e2a
     ttk::checkbutton $Name -text "" -variable mssqls_azure -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky w
-    set Prompt $Parent.f1.p2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Encrypt Connection :"
-    set Name $Parent.f1.e2b
+    set Name $Parent.c1.e2b
     ttk::checkbutton $Name -text "" -variable mssqls_encrypt_connection -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky w
-    set Prompt $Parent.f1.p2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "Trust Server Certificate :"
-    set Name $Parent.f1.e2c
+    set Name $Parent.c1.e2c
     ttk::checkbutton $Name -text "" -variable mssqls_trust_server_cert -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky w
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "SQL Server ODBC Driver :"
     if { $platform eq "lin" } {
         ttk::entry $Name  -width 30 -textvariable mssqls_linux_odbc
@@ -841,47 +832,47 @@ proc configmssqlstpch {option} {
     }
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
-    set Prompt $Parent.f1.pa
+    set Prompt $Parent.c1.pa
     ttk::label $Prompt -text "Authentication :"
     grid $Prompt -column 0 -row 8 -sticky e
-    set Name $Parent.f1.r1
+    set Name $Parent.c1.r1
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "windows" -text "Windows" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 8 -sticky w
-    bind .mssqlstpch.f1.r1 <ButtonPress-1> {
-        .mssqlstpch.f1.e4 configure -state disabled
-        .mssqlstpch.f1.e5 configure -state disabled
-        .mssqlstpch.f1.e5a configure -state disabled
+    bind .mssqlstpch.c1.r1 <ButtonPress-1> {
+        .mssqlstpch.c1.e4 configure -state disabled
+        .mssqlstpch.c1.e5 configure -state disabled
+        .mssqlstpch.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r2
+    set Name $Parent.c1.r2
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "sql" -text "SQL Server" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 9 -sticky w
-    bind .mssqlstpch.f1.r2 <ButtonPress-1> {
-        .mssqlstpch.f1.e4 configure -state normal
-        .mssqlstpch.f1.e5 configure -state normal
-        .mssqlstpch.f1.e5a configure -state disabled
+    bind .mssqlstpch.c1.r2 <ButtonPress-1> {
+        .mssqlstpch.c1.e4 configure -state normal
+        .mssqlstpch.c1.e5 configure -state normal
+        .mssqlstpch.c1.e5a configure -state disabled
     }
-    set Name $Parent.f1.r3
+    set Name $Parent.c1.r3
     if { $platform eq "lin" } {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_linux_authent
     } else {
         ttk::radiobutton $Name -value "entra" -text "Entra" -variable mssqls_authentication
     }
     grid $Name -column 1 -row 10 -sticky w
-    bind .mssqlstpch.f1.r3 <ButtonPress-1> {
-        .mssqlstpch.f1.e4 configure -state disabled
-        .mssqlstpch.f1.e5 configure -state disabled
-        .mssqlstpch.f1.e5a configure -state normal
+    bind .mssqlstpch.c1.r3 <ButtonPress-1> {
+        .mssqlstpch.c1.e4 configure -state disabled
+        .mssqlstpch.c1.e5 configure -state disabled
+        .mssqlstpch.c1.e5a configure -state normal
     }
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "SQL Server User ID :"
     ttk::entry $Name  -width 30 -textvariable mssqls_uid
     grid $Prompt -column 0 -row 11 -sticky e
@@ -889,8 +880,8 @@ proc configmssqlstpch {option} {
       if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "SQL Server User Password :"
     ttk::entry $Name -show * -width 30 -textvariable mssqls_pass
     grid $Prompt -column 0 -row 12 -sticky e
@@ -898,8 +889,8 @@ proc configmssqlstpch {option} {
       if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "entra") ) || ($platform eq "lin" && ($mssqls_linux_authent == "windows" || $mssqls_linux_authent == "entra") )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e5a
-    set Prompt $Parent.f1.p5a
+    set Name $Parent.c1.e5a
+    set Prompt $Parent.c1.p5a
     ttk::label $Prompt -text "MSI Object ID :"   
     ttk::entry $Name -width 30 -textvariable mssqls_msi_object_id
     grid $Prompt -column 0 -row 13 -sticky e
@@ -907,8 +898,8 @@ proc configmssqlstpch {option} {
     if {($platform eq "win" && ($mssqls_authentication == "windows" || $mssqls_authentication == "sql")) || ($platform eq "lin" && ($mssqls_linux_authent == "windows"  || $mssqls_linux_authent == "sql" ) )} {
         $Name configure -state disabled
     }
-    set Name $Parent.f1.e6
-    set Prompt $Parent.f1.p6
+    set Name $Parent.c1.e6
+    set Prompt $Parent.c1.p6
     ttk::label $Prompt -text "TPROC-H SQL Server Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mssqls_tpch_dbase
     grid $Prompt -column 0 -row 14 -sticky e

--- a/src/mysql/mysqlopt.tcl
+++ b/src/mysql/mysqlopt.tcl
@@ -88,18 +88,18 @@ proc countmysqlopts { bm } {
     if { $bm eq "TPC-C" } {
         if {![string match windows $::tcl_platform(platform)]} {
             set platform "lin"
-            set myoptsfields [ dict create connection {mysql_host {.countopt.f1.e1 get} mysql_port {.countopt.f1.e2 get} mysql_socket {.countopt.f1.e2a get} mysql_ssl_ca {.countopt.f1.e2d get} mysql_ssl_cert {.countopt.f1.e2e get} mysql_ssl_key {.countopt.f1.e2f get} mysql_ssl_cipher {.countopt.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath} tpcc {mysql_user {.countopt.f1.e3 get} mysql_pass {.countopt.f1.e4 get}} ]
+            set myoptsfields [ dict create connection {mysql_host {.countopt.c1.e1 get} mysql_port {.countopt.c1.e2 get} mysql_socket {.countopt.c1.e2a get} mysql_ssl_ca {.countopt.c1.e2d get} mysql_ssl_cert {.countopt.c1.e2e get} mysql_ssl_key {.countopt.c1.e2f get} mysql_ssl_cipher {.countopt.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath} tpcc {mysql_user {.countopt.c1.e3 get} mysql_pass {.countopt.c1.e4 get}} ]
         } else {
             set platform "win"
-            set myoptsfields [ dict create connection {mysql_host {.countopt.f1.e1 get} mysql_port {.countopt.f1.e2 get} mysql_socket {.countopt.f1.e2a get} mysql_ssl_ca {.countopt.f1.e2d get} mysql_ssl_cert {.countopt.f1.e2e get} mysql_ssl_key {.countopt.f1.e2f get} mysql_ssl_cipher {.countopt.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} tpcc {mysql_user {.countopt.f1.e3 get} mysql_pass {.countopt.f1.e4 get}} ]
+            set myoptsfields [ dict create connection {mysql_host {.countopt.c1.e1 get} mysql_port {.countopt.c1.e2 get} mysql_socket {.countopt.c1.e2a get} mysql_ssl_ca {.countopt.c1.e2d get} mysql_ssl_cert {.countopt.c1.e2e get} mysql_ssl_key {.countopt.c1.e2f get} mysql_ssl_cipher {.countopt.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} tpcc {mysql_user {.countopt.c1.e3 get} mysql_pass {.countopt.c1.e4 get}} ]
         }
     } else {
         if {![string match windows $::tcl_platform(platform)]} {
             set platform "lin"
-            set myoptsfields [ dict create connection {mysql_host {.countopt.f1.e1 get} mysql_port {.countopt.f1.e2 get} mysql_socket {.countopt.f1.e2a get} mysql_ssl_ca {.countopt.f1.e2d get} mysql_ssl_cert {.countopt.f1.e2e get} mysql_ssl_key {.countopt.f1.e2f get} mysql_ssl_cipher {.countopt.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath mysql_oceanbase_port $mysql_oceanbase_port} tpch {mysql_tpch_user {.countopt.f1.e3 get} mysql_tpch_pass {.countopt.f1.e4 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_tenant_name $mysql_ob_tenant_name} ]
+            set myoptsfields [ dict create connection {mysql_host {.countopt.c1.e1 get} mysql_port {.countopt.c1.e2 get} mysql_socket {.countopt.c1.e2a get} mysql_ssl_ca {.countopt.c1.e2d get} mysql_ssl_cert {.countopt.c1.e2e get} mysql_ssl_key {.countopt.c1.e2f get} mysql_ssl_cipher {.countopt.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath mysql_oceanbase_port $mysql_oceanbase_port} tpch {mysql_tpch_user {.countopt.c1.e3 get} mysql_tpch_pass {.countopt.c1.e4 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_tenant_name $mysql_ob_tenant_name} ]
         } else {
             set platform "win"
-            set myoptsfields [ dict create connection {mysql_host {.countopt.f1.e1 get} mysql_port {.countopt.f1.e2 get} mysql_socket {.countopt.f1.e2a get} mysql_ssl_ca {.countopt.f1.e2d get} mysql_ssl_cert {.countopt.f1.e2e get} mysql_ssl_key {.countopt.f1.e2f get} mysql_ssl_cipher {.countopt.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath} mysql_oceanbase_port $mysql_oceanbase_port} tpch {mysql_tpch_user {.countopt.f1.e3 get} mysql_tpch_pass {.countopt.f1.e4 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_tenant_name $mysql_ob_tenant_name} ]
+            set myoptsfields [ dict create connection {mysql_host {.countopt.c1.e1 get} mysql_port {.countopt.c1.e2 get} mysql_socket {.countopt.c1.e2a get} mysql_ssl_ca {.countopt.c1.e2d get} mysql_ssl_cert {.countopt.c1.e2e get} mysql_ssl_key {.countopt.c1.e2f get} mysql_ssl_cipher {.countopt.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath} mysql_oceanbase_port $mysql_oceanbase_port} tpch {mysql_tpch_user {.countopt.c1.e3 get} mysql_tpch_pass {.countopt.c1.e4 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_tenant_name $mysql_ob_tenant_name} ]
         }
     }
     if { [ info exists afval ] } {
@@ -112,92 +112,96 @@ proc countmysqlopts { bm } {
     wm withdraw .countopt
     wm title .countopt {MySQL TX Counter Options}
     set Parent .countopt
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MySQL Host :"
     ttk::entry $Name -width 30 -textvariable mysql_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MySQL Port :"   
     ttk::entry $Name  -width 30 -textvariable mysql_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MySQL Socket :"   
     ttk::entry $Name  -width 30 -textvariable mysql_socket
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     if {[string match windows $::tcl_platform(platform)]} {
         set mysql_socket "null"
-        .countopt.f1.e2a configure -state disabled
+        .countopt.c1.e2a configure -state disabled
     }
 
-    set Name $Parent.f1.e2b
-    set Prompt $Parent.f1.p2b
+    set Name $Parent.c1.e2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Enable SSL :"
     ttk::checkbutton $Name -text "" -variable mysql_ssl -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky w
     
-    bind .countopt.f1.e2b <Any-ButtonRelease> {
+    bind .countopt.c1.e2b <Any-ButtonRelease> {
         if { $mysql_ssl eq "true" } {
-            .countopt.f1.e2ba configure -state disabled
-            .countopt.f1.e2bb configure -state disabled
-            .countopt.f1.e2c configure -state disabled
-            .countopt.f1.e2d configure -state disabled
-            .countopt.f1.e2e configure -state disabled
-            .countopt.f1.e2f configure -state disabled
-            .countopt.f1.e2g configure -state disabled
+            .countopt.c1.e2ba configure -state disabled
+            .countopt.c1.e2bb configure -state disabled
+            .countopt.c1.e2c configure -state disabled
+            .countopt.c1.e2d configure -state disabled
+            .countopt.c1.e2e configure -state disabled
+            .countopt.c1.e2f configure -state disabled
+            .countopt.c1.e2g configure -state disabled
         } else {
-            .countopt.f1.e2ba configure -state normal
-            .countopt.f1.e2bb configure -state normal
-            .countopt.f1.e2c configure -state normal
-            .countopt.f1.e2d configure -state normal
+            .countopt.c1.e2ba configure -state normal
+            .countopt.c1.e2bb configure -state normal
+            .countopt.c1.e2c configure -state normal
+            .countopt.c1.e2d configure -state normal
             if { $mysql_ssl_two_way eq "true" } {
-                .countopt.f1.e2e configure -state normal
-                .countopt.f1.e2f configure -state normal
+                .countopt.c1.e2e configure -state normal
+                .countopt.c1.e2f configure -state normal
             }
-            .countopt.f1.e2g configure -state normal
+            .countopt.c1.e2g configure -state normal
         }
     }
     
-    set Name $Parent.f1.e2ba
+    set Name $Parent.c1.e2ba
     ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 5 -sticky w
     if { $mysql_ssl eq "false" } {
-        .countopt.f1.e2ba configure -state disabled
+        .countopt.c1.e2ba configure -state disabled
     }
-    bind .countopt.f1.e2ba <ButtonPress-1> {
-        .countopt.f1.e2e configure -state disabled
-        .countopt.f1.e2f configure -state disabled
+    bind .countopt.c1.e2ba <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .countopt.c1.e2e configure -state disabled
+        .countopt.c1.e2f configure -state disabled
+	}
     }
     
-    set Name $Parent.f1.e2bb
+    set Name $Parent.c1.e2bb
     ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 6 -sticky w
     if { $mysql_ssl eq "false" } {
-        .countopt.f1.e2bb configure -state disabled
+        .countopt.c1.e2bb configure -state disabled
     }
     
-    bind .countopt.f1.e2bb <ButtonPress-1> {
-        .countopt.f1.e2e configure -state normal
-        .countopt.f1.e2f configure -state normal
+    bind .countopt.c1.e2bb <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .countopt.c1.e2bb configure -state disabled
+        .countopt.c1.e2e configure -state normal
+        .countopt.c1.e2f configure -state normal
+	}
     }
     
-    set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+    set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mysql_ssl_linux_capath
@@ -210,8 +214,8 @@ proc countmysqlopts { bm } {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -220,8 +224,8 @@ proc countmysqlopts { bm } {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+    set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -230,8 +234,8 @@ proc countmysqlopts { bm } {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+    set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -240,8 +244,8 @@ proc countmysqlopts { bm } {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -250,8 +254,8 @@ proc countmysqlopts { bm } {
         $Name configure -state disabled
     }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MySQL User :"
     if { $bm eq "TPC-C" } {
         ttk::entry $Name  -width 30 -textvariable mysql_user
@@ -260,42 +264,44 @@ proc countmysqlopts { bm } {
     }
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
     if { $bm eq "TPC-C" } {
         ttk::entry $Name -show * -width 30 -textvariable mysql_pass
     } else {
         ttk::entry $Name -show * -width 30 -textvariable mysql_tpch_pass
     }
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky ew
 
-set Name $Parent.f1.e5a
-    set Prompt $Parent.f1.p5a
+set Name $Parent.c1.e5a
+    set Prompt $Parent.c1.p5a
     ttk::label $Prompt -text "Oceanbase Database Compatible :"
     ttk::checkbutton $Name -text "" -variable mysql_tpch_obcompat -onvalue "true" -offvalue "false"
-    grid $Prompt -column 0 -row 13 -sticky e
-    grid $Name -column 1 -row 13 -sticky w
-    bind $Parent.f1.e5a <Button> {
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky w
+    bind $Parent.c1.e5a <Button> {
         if { $mysql_tpch_obcompat eq "true" } {
              set mysql_port $default_mysql_port
-            .countopt.f1.e2b configure -state normal
-            .countopt.f1.e5b configure -state disabled
+            .countopt.c1.e2b configure -state normal
+            .countopt.c1.e5b configure -state disabled
         } else {
              set mysql_ssl "false"
              set mysql_port $mysql_oceanbase_port
-            .countopt.f1.e2b configure -state disabled
-            .countopt.f1.e2ba configure -state disabled
-            .countopt.f1.e2bb configure -state disabled
-            .countopt.f1.e2c configure -state disabled
-            .countopt.f1.e2d configure -state disabled
-            .countopt.f1.e2e configure -state disabled
-            .countopt.f1.e2f configure -state disabled
-            .countopt.f1.e2g configure -state disabled
-            .countopt.f1.e5b configure -state normal
+            .countopt.c1.e2b configure -state disabled
+            .countopt.c1.e2ba configure -state disabled
+            .countopt.c1.e2bb configure -state disabled
+            .countopt.c1.e2c configure -state disabled
+            .countopt.c1.e2d configure -state disabled
+            .countopt.c1.e2e configure -state disabled
+            .countopt.c1.e2f configure -state disabled
+            .countopt.c1.e2g configure -state disabled
+            .countopt.c1.e5b configure -state normal
         }
     }
-  set Name $Parent.f1.e5b
-    set Prompt $Parent.f1.5b
+  set Name $Parent.c1.e5b
+    set Prompt $Parent.c1.5b
     ttk::label $Prompt -text "Oceanbase Tenant Name:"
     ttk::entry $Name -width 30 -textvariable mysql_ob_tenant_name
     grid $Prompt -column 0 -row 14 -sticky e
@@ -341,7 +347,7 @@ set Name $Parent.f1.e5a
         $Name configure -state disabled
     }
 
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -409,13 +415,13 @@ proc configmysqltpcc {option} {
     upvar #0 configmysql configmysql
     #set variables to values in dict
     setlocaltpccvars $configmysql
-    set tpccfields [ dict create tpcc {mysql_user {.tpc.f1.e3 get} mysql_pass {.tpc.f1.e4 get} mysql_dbase {.tpc.f1.e5 get} mysql_storage_engine {.tpc.f1.e6 get} mysql_total_iterations {.tpc.f1.e14 get} mysql_rampup {.tpc.f1.e17 get} mysql_duration {.tpc.f1.e18 get} mysql_async_client {.tpc.f1.e22 get} mysql_async_delay {.tpc.f1.e23 get} mysql_count_ware $mysql_count_ware mysql_num_vu $mysql_num_vu mysql_partition $mysql_partition mysql_driver $mysql_driver mysql_raiseerror $mysql_raiseerror mysql_keyandthink $mysql_keyandthink mysql_allwarehouse $mysql_allwarehouse mysql_timeprofile $mysql_timeprofile mysql_async_scale $mysql_async_scale mysql_async_verbose $mysql_async_verbose mysql_prepared $mysql_prepared mysql_no_stored_procs $mysql_no_stored_procs mysql_connect_pool $mysql_connect_pool mysql_history_pk $mysql_history_pk} ]
+    set tpccfields [ dict create tpcc {mysql_user {.tpc.c1.e3 get} mysql_pass {.tpc.c1.e4 get} mysql_dbase {.tpc.c1.e5 get} mysql_storage_engine {.tpc.f1.e6 get} mysql_total_iterations {.tpc.f1.e14 get} mysql_rampup {.tpc.f1.e17 get} mysql_duration {.tpc.f1.e18 get} mysql_async_client {.tpc.f1.e22 get} mysql_async_delay {.tpc.f1.e23 get} mysql_count_ware $mysql_count_ware mysql_num_vu $mysql_num_vu mysql_partition $mysql_partition mysql_driver $mysql_driver mysql_raiseerror $mysql_raiseerror mysql_keyandthink $mysql_keyandthink mysql_allwarehouse $mysql_allwarehouse mysql_timeprofile $mysql_timeprofile mysql_async_scale $mysql_async_scale mysql_async_verbose $mysql_async_verbose mysql_prepared $mysql_prepared mysql_no_stored_procs $mysql_no_stored_procs mysql_connect_pool $mysql_connect_pool mysql_history_pk $mysql_history_pk} ]
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-        set mysqlconn [ dict create connection {mysql_host {.tpc.f1.e1 get} mysql_port {.tpc.f1.e2 get} mysql_socket {.tpc.f1.e2a get} mysql_ssl_ca {.tpc.f1.e2d get} mysql_ssl_cert {.tpc.f1.e2e get} mysql_ssl_key {.tpc.f1.e2f get} mysql_ssl_cipher {.tpc.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath} ]
+        set mysqlconn [ dict create connection {mysql_host {.tpc.c1.e1 get} mysql_port {.tpc.c1.e2 get} mysql_socket {.tpc.c1.e2a get} mysql_ssl_ca {.tpc.c1.e2d get} mysql_ssl_cert {.tpc.c1.e2e get} mysql_ssl_key {.tpc.c1.e2f get} mysql_ssl_cipher {.tpc.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath $mysql_ssl_linux_capath} ]
     } else {
         set platform "win"
-        set mysqlconn [ dict create connection {mysql_host {.tpc.f1.e1 get} mysql_port {.tpc.f1.e2 get} mysql_socket {.tpc.f1.e2a get} mysql_ssl_ca {.tpc.f1.e2d get} mysql_ssl_cert {.tpc.f1.e2e get} mysql_ssl_key {.tpc.f1.e2f get} mysql_ssl_cipher {.tpc.f1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} ]
+        set mysqlconn [ dict create connection {mysql_host {.tpc.c1.e1 get} mysql_port {.tpc.c1.e2 get} mysql_socket {.tpc.c1.e2a get} mysql_ssl_ca {.tpc.c1.e2d get} mysql_ssl_cert {.tpc.c1.e2e get} mysql_ssl_key {.tpc.c1.e2f get} mysql_ssl_cipher {.tpc.c1.e2g get} mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} ]
     }
     variable myfields
     set myfields [ dict merge $mysqlconn $tpccfields ]
@@ -431,101 +437,101 @@ proc configmysqltpcc {option} {
         "drive" {  wm title .tpc {MySQL TPROC-C Driver Options} }
     }
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MySQL Host :"
     ttk::entry $Name -width 30 -textvariable mysql_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MySQL Port :"   
     ttk::entry $Name  -width 30 -textvariable mysql_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MySQL Socket :"
     ttk::entry $Name  -width 30 -textvariable mysql_socket
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
     if {[string match windows $::tcl_platform(platform)]} {
         set mysql_socket "null"
-        .tpc.f1.e2a configure -state disabled
+        .tpc.c1.e2a configure -state disabled
     }
 
-    set Name $Parent.f1.e2b
-    set Prompt $Parent.f1.p2b
+    set Name $Parent.c1.e2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Enable SSL :"
     ttk::checkbutton $Name -text "" -variable mysql_ssl -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky w
     
-    bind .tpc.f1.e2b <Any-ButtonRelease> {
+    bind .tpc.c1.e2b <Any-ButtonRelease> {
         if { $mysql_ssl eq "true" } {
-            .tpc.f1.e2ba configure -state disabled
-            .tpc.f1.e2bb configure -state disabled
-            .tpc.f1.e2c configure -state disabled
-            .tpc.f1.e2d configure -state disabled
-            .tpc.f1.e2e configure -state disabled
-            .tpc.f1.e2f configure -state disabled
-            .tpc.f1.e2g configure -state disabled
+            .tpc.c1.e2ba configure -state disabled
+            .tpc.c1.e2bb configure -state disabled
+            .tpc.c1.e2c configure -state disabled
+            .tpc.c1.e2d configure -state disabled
+            .tpc.c1.e2e configure -state disabled
+            .tpc.c1.e2f configure -state disabled
+            .tpc.c1.e2g configure -state disabled
         } else {
-            .tpc.f1.e2ba configure -state normal
-            .tpc.f1.e2bb configure -state normal
-            .tpc.f1.e2c configure -state normal
-            .tpc.f1.e2d configure -state normal
+            .tpc.c1.e2ba configure -state normal
+            .tpc.c1.e2bb configure -state normal
+            .tpc.c1.e2c configure -state normal
+            .tpc.c1.e2d configure -state normal
             if { $mysql_ssl_two_way eq "true" } {
-                .tpc.f1.e2e configure -state normal
-                .tpc.f1.e2f configure -state normal
+                .tpc.c1.e2e configure -state normal
+                .tpc.c1.e2f configure -state normal
             }
-            .tpc.f1.e2g configure -state normal
+            .tpc.c1.e2g configure -state normal
         }
     }
     
-    set Name $Parent.f1.e2ba
+    set Name $Parent.c1.e2ba
     ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 5 -sticky w
     if { $mysql_ssl eq "false" } {
-        .tpc.f1.e2ba configure -state disabled
+        .tpc.c1.e2ba configure -state disabled
     }
-    bind .tpc.f1.e2ba <ButtonPress-1> {
-        .tpc.f1.e2e configure -state disabled
-        .tpc.f1.e2f configure -state disabled
+    bind .tpc.c1.e2ba <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .tpc.c1.e2e configure -state disabled
+        .tpc.c1.e2f configure -state disabled
+       }
     }
     
-    set Name $Parent.f1.e2bb
+    set Name $Parent.c1.e2bb
     ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 6 -sticky w
     if { $mysql_ssl eq "false" } {
-        .tpc.f1.e2bb configure -state disabled
+        .tpc.c1.e2bb configure -state disabled
     }
     
-    bind .tpc.f1.e2bb <ButtonPress-1> {
-        .tpc.f1.e2e configure -state normal
-        .tpc.f1.e2f configure -state normal
+    bind .tpc.c1.e2bb <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .tpc.c1.e2e configure -state normal
+        .tpc.c1.e2f configure -state normal
+       }
     }
     
-    set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+    set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mysql_ssl_linux_capath
@@ -538,8 +544,8 @@ proc configmysqltpcc {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -548,8 +554,8 @@ proc configmysqltpcc {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+    set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -558,8 +564,8 @@ proc configmysqltpcc {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+    set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -568,8 +574,8 @@ proc configmysqltpcc {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -578,20 +584,20 @@ proc configmysqltpcc {option} {
         $Name configure -state disabled
     }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MySQL User :"
     ttk::entry $Name  -width 30 -textvariable mysql_user
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mysql_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "TPROC-C MySQL Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mysql_dbase
     grid $Prompt -column 0 -row 14 -sticky e
@@ -843,8 +849,8 @@ proc configmysqltpcc {option} {
             set mysql_async_verbose "false"
             $Name configure -state disabled
         }
-        set Name $Parent.f1.e25
-        set Prompt $Parent.f1.p25
+        set Name $Parent.c1.e25
+        set Prompt $Parent.c1.p25
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mysql_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 37 -sticky e
@@ -855,7 +861,7 @@ proc configmysqltpcc {option} {
         set mysql_no_stored_procs "false"
         }
 
-         bind .tpc.f1.e25 <Any-ButtonRelease> {
+         bind .tpc.c1.e25 <Any-ButtonRelease> {
             if { $mysql_connect_pool eq "false" } {
                 set mysql_prepared "true"
                 set mysql_no_stored_procs "false"
@@ -916,14 +922,14 @@ proc configmysqltpch {option} {
     global default_mysql_port
     set default_mysql_port $mysql_port
     if { $mysql_port eq $mysql_oceanbase_port } { set default_mysql_port 3306 } 
-    set tpchfields [ dict create tpch {mysql_tpch_user {.mytpch.f1.e3 get} mysql_tpch_pass {.mytpch.f1.e4 get} mysql_tpch_dbase {.mytpch.f1.e5 get} mysql_tpch_storage_engine {.mytpch.f1.e6 get} mysql_total_querysets {.mytpch.f1.e9 get} mysql_update_sets {.mytpch.f1.e13 get} mysql_trickle_refresh {.mytpch.f1.e14 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_partition_num $mysql_ob_partition_num mysql_ob_tenant_name $mysql_ob_tenant_name mysql_scale_fact $mysql_scale_fact  mysql_num_tpch_threads $mysql_num_tpch_threads mysql_refresh_on $mysql_refresh_on mysql_raise_query_error $mysql_raise_query_error mysql_verbose $mysql_verbose mysql_refresh_verbose $mysql_refresh_verbose mysql_cloud_query $mysql_cloud_query} ]
+    set tpchfields [ dict create tpch {mysql_tpch_user {.mytpch.c1.e3 get} mysql_tpch_pass {.mytpch.c1.e4 get} mysql_tpch_dbase {.mytpch.c1.e5 get} mysql_tpch_storage_engine {.mytpch.f1.e6 get} mysql_total_querysets {.mytpch.f1.e9 get} mysql_update_sets {.mytpch.f1.e13 get} mysql_trickle_refresh {.mytpch.f1.e14 get} mysql_tpch_obcompat $mysql_tpch_obcompat mysql_ob_partition_num $mysql_ob_partition_num mysql_ob_tenant_name $mysql_ob_tenant_name mysql_scale_fact $mysql_scale_fact  mysql_num_tpch_threads $mysql_num_tpch_threads mysql_refresh_on $mysql_refresh_on mysql_raise_query_error $mysql_raise_query_error mysql_verbose $mysql_verbose mysql_refresh_verbose $mysql_refresh_verbose mysql_cloud_query $mysql_cloud_query} ]
     #set matching fields in dialog to temporary dict
     if {![string match windows $::tcl_platform(platform)]} {
         set platform "lin"
-    set mysqlconn [ dict create connection {mysql_host {.mytpch.f1.e1 get} mysql_port {.mytpch.f1.e2 get} mysql_socket {.mytpch.f1.e2a get} mysql_ssl_ca {.mytpch.f1.e2d get} mysql_ssl_cert {.mytpch.f1.e2e get} mysql_ssl_key {.mytpch.f1.e2f get} mysql_ssl_cipher {.mytpch.f1.e2g get} mysql_oceanbase_port $mysql_oceanbase_port mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath {$mysql_ssl_linux_capath}} ]
+    set mysqlconn [ dict create connection {mysql_host {.mytpch.c1.e1 get} mysql_port {.mytpch.c1.e2 get} mysql_socket {.mytpch.c1.e2a get} mysql_ssl_ca {.mytpch.c1.e2d get} mysql_ssl_cert {.mytpch.c1.e2e get} mysql_ssl_key {.mytpch.c1.e2f get} mysql_ssl_cipher {.mytpch.c1.e2g get} mysql_oceanbase_port $mysql_oceanbase_port mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_linux_capath {$mysql_ssl_linux_capath}} ]
         } else {
         set platform "win"
-    set mysqlconn [ dict create connection {mysql_host {.mytpch.f1.e1 get} mysql_port {.mytpch.f1.e2 get} mysql_socket {.mytpch.f1.e2a get} mysql_ssl_ca {.mytpch.f1.e2d get} mysql_ssl_cert {.mytpch.f1.e2e get} mysql_ssl_key {.mytpch.f1.e2f get} mysql_ssl_cipher {.mytpch.f1.e2g get} mysql_oceanbase_port $mysql_oceanbase_port mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} ]
+    set mysqlconn [ dict create connection {mysql_host {.mytpch.c1.e1 get} mysql_port {.mytpch.c1.e2 get} mysql_socket {.mytpch.c1.e2a get} mysql_ssl_ca {.mytpch.c1.e2d get} mysql_ssl_cert {.mytpch.c1.e2e get} mysql_ssl_key {.mytpch.c1.e2f get} mysql_ssl_cipher {.mytpch.c1.e2g get} mysql_oceanbase_port $mysql_oceanbase_port mysql_ssl $mysql_ssl mysql_ssl_two_way $mysql_ssl_two_way mysql_ssl_windows_capath {$mysql_ssl_windows_capath}} ]
         }
     variable myfields
     set myfields [ dict merge $mysqlconn $tpchfields ]
@@ -937,38 +943,34 @@ proc configmysqltpch {option} {
         "drive" {  wm title .mytpch {MySQL TPROC-H Driver Options} }
     }
     set Parent .mytpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "MySQL Host :"
     ttk::entry $Name -width 30 -textvariable mysql_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "MySQL Port :"   
     ttk::entry $Name  -width 30 -textvariable mysql_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2a
-    set Prompt $Parent.f1.p2a
+    set Name $Parent.c1.e2a
+    set Prompt $Parent.c1.p2a
     ttk::label $Prompt -text "MySQL Socket :"
     ttk::entry $Name  -width 30 -textvariable mysql_socket
     grid $Prompt -column 0 -row 3 -sticky e
@@ -976,11 +978,11 @@ proc configmysqltpch {option} {
 
     if {[string match windows $::tcl_platform(platform)]} {
         set mysql_socket "null"
-        .mytpch.f1.e2a configure -state disabled
+        .mytpch.c1.e2a configure -state disabled
     }
 
-    set Name $Parent.f1.e2b
-    set Prompt $Parent.f1.p2b
+    set Name $Parent.c1.e2b
+    set Prompt $Parent.c1.p2b
     ttk::label $Prompt -text "Enable SSL :"
     ttk::checkbutton $Name -text "" -variable mysql_ssl -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 4 -sticky e
@@ -990,55 +992,59 @@ proc configmysqltpch {option} {
         set $mysql_ssl "false"        
     }    
     
-    bind .mytpch.f1.e2b <Any-ButtonRelease> {
+    bind .mytpch.c1.e2b <Any-ButtonRelease> {
         if { $mysql_ssl eq "true" } {
-            .mytpch.f1.e2ba configure -state disabled
-            .mytpch.f1.e2bb configure -state disabled
-            .mytpch.f1.e2c configure -state disabled
-            .mytpch.f1.e2d configure -state disabled
-            .mytpch.f1.e2e configure -state disabled
-            .mytpch.f1.e2f configure -state disabled
-            .mytpch.f1.e2g configure -state disabled
+            .mytpch.c1.e2ba configure -state disabled
+            .mytpch.c1.e2bb configure -state disabled
+            .mytpch.c1.e2c configure -state disabled
+            .mytpch.c1.e2d configure -state disabled
+            .mytpch.c1.e2e configure -state disabled
+            .mytpch.c1.e2f configure -state disabled
+            .mytpch.c1.e2g configure -state disabled
         } else {
 	if { !$mysql_tpch_obcompat } {
-            .mytpch.f1.e2ba configure -state normal
-            .mytpch.f1.e2bb configure -state normal
-            .mytpch.f1.e2c configure -state normal
-            .mytpch.f1.e2d configure -state normal
+            .mytpch.c1.e2ba configure -state normal
+            .mytpch.c1.e2bb configure -state normal
+            .mytpch.c1.e2c configure -state normal
+            .mytpch.c1.e2d configure -state normal
             if { $mysql_ssl_two_way eq "true" } {
-                .mytpch.f1.e2e configure -state normal
-                .mytpch.f1.e2f configure -state normal
+                .mytpch.c1.e2e configure -state normal
+                .mytpch.c1.e2f configure -state normal
             }
-            .mytpch.f1.e2g configure -state normal
+            .mytpch.c1.e2g configure -state normal
     	    }
         }
     }
     
-    set Name $Parent.f1.e2ba
+    set Name $Parent.c1.e2ba
     ttk::radiobutton $Name -value "false" -text "SSL One-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 5 -sticky w
     if { $mysql_ssl eq "false" } {
-        .mytpch.f1.e2ba configure -state disabled
+        .mytpch.c1.e2ba configure -state disabled
     }
-    bind .mytpch.f1.e2ba <ButtonPress-1> {
-        .mytpch.f1.e2e configure -state disabled
-        .mytpch.f1.e2f configure -state disabled
+    bind .mytpch.c1.e2ba <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .mytpch.c1.e2e configure -state disabled
+        .mytpch.c1.e2f configure -state disabled
+       }
     }
     
-    set Name $Parent.f1.e2bb
+    set Name $Parent.c1.e2bb
     ttk::radiobutton $Name -value "true" -text "SSL Two-Way" -variable mysql_ssl_two_way
     grid $Name -column 1 -row 6 -sticky w
     if { $mysql_ssl eq "false" } {
-        .mytpch.f1.e2bb configure -state disabled
+        .mytpch.c1.e2bb configure -state disabled
     }
     
-    bind .mytpch.f1.e2bb <ButtonPress-1> {
-        .mytpch.f1.e2e configure -state normal
-        .mytpch.f1.e2f configure -state normal
+    bind .mytpch.c1.e2bb <ButtonPress-1> {
+    if { $mysql_ssl eq "true" } {
+        .mytpch.c1.e2e configure -state normal
+        .mytpch.c1.e2f configure -state normal
+       }
     }
     
-    set Name $Parent.f1.e2c
-    set Prompt $Parent.f1.p2c
+    set Name $Parent.c1.e2c
+    set Prompt $Parent.c1.p2c
     ttk::label $Prompt -text "SSL CApath :"
     if { $platform eq "lin" } {
         ttk::entry $Name -width 30 -textvariable mysql_ssl_linux_capath
@@ -1051,8 +1057,8 @@ proc configmysqltpch {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2d
-    set Prompt $Parent.f1.p2d
+    set Name $Parent.c1.e2d
+    set Prompt $Parent.c1.p2d
     ttk::label $Prompt -text "SSL CA :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_ca
     grid $Prompt -column 0 -row 8 -sticky e
@@ -1061,8 +1067,8 @@ proc configmysqltpch {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2e
-    set Prompt $Parent.f1.p2e
+    set Name $Parent.c1.e2e
+    set Prompt $Parent.c1.p2e
     ttk::label $Prompt -text "SSL Cert :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cert
     grid $Prompt -column 0 -row 9 -sticky e
@@ -1071,8 +1077,8 @@ proc configmysqltpch {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2f
-    set Prompt $Parent.f1.p2f
+    set Name $Parent.c1.e2f
+    set Prompt $Parent.c1.p2f
     ttk::label $Prompt -text "SSL Key :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_key
     grid $Prompt -column 0 -row 10 -sticky e
@@ -1081,8 +1087,8 @@ proc configmysqltpch {option} {
         $Name configure -state disabled
     }
     
-    set Name $Parent.f1.e2g
-    set Prompt $Parent.f1.p2g
+    set Name $Parent.c1.e2g
+    set Prompt $Parent.c1.p2g
     ttk::label $Prompt -text "SSL Cipher :"
     ttk::entry $Name  -width 30 -textvariable mysql_ssl_cipher
     grid $Prompt -column 0 -row 11 -sticky e
@@ -1091,55 +1097,55 @@ proc configmysqltpch {option} {
         $Name configure -state disabled
     }
 
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "MySQL User :"
     ttk::entry $Name  -width 30 -textvariable mysql_tpch_user
     grid $Prompt -column 0 -row 12 -sticky e
     grid $Name -column 1 -row 12 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "MySQL User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable mysql_tpch_pass
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "TPROC-H MySQL Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable mysql_tpch_dbase
     grid $Prompt -column 0 -row 14 -sticky e
     grid $Name -column 1 -row 14 -sticky ew
-    set Name $Parent.f1.e5a
-    set Prompt $Parent.f1.p5a
+    set Name $Parent.c1.e5a
+    set Prompt $Parent.c1.p5a
     ttk::label $Prompt -text "Oceanbase Database Compatible :"
     ttk::checkbutton $Name -text "" -variable mysql_tpch_obcompat -onvalue "true" -offvalue "false" 
     grid $Prompt -column 0 -row 15 -sticky e
     grid $Name -column 1 -row 15 -sticky w
-    bind $Parent.f1.e5a <Button> {
+    bind $Parent.c1.e5a <Button> {
         if { $mysql_tpch_obcompat eq "true" } {
              set mysql_port $default_mysql_port
-            .mytpch.f1.e2b configure -state normal                       
-            .mytpch.f1.e5b configure -state disabled   
+            .mytpch.c1.e2b configure -state normal                       
+            .mytpch.c1.e5b configure -state disabled   
 	    #only disable partitions in build
             if { [ llength [info commands .mytpch.f1.e6a ] ] != 0 } { .mytpch.f1.e6a configure -state disabled }
         } else {
              set mysql_ssl "false"
              set mysql_port $mysql_oceanbase_port
-            .mytpch.f1.e2b configure -state disabled
-            .mytpch.f1.e2ba configure -state disabled
-            .mytpch.f1.e2bb configure -state disabled
-            .mytpch.f1.e2c configure -state disabled
-            .mytpch.f1.e2d configure -state disabled
-            .mytpch.f1.e2e configure -state disabled
-            .mytpch.f1.e2f configure -state disabled
-            .mytpch.f1.e2g configure -state disabled
-            .mytpch.f1.e5b configure -state normal            
+            .mytpch.c1.e2b configure -state disabled
+            .mytpch.c1.e2ba configure -state disabled
+            .mytpch.c1.e2bb configure -state disabled
+            .mytpch.c1.e2c configure -state disabled
+            .mytpch.c1.e2d configure -state disabled
+            .mytpch.c1.e2e configure -state disabled
+            .mytpch.c1.e2f configure -state disabled
+            .mytpch.c1.e2g configure -state disabled
+            .mytpch.c1.e5b configure -state normal            
 	    #only enable partitions in build
             if { [ llength [info commands .mytpch.f1.e6a ] ] != 0  } { .mytpch.f1.e6a configure -state normal }            
         }
     } 
-    set Name $Parent.f1.e5b
-    set Prompt $Parent.f1.5b
+    set Name $Parent.c1.e5b
+    set Prompt $Parent.c1.5b
     ttk::label $Prompt -text "Oceanbase Tenant Name:"
     ttk::entry $Name -width 30 -textvariable mysql_ob_tenant_name
     grid $Prompt -column 0 -row 16 -sticky e

--- a/src/oracle/oraopt.tcl
+++ b/src/oracle/oraopt.tcl
@@ -26,10 +26,10 @@ proc countoraopts { bm } {
     variable oraoptsfields
     if { $bm eq "TPC-C" } { 
         set bm_for_count "tpcc_tt_compat" 
-        set oraoptsfields [ dict create connection {system_user {.countopt.f1.e2 get} system_password {.countopt.f1.e3 get} instance {.countopt.f1.e1 get} rac $rac} tpcc {tpcc_tt_compat $tpcc_tt_compat} ]
+        set oraoptsfields [ dict create connection {system_user {.countopt.c1.e2 get} system_password {.countopt.c1.e3 get} instance {.countopt.c1.e1 get} rac $rac} tpcc {tpcc_tt_compat $tpcc_tt_compat} ]
     } else { 
         set bm_for_count "tpch_tt_compat" 
-        set oraoptsfields [ dict create connection {system_user {.countopt.f1.e2 get} system_password {.countopt.f1.e3 get} instance {.countopt.f1.e1 get} rac $rac} tpch {tpch_tt_compat $tpch_tt_compat} ]
+        set oraoptsfields [ dict create connection {system_user {.countopt.c1.e2 get} system_password {.countopt.c1.e3 get} instance {.countopt.c1.e1 get} rac $rac} tpch {tpch_tt_compat $tpch_tt_compat} ]
     }
 
     if { [ info exists afval ] } {
@@ -41,34 +41,29 @@ proc countoraopts { bm } {
     wm transient .countopt .ed_mainFrame
     wm withdraw .countopt
     wm title .countopt {Oracle TX Counter Options}
-
     set Parent .countopt
-
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "Oracle Service Name :"
     ttk::entry $Name -width 30 -textvariable instance
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "System User :"   
     ttk::entry $Name  -width 30 -textvariable system_user
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "System User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
@@ -80,19 +75,19 @@ proc countoraopts { bm } {
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4
 
-    set Name $Parent.f1.e5
+    set Name $Parent.c1.e5
     ttk::checkbutton $Name -text "TimesTen Database Compatible" -variable $bm_for_count -onvalue "true" -offvalue "false"
     grid $Name -column 1 -row 5 -sticky w
-    bind .countopt.f1.e5 <Any-ButtonRelease> {
+    bind .countopt.c1.e5 <Any-ButtonRelease> {
         if { $bm eq "TPC-C" && $tpcc_tt_compat eq "false" || $bm eq "TPC-H" && $tpch_tt_compat eq "false" } {
             set rac 0
-            .countopt.f1.e6 configure -state disabled
+            .countopt.c1.e6 configure -state disabled
         } else {
-            .countopt.f1.e6 configure -state normal
+            .countopt.c1.e6 configure -state normal
         }
     }
 
-    set Name $Parent.f1.e6
+    set Name $Parent.c1.e6
     ttk::checkbutton $Name -text "RAC Global Transactions" -variable rac -onvalue 1 -offvalue 0
     grid $Name -column 1 -row 6 -sticky w
     if { $bm eq "TPC-C" && $tpcc_tt_compat eq "true" || $bm eq "TPC-H" && $tpch_tt_compat eq "true" } {
@@ -128,7 +123,7 @@ proc countoraopts { bm } {
         $Name configure -state disabled
     }
 
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -181,7 +176,7 @@ proc configoratpcc {option} {
     setlocaltpccvars $configoracle
     #set matching fields in dialog to temporary dict
     variable orafields
-    set orafields [ dict create connection {system_user {.tpc.f1.e2 get} system_password {.tpc.f1.e3 get} instance {.tpc.f1.e1 get}} tpcc {tpcc_user {.tpc.f1.e4 get} tpcc_pass {.tpc.f1.e5 get} tpcc_def_tab {.tpc.f1.e6 get} tpcc_ol_tab {.tpc.f1.e6a get} tpcc_def_temp {.tpc.f1.e7 get} total_iterations {.tpc.f1.e17 get} rampup {.tpc.f1.e21 get} duration {.tpc.f1.e22 get} async_client {.tpc.f1.e26 get} async_delay {.tpc.f1.e27 get} tpcc_tt_compat $tpcc_tt_compat hash_clusters $hash_clusters partition $partition count_ware $count_ware num_vu $num_vu ora_driver $ora_driver raiseerror $raiseerror keyandthink $keyandthink checkpoint $checkpoint allwarehouse $allwarehouse ora_timeprofile $ora_timeprofile async_scale $async_scale async_verbose $async_verbose connect_pool $connect_pool}]
+    set orafields [ dict create connection {system_user {.tpc.c1.e2 get} system_password {.tpc.c1.e3 get} instance {.tpc.c1.e1 get}} tpcc {tpcc_user {.tpc.c1.e4 get} tpcc_pass {.tpc.c1.e5 get} tpcc_def_tab {.tpc.f1.e6 get} tpcc_ol_tab {.tpc.f1.e6a get} tpcc_def_temp {.tpc.f1.e7 get} total_iterations {.tpc.f1.e17 get} rampup {.tpc.f1.e21 get} duration {.tpc.f1.e22 get} async_client {.tpc.f1.e26 get} async_delay {.tpc.f1.e27 get} tpcc_tt_compat $tpcc_tt_compat hash_clusters $hash_clusters partition $partition count_ware $count_ware num_vu $num_vu ora_driver $ora_driver raiseerror $raiseerror keyandthink $keyandthink checkpoint $checkpoint allwarehouse $allwarehouse ora_timeprofile $ora_timeprofile async_scale $async_scale async_verbose $async_verbose connect_pool $connect_pool}]
     set whlist [ get_warehouse_list_for_spinbox ]
     catch "destroy .tpc"
     ttk::toplevel .tpc
@@ -193,50 +188,46 @@ proc configoratpcc {option} {
         "drive" {  wm title .tpc {Oracle TPROC-C Driver Options} }
     }
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5  
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+    set Prompt $Parent.h2
+    ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "Oracle Service Name :"
     ttk::entry $Name -width 30 -textvariable instance
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "System User :"   
     ttk::entry $Name  -width 30 -textvariable system_user
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "System User Password :"   
     ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "TPROC-C User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable tpcc_user
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "TPROC-C User Password :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -show * -width 30 -textvariable tpcc_pass
     grid $Prompt -column 0 -row 5 -sticky e
@@ -261,9 +252,9 @@ proc configoratpcc {option} {
         grid $Prompt -column 0 -row 8 -sticky e
         grid $Name -column 1 -row 8 -sticky ew
     }
-    set Prompt $Parent.f1.p8
+    set Prompt $Parent.c1.p8
     ttk::label $Prompt -text "TimesTen Database Compatible :"
-    set Name $Parent.f1.e8
+    set Name $Parent.c1.e8
     ttk::checkbutton $Name -text "" -variable tpcc_tt_compat -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 9 -sticky e
     grid $Name -column 1 -row 9 -sticky w
@@ -281,7 +272,7 @@ proc configoratpcc {option} {
             catch {.tpc.f1.$field configure -state disabled}
         }
     }
-    bind .tpc.f1.e8 <ButtonPress-1> {
+    bind .tpc.c1.e8 <ButtonPress-1> {
         if { $tpcc_tt_compat eq "true" } {
             foreach field {e2 e3 e6 e7} {
                 catch {.tpc.f1.$field configure -state normal}
@@ -555,8 +546,8 @@ proc configoratpcc {option} {
             set async_verbose "false"
             $Name configure -state disabled
         }
-        set Name $Parent.f1.e29
-        set Prompt $Parent.f1.p29
+        set Name $Parent.c1.e29
+        set Prompt $Parent.c1.p29
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 31 -sticky e
@@ -607,7 +598,7 @@ proc configoratpch {option} {
     #set variables to values in dict
     setlocaltpchvars $configoracle
     variable orafields
-    set orafields [ dict create connection {instance {.tpch.f1.e1 get} system_user {.tpch.f1.e1a get} system_password {.tpch.f1.e2 get}} tpch {tpch_user {.tpch.f1.e3 get} tpch_pass {.tpch.f1.e4 get} tpch_def_tab {.tpch.f1.e5 get} tpch_def_temp {.tpch.f1.e6 get} total_querysets {.tpch.f1.e10 get} degree_of_parallel {.tpch.f1.e13 get} update_sets {.tpch.f1.e15 get} trickle_refresh {.tpch.f1.e16 get} tpch_tt_compat $tpch_tt_compat scale_fact $scale_fact num_tpch_threads $num_tpch_threads raise_query_error $raise_query_error verbose $verbose refresh_on $refresh_on refresh_verbose $refresh_verbose cloud_query $cloud_query}]
+    set orafields [ dict create connection {instance {.tpch.c1.e1 get} system_user {.tpch.c1.e1a get} system_password {.tpch.c1.e2 get}} tpch {tpch_user {.tpch.c1.e3 get} tpch_pass {.tpch.c1.e4 get} tpch_def_tab {.tpch.f1.e5 get} tpch_def_temp {.tpch.f1.e6 get} total_querysets {.tpch.f1.e10 get} degree_of_parallel {.tpch.f1.e13 get} update_sets {.tpch.f1.e15 get} trickle_refresh {.tpch.f1.e16 get} tpch_tt_compat $tpch_tt_compat scale_fact $scale_fact num_tpch_threads $num_tpch_threads raise_query_error $raise_query_error verbose $verbose refresh_on $refresh_on refresh_verbose $refresh_verbose cloud_query $cloud_query}]
     catch "destroy .tpch"
     ttk::toplevel .tpch
     wm transient .tpch .ed_mainFrame
@@ -618,50 +609,46 @@ proc configoratpch {option} {
         "drive" {  wm title .tpch {Oracle TPROC-H Driver Options} }
     }
     set Parent .tpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "Oracle Service Name :"
     ttk::entry $Name -width 30 -textvariable instance
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -columnspan 4 -sticky ew
-    set Name $Parent.f1.e1a
-    set Prompt $Parent.f1.p1a
+    set Name $Parent.c1.e1a
+    set Prompt $Parent.c1.p1a
     ttk::label $Prompt -text "System User :"   
     ttk::entry $Name  -width 30 -textvariable system_user
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "System User Password :"
     ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -columnspan 4 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "TPROC-H User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable tpch_user
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -columnspan 4 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "TPROC-H User Password :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -show * -width 30 -textvariable tpch_pass
     grid $Prompt -column 0 -row 5 -sticky e
@@ -680,9 +667,9 @@ proc configoratpch {option} {
         grid $Prompt -column 0 -row 7 -sticky e
         grid $Name -column 1 -row 7 -columnspan 4 -sticky ew
     }
-    set Prompt $Parent.f1.p7
+    set Prompt $Parent.c1.p7
     ttk::label $Prompt -text "TimesTen Database Compatible :"
-    set Name $Parent.f1.e7
+    set Name $Parent.c1.e7
     ttk::checkbutton $Name -text "" -variable tpch_tt_compat -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 8 -sticky e
     grid $Name -column 1 -row 8 -sticky w
@@ -695,7 +682,7 @@ proc configoratpch {option} {
             catch {.tpch.f1.$field configure -state disabled}
         }
     }
-    bind .tpch.f1.e7 <ButtonPress-1> {
+    bind .tpch.c1.e7 <ButtonPress-1> {
         if { $tpch_tt_compat eq "true" } {
             foreach field {e2 e5 e6 e13} {
                 catch {.tpch.f1.$field configure -state normal}
@@ -881,7 +868,7 @@ proc metoraopts {} {
     #use same parameters as transaction counter
     setlocaltcountvars $configoracle 1
     variable oraoptsfields
-    set oraoptsfields [ dict create connection {system_user {.metric.f1.e4 get} system_password {.metric.f1.e5 get} instance {.metric.f1.e3 get}} ]
+    set oraoptsfields [ dict create connection {system_user {.metric.c1.e4 get} system_password {.metric.c1.e5 get} instance {.metric.c1.e3 get}} ]
     if {  [ info exists agent_hostname ] } { ; } else { set agent_hostname "localhost" }
     if {  [ info exists agent_id ] } { ; } else { set agent_id 0 }
     set old_agent $agent_hostname
@@ -892,17 +879,14 @@ proc metoraopts {} {
     wm withdraw .metric
     wm title .metric {Oracle Metrics Options}
     set Parent .metric
-    set Name $Parent.f1
-    ttk::frame $Name
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Oracle Metrics Options" -image [ create_image dashboard icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image dashboard icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Oracle and OS Agent"
-    grid $Prompt -column 1 -row 0 -sticky w
-
     set Name $Parent.f1.e1
     set Prompt $Parent.f1.p1
     ttk::label $Prompt -text "Agent ID :"
@@ -915,20 +899,20 @@ proc metoraopts {} {
     ttk::entry $Name -width 30 -textvariable agent_hostname
     grid $Prompt -column 0 -row 8 -sticky e
     grid $Name -column 1 -row 8
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "Oracle Service Name :"
     ttk::entry $Name -width 30 -textvariable instance
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "System User :"
     ttk::entry $Name  -width 30 -textvariable system_user
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "System User Password :"
     ttk::entry $Name -show * -width 30 -textvariable system_password
     grid $Prompt -column 0 -row 6 -sticky e

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -17,9 +17,9 @@ proc countpgopts { bm } {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.countopt.f1.e3 get} pg_superuserpass {.countopt.f1.e4 get} pg_defaultdbase {.countopt.f1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.countopt.c1.e3 get} pg_superuserpass {.countopt.c1.e4 get} pg_defaultdbase {.countopt.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.countopt.f1.e1 get} pg_port {.countopt.f1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.countopt.f1.e3 get} pg_tpch_superuserpass {.countopt.f1.e4 get} pg_tpch_defaultdbase {.countopt.f1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.countopt.c1.e3 get} pg_tpch_superuserpass {.countopt.c1.e4 get} pg_tpch_defaultdbase {.countopt.c1.e5 get}} ]
     }
     if { [ info exists afval ] } {
         after cancel $afval
@@ -44,29 +44,28 @@ proc countpgopts { bm } {
     wm withdraw .countopt
     wm title .countopt {PostgreSQL TX Counter Options}
     set Parent .countopt
-    set Name $Parent.f1
-    ttk::frame $Name 
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "Transaction Counter Options" -image [ create_image pencil icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image pencil icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "Transaction Counter Options"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "PostgreSQL Host :"
     ttk::entry $Name -width 30 -textvariable pg_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "PostgreSQL Port :"   
     ttk::entry $Name  -width 30 -textvariable pg_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "PostgreSQL Superuser :"
     if { $bm eq "TPC-C" } {
         ttk::entry $Name  -width 30 -textvariable pg_superuser
@@ -75,8 +74,8 @@ proc countpgopts { bm } {
     }
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
     if { $bm eq "TPC-C" } {
         ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
@@ -85,8 +84,8 @@ proc countpgopts { bm } {
     }
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "PostgreSQL Default Database :"
     if { $bm eq "TPC-C" } {
         ttk::entry $Name -width 30 -textvariable pg_defaultdbase
@@ -103,9 +102,9 @@ proc countpgopts { bm } {
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky ew
 
-    set Prompt $Parent.f1.p6a
+    set Prompt $Parent.c1.p6a
     ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
-    set Name $Parent.f1.e6a
+    set Name $Parent.c1.e6a
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky w
@@ -138,7 +137,7 @@ proc countpgopts { bm } {
     if {$tclog == 0} {
         $Name configure -state disabled
     }
-    bind .countopt.f1.e1 <Delete> {
+    bind .countopt.c1.e1 <Delete> {
         if [%W selection present] {
             %W delete sel.first sel.last
         } else {
@@ -207,7 +206,7 @@ proc configpgtpcc {option} {
     setlocaltpccvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.tpc.f1.e1 get} pg_port {.tpc.f1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.tpc.f1.e3 get} pg_superuserpass {.tpc.f1.e4 get} pg_defaultdbase {.tpc.f1.e5 get} pg_user {.tpc.f1.e6 get} pg_pass {.tpc.f1.e7 get} pg_dbase {.tpc.f1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
+    set pgfields [ dict create connection {pg_host {.tpc.c1.e1 get} pg_port {.tpc.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.tpc.c1.e3 get} pg_superuserpass {.tpc.c1.e4 get} pg_defaultdbase {.tpc.c1.e5 get} pg_user {.tpc.c1.e6 get} pg_pass {.tpc.c1.e7 get} pg_dbase {.tpc.c1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
     set whlist [ get_warehouse_list_for_spinbox ]
     if { $pg_oracompat eq "true" } {
         if { $pg_port eq "5432" } { set pg_port "5444" }
@@ -229,68 +228,64 @@ proc configpgtpcc {option} {
         "drive" {  wm title .tpc {PostgreSQL TPROC-C Driver Options} }
     }
     set Parent .tpc
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+    set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "PostgreSQL Host :"
     ttk::entry $Name -width 30 -textvariable pg_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "PostgreSQL Port :"   
     ttk::entry $Name  -width 30 -textvariable pg_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "PostgreSQL Superuser :"
     ttk::entry $Name  -width 30 -textvariable pg_superuser
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
     ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "PostgreSQL Default Database :"
     ttk::entry $Name -width 30 -textvariable pg_defaultdbase
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky ew
-    set Name $Parent.f1.e6
-    set Prompt $Parent.f1.p6
+    set Name $Parent.c1.e6
+    set Prompt $Parent.c1.p6
     ttk::label $Prompt -text "TPROC-C PostgreSQL User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable pg_user
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky ew
-    set Name $Parent.f1.e7
-    set Prompt $Parent.f1.p7
+    set Name $Parent.c1.e7
+    set Prompt $Parent.c1.p7
     ttk::label $Prompt -text "TPROC-C PostgreSQL User Password :" -image [ create_image hdbicon icons ] -compound left 
     ttk::entry $Name -show * -width 30 -textvariable pg_pass
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
-    set Name $Parent.f1.e8
-    set Prompt $Parent.f1.p8
+    set Name $Parent.c1.e8
+    set Prompt $Parent.c1.p8
     ttk::label $Prompt -text "TPROC-C PostgreSQL Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable pg_dbase
     grid $Prompt -column 0 -row 8 -sticky e
@@ -303,13 +298,13 @@ proc configpgtpcc {option} {
         grid $Prompt -column 0 -row 9 -sticky e
         grid $Name -column 1 -row 9 -sticky ew
     }
-    set Prompt $Parent.f1.p9
+    set Prompt $Parent.c1.p9
     ttk::label $Prompt -text "EnterpriseDB Oracle Compatible :"
-    set Name $Parent.f1.e9
+    set Name $Parent.c1.e9
     ttk::checkbutton $Name -text "" -variable pg_oracompat -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 10 -sticky e
     grid $Name -column 1 -row 10 -sticky w
-    bind .tpc.f1.e9 <Button> { 
+    bind .tpc.c1.e9 <Button> { 
         if { $pg_cituscompat == "true" } {
             # do nothing, button is disabled
         } elseif { $pg_oracompat != "true" } {
@@ -318,22 +313,22 @@ proc configpgtpcc {option} {
             if { $pg_defaultdbase eq "postgres" } { set pg_defaultdbase "edb" }
             if { $pg_storedprocs eq "true" } { set pg_storedprocs "false" }
             .tpc.f1.e9a configure -state disabled
-            .tpc.f1.e9c configure -state disabled
+            .tpc.c1.e9c configure -state disabled
         } else {
             if { $pg_port eq "5444" } { set pg_port "5432" }
             if { $pg_superuser eq "enterprisedb" } { set pg_superuser "postgres" }
             if { $pg_defaultdbase eq "edb" } { set pg_defaultdbase "postgres" }
             .tpc.f1.e9a configure -state normal
-            .tpc.f1.e9c configure -state normal
+            .tpc.c1.e9c configure -state normal
         }
     }
-    set Prompt $Parent.f1.p9c
+    set Prompt $Parent.c1.p9c
     ttk::label $Prompt -text "Citus Compatible :"
-    set Name $Parent.f1.e9c
+    set Name $Parent.c1.e9c
     ttk::checkbutton $Name -text "" -variable pg_cituscompat -onvalue "true" -offvalue "false"
     grid $Prompt -column 0 -row 11 -sticky e
     grid $Name -column 1 -row 11 -sticky w
-    bind .tpc.f1.e9c <Button> {
+    bind .tpc.c1.e9c <Button> {
         if { $pg_oracompat == "true" } {
             # do nothing, button is disabled
         } elseif { $pg_cituscompat != "true" } {
@@ -341,31 +336,22 @@ proc configpgtpcc {option} {
             if { $pg_defaultdbase eq "postgres" } { set pg_defaultdbase "citus" }
             set pg_storedprocs "true"
             set pg_partition "false"
-            .tpc.f1.e9 configure -state disabled
+            .tpc.c1.e9 configure -state disabled
             .tpc.f1.e9a configure -state disabled
 	    if { ".tpc.f1.e11a" in [ info commands ] } { .tpc.f1.e11a configure -state disabled }
         } else {
             if { $pg_superuser eq "citus" } { set pg_superuser "postgres" }
             if { $pg_defaultdbase eq "citus" } { set pg_defaultdbase "postgres" }
-            .tpc.f1.e9 configure -state normal
+            .tpc.c1.e9 configure -state normal
             .tpc.f1.e9a configure -state normal
             if { $pg_count_ware > 200 } {
 	    if { ".tpc.f1.e11a" in [ info commands ] } { .tpc.f1.e11a configure -state normal }
             }
         }
     }
-    set Prompt $Parent.f1.p9a
-    ttk::label $Prompt -text "PostgreSQL Stored Procedures :"
-    set Name $Parent.f1.e9a
-    ttk::checkbutton $Name -text "" -variable pg_storedprocs -onvalue "true" -offvalue "false"
-    if {$pg_oracompat == "true" } {
-        $Name configure -state disabled
-    }
-    grid $Prompt -column 0 -row 12 -sticky e
-    grid $Name -column 1 -row 12 -sticky w
-    set Prompt $Parent.f1.p9b
+    set Prompt $Parent.c1.p9b
     ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
-    set Name $Parent.f1.e9b
+    set Name $Parent.c1.e9b
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky w
@@ -409,6 +395,15 @@ proc configpgtpcc {option} {
         if {$pg_count_ware < 200 } {
             $Name configure -state disabled
         }
+        set Prompt $Parent.f1.p9a
+        ttk::label $Prompt -text "PostgreSQL Stored Procedures :"
+        set Name $Parent.f1.e9a
+        ttk::checkbutton $Name -text "" -variable pg_storedprocs -onvalue "true" -offvalue "false"
+        if {$pg_oracompat == "true" } {
+        $Name configure -state disabled
+        }
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky w
     }
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {
@@ -507,12 +502,21 @@ proc configpgtpcc {option} {
         if {$pg_driver == "test" } {
             $Name configure -state disabled
         }
+        set Prompt $Parent.f1.p9a
+        ttk::label $Prompt -text "PostgreSQL Stored Procedures :"
+        set Name $Parent.f1.e9a
+        ttk::checkbutton $Name -text "" -variable pg_storedprocs -onvalue "true" -offvalue "false"
+        if {$pg_oracompat == "true" } {
+        $Name configure -state disabled
+        }
+        grid $Prompt -column 0 -row 25 -sticky e
+        grid $Name -column 1 -row 25 -sticky w
         set Name $Parent.f1.e21
         set Prompt $Parent.f1.p21
         ttk::label $Prompt -text "Minutes of Rampup Time :"
         ttk::entry $Name -width 30 -textvariable pg_rampup
-        grid $Prompt -column 0 -row 25 -sticky e
-        grid $Name -column 1 -row 25 -sticky ew
+        grid $Prompt -column 0 -row 26 -sticky e
+        grid $Name -column 1 -row 26 -sticky ew
         if {$pg_driver == "test" } {
             $Name configure -state disabled
         }
@@ -520,8 +524,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p22
         ttk::label $Prompt -text "Minutes for Test Duration :"
         ttk::entry $Name -width 30 -textvariable pg_duration
-        grid $Prompt -column 0 -row 26 -sticky e
-        grid $Name -column 1 -row 26 -sticky ew
+        grid $Prompt -column 0 -row 27 -sticky e
+        grid $Name -column 1 -row 27 -sticky ew
         if {$pg_driver == "test" } {
             $Name configure -state disabled
         }
@@ -529,8 +533,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p23
         ttk::label $Prompt -text "Use All Warehouses :"
         ttk::checkbutton $Name -text "" -variable pg_allwarehouse -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 27 -sticky e
-        grid $Name -column 1 -row 27 -sticky ew
+        grid $Prompt -column 0 -row 28 -sticky e
+        grid $Name -column 1 -row 28 -sticky ew
         if {$pg_driver == "test" } {
             $Name configure -state disabled
         }
@@ -538,8 +542,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p24
         ttk::label $Prompt -text "Time Profile :"
         ttk::checkbutton $Name -text "" -variable pg_timeprofile -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 28 -sticky e
-        grid $Name -column 1 -row 28 -sticky ew
+        grid $Prompt -column 0 -row 29 -sticky e
+        grid $Name -column 1 -row 29 -sticky ew
         if {$pg_driver == "test" } {
             $Name configure -state disabled
         }
@@ -547,8 +551,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p25
         ttk::label $Prompt -text "Asynchronous Scaling :"
         ttk::checkbutton $Name -text "" -variable pg_async_scale -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 29 -sticky e
-        grid $Name -column 1 -row 29 -sticky ew
+        grid $Prompt -column 0 -row 30 -sticky e
+        grid $Name -column 1 -row 30 -sticky ew
         if {$pg_driver == "test" } {
             set pg_async_scale "false"
             $Name configure -state disabled
@@ -572,8 +576,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p26
         ttk::label $Prompt -text "Asynch Clients per Virtual User :"
         ttk::entry $Name -width 30 -textvariable pg_async_client
-        grid $Prompt -column 0 -row 30 -sticky e
-        grid $Name -column 1 -row 30 -sticky ew
+        grid $Prompt -column 0 -row 31 -sticky e
+        grid $Name -column 1 -row 31 -sticky ew
         if {$pg_driver == "test" || $pg_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -581,8 +585,8 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p27
         ttk::label $Prompt -text "Asynch Client Login Delay :"
         ttk::entry $Name -width 30 -textvariable pg_async_delay
-        grid $Prompt -column 0 -row 31 -sticky e
-        grid $Name -column 1 -row 31 -sticky ew
+        grid $Prompt -column 0 -row 32 -sticky e
+        grid $Name -column 1 -row 32 -sticky ew
         if {$pg_driver == "test" || $pg_async_scale == "false" } {
             $Name configure -state disabled
         }
@@ -590,18 +594,18 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p28
         ttk::label $Prompt -text "Asynchronous Verbose :"
         ttk::checkbutton $Name -text "" -variable pg_async_verbose -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 32 -sticky e
-        grid $Name -column 1 -row 32 -sticky ew
+        grid $Prompt -column 0 -row 33 -sticky e
+        grid $Name -column 1 -row 33 -sticky ew
         if {$pg_driver == "test" || $pg_async_scale == "false" } {
             set pg_async_verbose "false"
             $Name configure -state disabled
         }
-        set Name $Parent.f1.e29
-        set Prompt $Parent.f1.p29
+        set Name $Parent.c1.e29
+        set Prompt $Parent.c1.p29
         ttk::label $Prompt -text "XML Connect Pool :"
         ttk::checkbutton $Name -text "" -variable pg_connect_pool -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 33 -sticky e
-        grid $Name -column 1 -row 33 -sticky ew
+        grid $Prompt -column 0 -row 34 -sticky e
+        grid $Name -column 1 -row 34 -sticky ew
     }
     #This is the Cancel button variables stay as before
     set Name $Parent.b2
@@ -647,7 +651,7 @@ proc configpgtpch {option} {
     setlocaltpchvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.pgtpch.f1.e1 get} pg_port {.pgtpch.f1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.pgtpch.f1.e3 get} pg_tpch_superuserpass {.pgtpch.f1.e4 get} pg_tpch_defaultdbase {.pgtpch.f1.e5 get} pg_tpch_user {.pgtpch.f1.e6 get} pg_tpch_pass {.pgtpch.f1.e7 get} pg_tpch_dbase {.pgtpch.f1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
+    set pgfields [ dict create connection {pg_host {.pgtpch.c1.e1 get} pg_port {.pgtpch.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.pgtpch.c1.e3 get} pg_tpch_superuserpass {.pgtpch.c1.e4 get} pg_tpch_defaultdbase {.pgtpch.c1.e5 get} pg_tpch_user {.pgtpch.c1.e6 get} pg_tpch_pass {.pgtpch.c1.e7 get} pg_tpch_dbase {.pgtpch.c1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
     catch "destroy .pgtpch"
     ttk::toplevel .pgtpch
     wm transient .pgtpch .ed_mainFrame
@@ -658,77 +662,73 @@ proc configpgtpch {option} {
         "drive" {  wm title .pgtpch {PostgreSQL TPROC-H Driver Options} }
     }
     set Parent .pgtpch
-    set Name $Parent.f1
-    ttk::frame $Name
-    pack $Name -anchor nw -fill x -side top -padx 5
     if { $option eq "all" || $option eq "build" } {
-        set Prompt $Parent.f1.h1
-        ttk::label $Prompt -image [ create_image boxes icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h2
-        ttk::label $Prompt -text "Build Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h1
+	ttk::label $Prompt -compound left -text "Build Options" -image [ create_image boxes icons ]
+    	pack $Prompt -anchor center -side top 
     } else {
-        set Prompt $Parent.f1.h3
-        ttk::label $Prompt -image [ create_image driveroptlo icons ]
-        grid $Prompt -column 0 -row 0 -sticky e
-        set Prompt $Parent.f1.h4
-        ttk::label $Prompt -text "Driver Options"
-        grid $Prompt -column 1 -row 0 -sticky w
+        set Prompt $Parent.h2
+	ttk::label $Prompt -compound left -text "Driver Options" -image [ create_image driveroptlo icons ]
+    	pack $Prompt -anchor center -side top 
     }
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
+    pack $Name -anchor nw -fill x -side top -padx 5
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "PostgreSQL Host :"
     ttk::entry $Name -width 30 -textvariable pg_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "PostgreSQL Port :"
     ttk::entry $Name  -width 30 -textvariable pg_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
     if { $option eq "all" || $option eq "build" } {
-        set Name $Parent.f1.e3
-        set Prompt $Parent.f1.p3
+        set Name $Parent.c1.e3
+        set Prompt $Parent.c1.p3
         ttk::label $Prompt -text "PostgreSQL Superuser :"
         ttk::entry $Name  -width 30 -textvariable pg_tpch_superuser
         grid $Prompt -column 0 -row 3 -sticky e
         grid $Name -column 1 -row 3 -sticky ew
-        set Name $Parent.f1.e4
-        set Prompt $Parent.f1.p4
+        set Name $Parent.c1.e4
+        set Prompt $Parent.c1.p4
         ttk::label $Prompt -text "PostgreSQL Superuser Password :"
         ttk::entry $Name -show * -width 30 -textvariable pg_tpch_superuserpass
         grid $Prompt -column 0 -row 4 -sticky e
         grid $Name -column 1 -row 4 -sticky ew
-        set Name $Parent.f1.e5
-        set Prompt $Parent.f1.p5
+        set Name $Parent.c1.e5
+        set Prompt $Parent.c1.p5
         ttk::label $Prompt -text "PostgreSQL Default Database :"
         ttk::entry $Name -width 30 -textvariable pg_tpch_defaultdbase
         grid $Prompt -column 0 -row 5 -sticky e
         grid $Name -column 1 -row 5 -sticky ew
     }
-    set Name $Parent.f1.e6
-    set Prompt $Parent.f1.p6
+    set Name $Parent.c1.e6
+    set Prompt $Parent.c1.p6
     ttk::label $Prompt -text "TPROC-H PostgreSQL User :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name  -width 30 -textvariable pg_tpch_user
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky ew
-    set Name $Parent.f1.e7
-    set Prompt $Parent.f1.p7
+    set Name $Parent.c1.e7
+    set Prompt $Parent.c1.p7
     ttk::label $Prompt -text "TPROC-H PostgreSQL User Password :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -show * -width 30 -textvariable pg_tpch_pass
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky ew
-    set Name $Parent.f1.e8
-    set Prompt $Parent.f1.p8
+    set Name $Parent.c1.e8
+    set Prompt $Parent.c1.p8
     ttk::label $Prompt -text "TPROC-H PostgreSQL Database :" -image [ create_image hdbicon icons ] -compound left
     ttk::entry $Name -width 30 -textvariable pg_tpch_dbase
     grid $Prompt -column 0 -row 8 -sticky e
     grid $Name -column 1 -row 8 -sticky ew
-    set Prompt $Parent.f1.p8b
+    set Prompt $Parent.c1.p8b
     ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
-    set Name $Parent.f1.e8b
+    set Name $Parent.c1.e8b
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 10 -sticky e
     grid $Name -column 1 -row 10 -sticky w
@@ -739,11 +739,11 @@ proc configpgtpch {option} {
         ttk::entry $Name -width 30 -textvariable pg_tpch_tspace
         grid $Prompt -column 0 -row 9 -sticky e
         grid $Name -column 1 -row 9 -sticky ew
-        set Prompt $Parent.f1.p9
+        set Prompt $Parent.c1.p9
         ttk::label $Prompt -text "Greenplum Database Compatible :"
-        set Name $Parent.f1.e9
+        set Name $Parent.c1.e9
         ttk::checkbutton $Name -text "" -variable pg_tpch_gpcompat -onvalue "true" -offvalue "false"
-        bind $Parent.f1.e9 <Button> {
+        bind $Parent.c1.e9 <Button> {
             if {$pg_tpch_gpcompat eq "true"} { 
                 .pgtpch.f1.e10 configure -state disabled 
                 set pg_tpch_gpcompress "false"
@@ -897,7 +897,7 @@ proc configpgtpch {option} {
         grid $Prompt -column 0 -row 24 -sticky e
         grid $Name -column 1 -row 24 -sticky w
         set Prompt $Parent.f1.p22
-        ttk::label $Prompt -text "Redshift Compatible :"
+        ttk::label $Prompt -text "Redshift Compatible Queries :"
         set Name $Parent.f1.e22
         ttk::checkbutton $Name -text "" -variable pg_rs_compat -onvalue "true" -offvalue "false"
         if {$pg_cloud_query == "false" } {
@@ -952,9 +952,9 @@ proc metpgopts {} {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.metric.f1.e1 get} pg_port {.metric.f1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.metric.f1.e3 get} pg_superuserpass {.metric.f1.e4 get} pg_defaultdbase {.metric.f1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.metric.c1.e3 get} pg_superuserpass {.metric.c1.e4 get} pg_defaultdbase {.metric.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.metric.f1.e1 get} pg_port {.metric.f1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.metric.f1.e3 get} pg_tpch_superuserpass {.metric.f1.e4 get} pg_tpch_defaultdbase {.metric.f1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.metric.c1.e3 get} pg_tpch_superuserpass {.metric.c1.e4 get} pg_tpch_defaultdbase {.metric.c1.e5 get}} ]
     }
     if { $bm eq "TPC-C" } {
         if { $pg_oracompat eq "true" } {
@@ -977,29 +977,28 @@ proc metpgopts {} {
     wm withdraw .metric
     wm title .metric {PostgreSQL Metrics Options}
     set Parent .metric
-    set Name $Parent.f1
-    ttk::frame $Name
+    set Prompt $Parent.h1
+    ttk::label $Prompt -compound left -text "PostgreSQL Metrics Options" -image [ create_image dashboard icons ]
+    pack $Prompt -anchor center -side top 
+    set Name $Parent.notebook
+    ttk::notebook $Name
+    $Name add [ ttk::frame $Parent.c1 ] -text "Connection" -sticky ne
+    $Name add [ ttk::frame $Parent.f1 ] -text "Settings" -sticky ne
     pack $Name -anchor nw -fill x -side top -padx 5
-    set Prompt $Parent.f1.h1
-    ttk::label $Prompt -image [ create_image dashboard icons ]
-    grid $Prompt -column 0 -row 0 -sticky e
-    set Prompt $Parent.f1.h2
-    ttk::label $Prompt -text "PostgreSQL and OS Agent"
-    grid $Prompt -column 1 -row 0 -sticky w
-    set Name $Parent.f1.e1
-    set Prompt $Parent.f1.p1
+    set Name $Parent.c1.e1
+    set Prompt $Parent.c1.p1
     ttk::label $Prompt -text "PostgreSQL Host :"
     ttk::entry $Name -width 30 -textvariable pg_host
     grid $Prompt -column 0 -row 1 -sticky e
     grid $Name -column 1 -row 1 -sticky ew
-    set Name $Parent.f1.e2
-    set Prompt $Parent.f1.p2
+    set Name $Parent.c1.e2
+    set Prompt $Parent.c1.p2
     ttk::label $Prompt -text "PostgreSQL Port :"   
     ttk::entry $Name  -width 30 -textvariable pg_port
     grid $Prompt -column 0 -row 2 -sticky e
     grid $Name -column 1 -row 2 -sticky ew
-    set Name $Parent.f1.e3
-    set Prompt $Parent.f1.p3
+    set Name $Parent.c1.e3
+    set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "PostgreSQL Superuser :"
     if { $bm eq "TPC-C" } {
         ttk::entry $Name  -width 30 -textvariable pg_superuser
@@ -1008,8 +1007,8 @@ proc metpgopts {} {
     }
     grid $Prompt -column 0 -row 3 -sticky e
     grid $Name -column 1 -row 3 -sticky ew
-    set Name $Parent.f1.e4
-    set Prompt $Parent.f1.p4
+    set Name $Parent.c1.e4
+    set Prompt $Parent.c1.p4
     ttk::label $Prompt -text "PostgreSQL Superuser Password :"   
     if { $bm eq "TPC-C" } {
         ttk::entry $Name -show * -width 30 -textvariable pg_superuserpass
@@ -1018,8 +1017,8 @@ proc metpgopts {} {
     }
     grid $Prompt -column 0 -row 4 -sticky e
     grid $Name -column 1 -row 4 -sticky ew
-    set Name $Parent.f1.e5
-    set Prompt $Parent.f1.p5
+    set Name $Parent.c1.e5
+    set Prompt $Parent.c1.p5
     ttk::label $Prompt -text "PostgreSQL Default Database :"
     if { $bm eq "TPC-C" } {
         ttk::entry $Name -width 30 -textvariable pg_defaultdbase
@@ -1028,9 +1027,9 @@ proc metpgopts {} {
     }
     grid $Prompt -column 0 -row 5 -sticky e
     grid $Name -column 1 -row 5 -sticky ew
-    set Prompt $Parent.f1.p6
+    set Prompt $Parent.c1.p6
     ttk::label $Prompt -text "Prefer PostgreSQL SSL Mode :"
-    set Name $Parent.f1.e6
+    set Name $Parent.c1.e6
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky w


### PR DESCRIPTION
As we've added options over time, some of the GUI options dialog boxes have become too large. 
This PR takes the typical tabbed properties dialog approach to break the dialog into 2 tabs of connections and settings to reduce the size. 

Example from Linux with MySQL

New Connection
![connection](https://github.com/TPC-Council/HammerDB/assets/38044085/ee4ea127-d4ba-4b45-b022-dcac13107838)
New Settings
![settings](https://github.com/TPC-Council/HammerDB/assets/38044085/2958d56e-2a81-40ad-8c33-2eeb1a3610d9)
Current Dialog
![previous](https://github.com/TPC-Council/HammerDB/assets/38044085/1fabcb60-73e8-4428-9fae-93e4cae19f05)

