### PR TITLE
Fix RETURNING d_next_o_id in NEWORD

### DIFF
--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -91,7 +91,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             FROM customer, warehouse
             WHERE warehouse.w_id = no_w_id AND customer.c_w_id = no_w_id AND
             customer.c_d_id = no_d_id AND customer.c_id = no_c_id;
-            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
+            UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id - 1, d_tax INTO no_d_next_o_id, no_d_tax;
             o_id := no_d_next_o_id;
             INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (o_id, no_d_id, no_w_id, no_c_id, tstamp, no_o_ol_cnt, no_o_all_local);
             INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (o_id, no_d_id, no_w_id);
@@ -535,7 +535,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 order_line_array[loop_counter] := loop_counter;
                 END LOOP;
 
-                UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
+                UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id - 1, d_tax INTO no_d_next_o_id, no_d_tax;
 
                 INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
                 INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);
@@ -1072,7 +1072,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 order_line_array[loop_counter] := loop_counter;
                 END LOOP;
 
-                UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id, d_tax INTO no_d_next_o_id, no_d_tax;
+                UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_id = no_d_id AND d_w_id = no_w_id RETURNING d_next_o_id - 1, d_tax INTO no_d_next_o_id, no_d_tax;
 
                 INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, current_timestamp, no_o_ol_cnt, no_o_all_local);
                 INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);


### PR DESCRIPTION
Fix for consistency check 2 fails in PostgreSQL because all values are out by 1 e.g.

```
Vuser 1:resArray(0,d_id) = 1
Vuser 1:resArray(0,d_w_id) = 6
Vuser 1:resArray(0,order_max) = 22816
Vuser 1:resArray(0,order_next) = 22815
Vuser 1:resArray(1,d_id) = 1
Vuser 1:resArray(1,d_w_id) = 7
Vuser 1:resArray(1,order_max) = 22892
Vuser 1:resArray(1,order_next) = 22891
Vuser 1:resArray(10,d_id) = 6
Vuser 1:resArray(10,d_w_id) = 6
Vuser 1:resArray(10,order_max) = 22637
Vuser 1:resArray(10,order_next) = 22636
...
```
