### PR TITLE
Add Database version to TPROC-C timed test

### DIFF
--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -1240,7 +1240,18 @@ namespace eval jobs {
                             return
                           } else {
                             if { [ dict keys $paramdict ] eq "jobid db" } {
-                              set joboutput [ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]
+                            #A Timed run will include a query for a version string, add the version if we find it
+		            set temp_output [ join [ hdbjobs eval {SELECT OUTPUT FROM JOBOUTPUT WHERE JOBID=$jobid AND VU=1} ]]
+		            if { [ string match "*DBVersion*" $temp_output ] } {
+        		    set matcheddbversion [regexp {(DBVersion:)(\d.+?)\s} $temp_output match header version ]
+			    if { $matcheddbversion } {
+                            set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]] $version"
+			    } else {
+                            set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]"
+			    }
+			    } else {
+                            set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]"
+				}
                             } else {
                               if { [ dict keys $paramdict ] eq "jobid bm" } {
                                 set joboutput [ join [ hdbjobs eval {SELECT bm FROM JOBMAIN WHERE JOBID=$jobid} ]]
@@ -1856,7 +1867,18 @@ namespace eval jobs {
                       return
                     } else {
                       if { [ dict keys $paramdict ] eq "jobid db" } {
-                        set joboutput [ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]
+                      #A Timed run will include a query for a version string, add the version if we find it
+		      set temp_output [ join [ hdbjobs eval {SELECT OUTPUT FROM JOBOUTPUT WHERE JOBID=$jobid AND VU=1} ]]
+		      if { [ string match "*DBVersion*" $temp_output ] } {
+        		set matcheddbversion [regexp {(DBVersion:)(\d.+?)\s} $temp_output match header version ]
+			if { $matcheddbversion } {
+                        set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]] $version"
+			} else {
+                        set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]"
+			}
+			} else {
+                        set joboutput "[ join [ hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid} ]]"
+			}
                         #huddle JSON is list return at end
                       } else {
                         if { [ dict keys $paramdict ] eq "jobid bm" } {

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -1596,12 +1596,26 @@ proc ConnectToDb2 { dbname user password } {
         puts "Connection established"
         return $db_handle
 }}
+
+proc CheckDBVersion { db_handle } {
+           if {[catch {set stmnt_handledbv [ db2_select_direct $db_handle "SELECT service_level from SYSIBMADM.ENV_INST_INFO" ]}]} {
+           set dbversion "DBVersion:NULL"
+           } else {
+            set dbversion [ db2_fetchrow $stmnt_handledbv ]
+            db2_finish $stmnt_handledbv
+	    regsub -all {DB2\ v} $dbversion "" dbversion
+            set dbversion "DBVersion:[join $dbversion]"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 {
         if { $mode eq "Local" || $mode eq "Primary" } {
             set db_handle [ ConnectToDb2 $dbname $user $password ]
             set ramptime 0
+	    puts [ CheckDBVersion $db_handle ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -1963,12 +1977,26 @@ proc ConnectToDb2 { dbname user password } {
         puts "Connection established"
         return $db_handle
 }}
+
+proc CheckDBVersion { db_handle } {
+           if {[catch {set stmnt_handledbv [ db2_select_direct $db_handle "SELECT service_level from SYSIBMADM.ENV_INST_INFO" ]}]} {
+           set dbversion "DBVersion:NULL"
+           } else {
+            set dbversion [ db2_fetchrow $stmnt_handledbv ]
+            db2_finish $stmnt_handledbv
+	    regsub -all {DB2\ v} $dbversion "" dbversion
+            set dbversion "DBVersion:[join $dbversion]"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 {
         if { $mode eq "Local" || $mode eq "Primary" } {
             set db_handle [ ConnectToDb2 $dbname $user $password ]
             set ramptime 0
+	    puts [ CheckDBVersion $db_handle ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -2225,6 +2225,15 @@ proc purge { maria_handler verbose } {
         }
 }
 
+proc CheckDBVersion { maria_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]}]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+		set dbversion "DBVersion:$dbversion"
+	   }	
+	   return "$dbversion"
+	}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2232,6 +2241,7 @@ switch $myposition {
 	set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password $db ]
         maria::autocommit $maria_handler 1
             set ramptime 0
+	    puts [ CheckDBVersion $maria_handler ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -2797,6 +2807,15 @@ proc purge { maria_handler verbose } {
         }
 }
 
+proc CheckDBVersion { maria_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]}]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+		set dbversion "DBVersion:$dbversion"
+	   }	
+	   return "$dbversion"
+	}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2804,6 +2823,7 @@ switch $myposition {
 	set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password $db ]
         maria::autocommit $maria_handler 1
             set ramptime 0
+	    puts [ CheckDBVersion $maria_handler ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -2693,6 +2693,15 @@ proc connect_string { server port odbc_driver authentication uid pwd tcp azure d
     return $connection
 }
 
+proc CheckDBVersion { odbc } {
+	   if {[catch {set rows [ odbc allrows "SELECT SERVERPROPERTY('productversion')" ]} message ]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+	        set dbversion "DBVersion:[ lindex {*}$rows 1 ]"
+	   }
+	   return "$dbversion"
+	}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2704,6 +2713,7 @@ switch $myposition {
                 if {!$azure} { odbc evaldirect "use $database" }
             }
             set ramptime 0
+	    puts [ CheckDBVersion odbc ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -3121,6 +3131,15 @@ proc connect_string { server port odbc_driver authentication uid pwd tcp azure d
     return $connection
 }
 
+proc CheckDBVersion { odbc } {
+	   if {[catch {set rows [ odbc allrows "SELECT SERVERPROPERTY('productversion')" ]} message ]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+	        set dbversion "DBVersion:[ lindex {*}$rows 1 ]"
+	   }
+	   return "$dbversion"
+	}
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -3132,6 +3151,7 @@ switch $myposition {
                 if {!$azure} { odbc evaldirect "use $database" }
             }
             set ramptime 0
+	    puts [ CheckDBVersion odbc ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -2054,6 +2054,15 @@ proc ConnectToMySQL { host port socket ssl_options user password db } {
     }
 }
 
+proc CheckDBVersion { mysql_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ mysql::sel $mysql_handler "select version()" -list ] ] - ] 0 ]}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2061,6 +2070,7 @@ switch $myposition {
 	        set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password $db ]
             mysql::autocommit $mysql_handler 1
             set ramptime 0
+	    puts [ CheckDBVersion $mysql_handler ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -2475,13 +2485,23 @@ proc ConnectToMySQLAsynch { host port socket ssl_options user password db client
     }
 }
 
+proc CheckDBVersion { mysql_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ mysql::sel $mysql_handler "select version()" -list ] ] - ] 0 ]}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
         if { $mode eq "Local" || $mode eq "Primary" } {
-	        set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password $db ]
+	    set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password $db ]
             mysql::autocommit $mysql_handler 1
             set ramptime 0
+	    puts [ CheckDBVersion $mysql_handler ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -2489,6 +2489,21 @@ proc SetNLS { lda } {
     oraclose $curn_nls
 }
 
+proc CheckDBVersion { curn } {
+set dbversion ""
+    if {[catch {orasql $curn {select version from v$instance}}]} {
+	    set dbversion "DBVersion:NULL"
+    } else {
+        orafetch  $curn -datavariable output
+        while { [ oramsg  $curn ] == 0 } {
+            lappend dbversion $output
+            orafetch $curn -datavariable output
+        }
+        set dbversion "DBVersion:$dbversion"
+    	}
+        return "$dbversion"
+    }
+
 if { [ chk_thread ] eq "FALSE" } {
     error "AWR Snapshot Script must be run in Thread Enabled Interpreter"
 }
@@ -2514,6 +2529,7 @@ switch $myposition {
                 oraparse $curn1 $sql1
             }
             set ramptime 0
+	    puts [ CheckDBVersion $curn1 ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -2899,6 +2915,21 @@ proc SetNLS { lda } {
     oraclose $curn_nls
 }
 
+proc CheckDBVersion { curn } {
+set dbversion ""
+    if {[catch {orasql $curn {select version from v$instance}}]} {
+	    set dbversion "DBVersion:NULL"
+    } else {
+        orafetch  $curn -datavariable output
+        while { [ oramsg  $curn ] == 0 } {
+            lappend dbversion $output
+            orafetch $curn -datavariable output
+        }
+        set dbversion "DBVersion:$dbversion"
+    	}
+        return "$dbversion"
+    }
+
 if { [ chk_thread ] eq "FALSE" } {
     error "AWR Snapshot Script must be run in Thread Enabled Interpreter"
 }
@@ -2924,6 +2955,7 @@ switch $myposition {
                 oraparse $curn1 $sql1
             }
             set ramptime 0
+	    puts [ CheckDBVersion $curn1 ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2852,6 +2852,18 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     }
     return $lda
 }
+
+proc CheckDBVersion { lda1 } {
+           if {[catch {pg_select $lda1 "select current_setting('server_version')" version_arr {
+                set dbversion $version_arr(current_setting)
+            }}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -2867,6 +2879,7 @@ switch $myposition {
                 error "error, the database connection to $host could not be established"
             } 
             set ramptime 0
+	    puts [ CheckDBVersion $lda1 ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {
@@ -3279,6 +3292,18 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     }
     return $lda
 }
+
+proc CheckDBVersion { lda1 } {
+           if {[catch {pg_select $lda1 "select current_setting('server_version')" version_arr {
+                set dbversion $version_arr(current_setting)
+            }}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 set rema [ lassign [ findvuposition ] myposition totalvirtualusers ]
 switch $myposition {
     1 { 
@@ -3294,6 +3319,7 @@ switch $myposition {
                 error "error, the database connection to $host could not be established"
             } 
             set ramptime 0
+	    puts [ CheckDBVersion $lda1 ]
             puts "Beginning rampup time of $rampup minutes"
             set rampup [ expr $rampup*60000 ]
             while {$ramptime != $rampup} {


### PR DESCRIPTION
Pull request adds a database version number query to the TPROC-C timed test and prints the string such as `DBVersion:16.0.1000.6` at the start of the test. If the version cannot be queried or the version is not an expected version of digits and dots then the test will not error but instead record the version as `DBVersion:NULL`

This can then be queried at a later point with the jobs db command. 

```
hammerdb>job 6601BCF63E8403E263532363 db
[
 "MSSQLServer",
 "16.0.1000.6"
]
```

The enhancement means we will now have a record of the database version stored along with the test data. 