### PR TITLE
Add CPU metrics to CLI, Jobs and automate start

### DIFF
--- a/agent/agent
+++ b/agent/agent
@@ -32,6 +32,23 @@ exit
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 #load files
+#Accept argument of port for agent to run on. No argument generates random port number
+ if {$argc == 0} {
+	set port {}
+	set restart true
+ 	} else {
+    if {$argc != 1} {
+	puts {Usage: agent port}
+	#exit
+	} else {
+	set restart false
+        set port [lindex $argv 0]
+	if { ![string is entier $port] } {
+	puts {Usage: agent port}
+	#exit
+	     } else { ; }
+          } 
+	}
 set UserDefaultDir [ file dirname [ info script ] ]
 ::tcl::tm::path add "../$UserDefaultDir/modules"
 package require comm
@@ -116,7 +133,7 @@ global cpu_model
     }
 }
 
-proc ConfigureNetworkAgent { } {
+proc ConfigureNetworkAgent { port restart } {
 global agentlist S connectestablished
 set chanlist [ lindex [ ::comm channels ] end ]
 if { $chanlist eq "::Slave" } {
@@ -125,7 +142,7 @@ if { [catch { $chanlist destroy } b] } {
 puts "Error $b"
 	}
 }
-if { [catch {::comm new Agent -listen 1 -local 0 -silent "TRUE" -port {}} b] } {
+if { [catch {::comm new Agent -listen 1 -local 0 -silent "TRUE" -port $port} b] } {
 puts "Creation Failed : $b" } else {
 puts "HammerDB Metric Agent active @ id [ Agent self ] hostname [ info hostname ] (Ctrl-C to Exit)"
 Agent hook incoming {
@@ -136,12 +153,16 @@ set connectestablished 1
 	}
 }
 Agent hook lost {
-global agentlist S connectestablished
+global agentlist S connectestablished restart
 set todel [ lsearch $agentlist $id ]
 if { $todel != -1 } {
 puts "Connection to display $id lost: $reason"
 unset -nocomplain connectestablished
+if {$restart} {
 puts "Reinitializing HammerDB Metric Agent"
+	} else {
+puts "Closing HammerDB Metric Agent"
+}
 set agentlist [ lreplace $agentlist $todel $todel ]
 set ::DONE 2
 	}
@@ -149,6 +170,12 @@ set ::DONE 2
 Agent hook eval {
 global agentlist S
 if {[regexp {\"([0-9]+)\W([[:alnum:],[:punct:]]+)\"} $buffer all id host]} {
+if { [ string match "*STOP*" $buffer ] } {
+#Received Message to Stop Metrics before a Display connection
+puts "Closing HammerDB Metric Agent"
+::Agent destroy
+exit
+}	
 lappend agentlist "$id $host"
 puts "New display accepted @ $id $host"
 #Start Gathering and Sending Metrics
@@ -211,7 +238,7 @@ puts "connection established"
 if $iswin {
     set fin [open "| mpstat.bat" r]
     } else {
-    set fin [open "|mpstat -P [join $::S(cpus,list) ,] 2" r]
+    set fin [open "|mpstat -P ALL 2" r]
 	}
     fconfigure $fin -blocking false
     fileevent $fin readable [list isReadable $fin] 
@@ -241,12 +268,16 @@ HowManyProcessorsLinux
   }
 
 puts "Initializing HammerDB Metric Agent $version"
-ConfigureNetworkAgent 
+ConfigureNetworkAgent $port $restart
 vwait ::DONE
 while 1 {	
 #Lost connection, reinitialize agent
 ::Agent destroy
 unset -nocomplain ::DONE
-ConfigureNetworkAgent 
+if {$restart} {
+ConfigureNetworkAgent $port $restart
 vwait ::DONE
+	} else {
+exit
+}
 	}

--- a/agent/agent.bat
+++ b/agent/agent.bat
@@ -1,3 +1,3 @@
 @echo off
 set path=..\.\bin;%PATH%
-START tclsh86t .\agent
+START tclsh86t .\agent %1

--- a/agent/mpstat.bat
+++ b/agent/mpstat.bat
@@ -47,7 +47,7 @@ set cpus_per_node [ expr $cpu_count / $numa_node_count ]
 puts "Mpstat for Windows $osinfo $osversion {$hostname}  [clock format [twapi::large_system_time_to_secs_since_1970 [twapi::get_system_time]] -format "%d/%m/%Y"] {$cpu_count CPU}\n"
 puts "[clock format [twapi::large_system_time_to_secs_since_1970 [twapi::get_system_time]] -format "%I:%M:%S %p"]\tCPU\t%usr\t%nice\t%sys\t%iowait\t%irq\t%soft\t%steal\t%guest\t%idle"
 #Define Query
-set qh [ twapi::pdh_system_performance_query user_utilization_per_cpu privileged_utilization_per_cpu interrupt_utilization_per_cpu idle_utilization_per_cpu]
+set qh [ twapi::pdh_system_performance_query user_utilization privileged_utilization interrupt_utilization idle_utilization user_utilization_per_cpu privileged_utilization_per_cpu interrupt_utilization_per_cpu idle_utilization_per_cpu]
 #Get Data
 while {1} {
 set cpu_number 0
@@ -55,6 +55,7 @@ catch { twapi::pdh_query_update $qh }
 catch { set perf_data [ twapi::pdh_query_get $qh ] }
 if { [ info exists perf_data ] } {
 if { [ dict size $perf_data ] > 0 } {
+puts "[clock format [clock seconds] -format "%I:%M:%S %p"]\tall\t[format "%.2f" [ dict get $perf_data user_utilization ]]\t0.00\t[format "%.2f" [dict get $perf_data privileged_utilization ]]\t0.00\t[format "%.2f" [ dict get $perf_data interrupt_utilization ]]\t0.00\t0.00\t0.00\t[format "%.2f" [ dict get $perf_data idle_utilization ]]"
 for {set i 0} {$i < $numa_node_count} {incr i} {
 for {set j 0} {$j < $cpus_per_node} {incr j} {
 puts "[clock format [clock seconds] -format "%I:%M:%S %p"]\t$cpu_number\t[format "%.2f" [ dict get [ dict get $perf_data user_utilization_per_cpu ] $i,$j ]]\t0.00\t[format "%.2f" [dict get [ dict get $perf_data privileged_utilization_per_cpu ] $i,$j ]]\t0.00\t[format "%.2f" [dict get [ dict get $perf_data interrupt_utilization_per_cpu ] $i,$j ]]\t0.00\t0.00\t0.00\t[format "%.2f" [ dict get [ dict get $perf_data idle_utilization_per_cpu ] $i,$j ]]"

--- a/config/generic.xml
+++ b/config/generic.xml
@@ -51,7 +51,7 @@
     <metrics>
     	<metric_options>
     	    <agent_hostname>localhost</agent_hostname>
-    	    <agent_id>0</agent_id>
+    	    <agent_id>10000</agent_id>
     	</metric_options>
     </metrics>
     <datageneration>

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -90,7 +90,7 @@ set cli_common_init {set UserDefaultDir [ file dirname [ info script ] ]
     }
   }
 
-  append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl genmodes.tcl gentccmn.tcl gentccli.tcl geninitcli.tcl gencli.tcl genhelp.tcl genstep.tcl }
+  append loadlist { genvu.tcl gentpcc.tcl gentpch.tcl gengen.tcl genxml.tcl genmodes.tcl genmetricscli.tcl gentccmn.tcl gentccli.tcl geninitcli.tcl gencli.tcl genhelp.tcl genstep.tcl }
   for { set loadcount 0 } { $loadcount < [llength $loadlist] } { incr loadcount } {
     set f [lindex $loadlist $loadcount]
     set loadtext $f

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -1782,7 +1782,7 @@ namespace eval jobs {
             #set irqseries [ lreplace $irqseries 0 0 ]
             set xaxisvals [ lreplace $xaxisvals 0 0 ]
           }
-          while { [ lindex $usrseries end ] eq 0 } {
+          while { [ lindex $usrseries end ] eq 0.0 } {
             set usrseries [ lreplace $usrseries end end ]
             set sysseries [ lreplace $sysseries end end ]
 	    #to include interrupt requests uncomment below

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -75,15 +75,23 @@ namespace eval jobs {
         catch {hdbjobs eval {DROP TABLE JOBMAIN}}
         catch {hdbjobs eval {DROP TABLE JOBTIMING}}
         catch {hdbjobs eval {DROP TABLE JOBTCOUNT}}
+        catch {hdbjobs eval {DROP TABLE JOBMETRIC}}
+        catch {hdbjobs eval {DROP TABLE JOBSYSTEM}}
         catch {hdbjobs eval {DROP TABLE JOBOUTPUT}}
         catch {hdbjobs eval {DROP TABLE JOBCHART}}
-        if [catch {hdbjobs eval {CREATE TABLE JOBMAIN(jobid TEXT, db TEXT, bm TEXT, jobdict TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')))}} message ] {
+        if [catch {hdbjobs eval {CREATE TABLE JOBMAIN(jobid TEXT primary key, db TEXT, bm TEXT, jobdict TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')))}} message ] {
           puts "Error creating JOBMAIN table in SQLite in-memory database : $message"
           return
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTIMING(jobid TEXT, vu INTEGER, procname TEXT, calls INTEGER, min_ms REAL, avg_ms REAL, max_ms REAL, total_ms REAL, p99_ms REAL, p95_ms REAL, p50_ms REAL, sd REAL, ratio_pct REAL, summary INTEGER, elapsed_ms REAL, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBTIMING table in SQLite in-memory database : $message"
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTCOUNT(jobid TEXT, counter INTEGER, metric TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBTCOUNT table in SQLite in-memory database : $message"
+          return
+        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+          puts "Error creating JOBMETRIC table in SQLite in-memory database : $message"
+          return
+        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+          puts "Error creating JOBSYSTEM table in SQLite in-memory database : $message"
           return
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBOUTPUT(jobid TEXT, vu INTEGER, output TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBOUTPUT table in SQLite in-memory database : $message"
@@ -96,6 +104,8 @@ namespace eval jobs {
           catch {hdbjobs eval {CREATE INDEX JOBMAIN_IDX ON JOBMAIN(jobid)}}
           catch {hdbjobs eval {CREATE INDEX JOBTIMING_IDX ON JOBTIMING(jobid)}}
           catch {hdbjobs eval {CREATE INDEX JOBTCOUNT_IDX ON JOBTCOUNT(jobid)}}
+          catch {hdbjobs eval {CREATE INDEX JOBMETRIC_IDX ON JOBMETRIC(jobid)}}
+          catch {hdbjobs eval {CREATE INDEX JOBSYSTEM_IDX ON JOBSYSTEM(jobid)}}
           catch {hdbjobs eval {CREATE INDEX JOBOUTPUT_IDX ON JOBOUTPUT(jobid)}}
           catch {hdbjobs eval {CREATE INDEX JOBCHART_IDX ON JOBCHART(jobid)}}
           puts "Initialized new Jobs in-memory database"
@@ -106,7 +116,7 @@ namespace eval jobs {
           return
         } else {
           if { $tblname eq "" } {
-            if [catch {hdbjobs eval {CREATE TABLE JOBMAIN(jobid TEXT, db TEXT, bm TEXT, jobdict TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')))}} message ] {
+            if [catch {hdbjobs eval {CREATE TABLE JOBMAIN(jobid TEXT primary key, db TEXT, bm TEXT, jobdict TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')))}} message ] {
               puts "Error creating JOBMAIN table in SQLite on-disk database : $message"
               return
             } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTIMING(jobid TEXT, vu INTEGER, procname TEXT, calls INTEGER, min_ms REAL, avg_ms REAL, max_ms REAL, total_ms REAL, p99_ms REAL, p95_ms REAL, p50_ms REAL, sd REAL, ratio_pct REAL, summary INTEGER, elapsed_ms REAL, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
@@ -114,6 +124,12 @@ namespace eval jobs {
               return
             } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTCOUNT(jobid TEXT, counter INTEGER, metric TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
               puts "Error creating JOBTCOUNT table in SQLite on-disk database : $message"
+              return
+            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+             puts "Error creating JOBMETRIC table in SQLite on-disk database : $message"
+             return
+            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+              puts "Error creating JOBSYSTEM table in SQLite on-disk database : $message"
               return
             } elseif [catch {hdbjobs eval {CREATE TABLE JOBOUTPUT(jobid TEXT, vu INTEGER, output TEXT)}} message ] {
               puts "Error creating JOBOUTPUT table in SQLite on-disk database : $message"
@@ -125,6 +141,8 @@ namespace eval jobs {
               catch {hdbjobs eval {CREATE INDEX JOBMAIN_IDX ON JOBMAIN(jobid)}}
               catch {hdbjobs eval {CREATE INDEX JOBTIMING_IDX ON JOBTIMING(jobid)}}
               catch {hdbjobs eval {CREATE INDEX JOBTCOUNT_IDX ON JOBTCOUNT(jobid)}}
+              catch {hdbjobs eval {CREATE INDEX JOBMETRIC_IDX ON JOBMETRIC(jobid)}}
+              catch {hdbjobs eval {CREATE INDEX JOBSYSTEM_IDX ON JOBSYSTEM(jobid)}}
               catch {hdbjobs eval {CREATE INDEX JOBOUTPUT_IDX ON JOBOUTPUT(jobid)}}
               catch {hdbjobs eval {CREATE INDEX JOBCHART_IDX ON JOBCHART(jobid)}}
               puts "Initialized new Jobs on-disk database $sqlite_db"
@@ -259,8 +277,8 @@ namespace eval jobs {
           puts $res
         } elseif { [ string equal $cmd "getchart" ] } {
           set charttype $param3
-          if { ![string equal $charttype "result" ] && ![string equal $charttype "timing" ] && ![string equal $charttype "tcount" ]  } {
-            puts "Error: Jobs Three Parameter Usage: jobs jobid getchart \[ result | timing | tcount \]"
+          if { ![string equal $charttype "result" ] && ![string equal $charttype "timing" ] && ![string equal $charttype "tcount" ]  && ![string equal $charttype "metrics" ]  } {
+            puts "Error: Jobs Three Parameter Usage: jobs jobid getchart \[ result | timing | tcount | metrics\]"
           } else {
             set ctype "chart=$charttype"
             set res [getjob "jobid=$jobid&$cmd&$ctype" ]
@@ -1041,7 +1059,7 @@ namespace eval jobs {
       }
       #2 or more parameters
     } else {
-      if { [ dict keys $paramdict ] eq "jobid index" || [ dict keys $paramdict ] eq "jobid vu" || [ dict keys $paramdict ] eq "jobid status" || [ dict keys $paramdict ] eq "jobid result" || [ dict keys $paramdict ] eq "jobid resultdata" || [ dict keys $paramdict ] eq "jobid DELETE" || [ dict keys $paramdict ] eq "jobid delete" || [ dict keys $paramdict ] eq "jobid timestamp" || [ dict keys $paramdict ] eq "jobid dict" || [ dict keys $paramdict ] eq "jobid timing" || [ dict keys $paramdict ] eq "jobid timingdata" || [ dict keys $paramdict ] eq "jobid db" ||  [ dict keys $paramdict ] eq "jobid bm" || [ dict keys $paramdict ] eq "jobid tcount" || [ dict keys $paramdict ] eq "jobid tcountdata" } {
+      if { [ dict keys $paramdict ] eq "jobid index" || [ dict keys $paramdict ] eq "jobid vu" || [ dict keys $paramdict ] eq "jobid status" || [ dict keys $paramdict ] eq "jobid result" || [ dict keys $paramdict ] eq "jobid resultdata" || [ dict keys $paramdict ] eq "jobid DELETE" || [ dict keys $paramdict ] eq "jobid delete" || [ dict keys $paramdict ] eq "jobid timestamp" || [ dict keys $paramdict ] eq "jobid dict" || [ dict keys $paramdict ] eq "jobid timing" || [ dict keys $paramdict ] eq "jobid timingdata" || [ dict keys $paramdict ] eq "jobid db" ||  [ dict keys $paramdict ] eq "jobid bm" || [ dict keys $paramdict ] eq "jobid tcount" || [ dict keys $paramdict ] eq "jobid tcountdata" || [ dict keys $paramdict ] eq "jobid metrics"  || [ dict keys $paramdict ] eq "jobid metricsdata" ||  [ dict keys $paramdict ] eq "jobid system" } {
         set jobid [ dict get $paramdict jobid ]
         if { [ dict keys $paramdict ] eq "jobid vu" } {
           set vuid [ dict get $paramdict vu ]
@@ -1062,7 +1080,7 @@ namespace eval jobs {
           set url "[wapp-param BASE_URL]/jobs?jobid=$jobid"
           set text "output"
           wapp-subst {<li><a href='%html($url)'>%html($text)</a>\n}
-          foreach option "bm db dict result status tcount timestamp timing delete" {
+          foreach option "bm db system dict result status tcount metrics timestamp timing delete" {
             set url "[wapp-param BASE_URL]/jobs?jobid=$jobid&$option"
             switch $option {
               bm {
@@ -1070,6 +1088,9 @@ namespace eval jobs {
               }
               db {
                 wapp-subst {<li><a href='%html($url)'>%html(database)</a>\n}
+              }
+              system {
+                wapp-subst {<li><a href='%html($url)'>%html(system)</a>\n}
               }
               dict {
                 wapp-subst {<li><a href='%html($url)'>%html(dict configuration)</a>\n}
@@ -1088,6 +1109,14 @@ namespace eval jobs {
                   ;#No result exclude link
                 } else {
                   wapp-subst {<li><a href='%html($url)'>%html(transaction count)</a>\n}
+                }
+              }
+              metrics {
+                set jobmetrics [ getjobmetrics $jobid ]
+                if { [ llength $jobmetrics ] eq 2 && [ string match [ lindex $jobmetrics 1 ] "Jobid has no metrics data" ] } {
+                  ;#No result exclude link
+                } else {
+                  wapp-subst {<li><a href='%html($url)'>%html(metrics)</a>\n}
                 }
               }
               timing {
@@ -1151,6 +1180,8 @@ namespace eval jobs {
               set joboutput [ hdbjobs eval {DELETE FROM JOBMAIN WHERE JOBID=$jobid} ]
               set joboutput [ hdbjobs eval {DELETE FROM JOBTIMING WHERE JOBID=$jobid} ]
               set joboutput [ hdbjobs eval {DELETE FROM JOBTCOUNT WHERE JOBID=$jobid} ]
+              set joboutput [ hdbjobs eval {DELETE FROM JOBMETRIC WHERE JOBID=$jobid} ]
+              set joboutput [ hdbjobs eval {DELETE FROM JOBSYSTEM WHERE JOBID=$jobid} ]
               set joboutput [ hdbjobs eval {DELETE FROM JOBOUTPUT WHERE JOBID=$jobid} ]
               set joboutput [ hdbjobs eval {DELETE FROM JOBCHART WHERE JOBID=$jobid} ]
               dict set jsondict success message "Deleted Jobid $jobid"
@@ -1216,6 +1247,21 @@ namespace eval jobs {
                       wapp-subst {<a href='%html($url)'>%html($text)</a><br><br>\n}
                       common-footer
                       return
+                  } else {
+                    if { [ dict keys $paramdict ] eq "jobid metrics" } {
+                      wapp-content-security-policy off
+                      wapp-subst {<link href="%url([wapp-param BASE_URL]/style.css)" rel="stylesheet">}
+                      foreach l [ split [ getchart $jobid $vuid "metrics" ] \n] {
+                        if { [ string match [ string trim $l ] <body> ] } {
+                          set l "\t<body>\n\t<p><img src='[wapp-param BASE_URL]/logo.png' width='347' height='60'></p>"
+                        }
+                        wapp-subst {%unsafe($l)\n}
+                      }
+                      set url "[wapp-param BASE_URL]/jobs?jobid=$jobid&metricsdata"
+                      set text "Metrics Data"
+                      wapp-subst {<a href='%html($url)'>%html($text)</a><br><br>\n}
+                      common-footer
+                      return
                     } else {
                       if { [ dict keys $paramdict ] eq "jobid resultdata" } {
                         set joboutput [ getjobresult $jobid $vuid ]
@@ -1238,6 +1284,11 @@ namespace eval jobs {
                             set jsondict [ getjobtcount $jobid ]
                             wapp-2-json 2 $jsondict
                             return
+                        } else {
+                          if { [ dict keys $paramdict ] eq "jobid metricsdata" } {
+                            set jsondict [ getjobmetrics $jobid ]
+                            wapp-2-json 2 $jsondict
+                            return
                           } else {
                             if { [ dict keys $paramdict ] eq "jobid db" } {
                             #A Timed run will include a query for a version string, add the version if we find it
@@ -1255,17 +1306,23 @@ namespace eval jobs {
                             } else {
                               if { [ dict keys $paramdict ] eq "jobid bm" } {
                                 set joboutput [ join [ hdbjobs eval {SELECT bm FROM JOBMAIN WHERE JOBID=$jobid} ]]
+                            } else {
+                              if { [ dict keys $paramdict ] eq "jobid system" } {
+				set joboutput [ list "No system data available" ]
+                                hdbjobs eval {SELECT hostname,cpucount,cpumodel FROM JOBSYSTEM WHERE JOBID=$jobid} {
+				set joboutput [ list $hostname $cpucount $cpumodel ]
+				}
                               } else {
                                 set joboutput [ list $jobid "Cannot find Jobid output" ]
                               }
-            }}}}}}}}}
+            }}}}}}}}}}}}
             set huddleobj [ huddle compile {list} $joboutput ]
             wapp-mimetype application/json
             wapp-trim { %unsafe([huddle jsondump $huddleobj]) }
           }
         }
       } else {
-        dict set jsondict error message "Jobs Two Parameter Usage: jobs?jobid=TEXT&status or jobs?jobid=TEXT&db or jobs?jobid=TEXT&bm or jobs?jobid=TEXT&timestamp or jobs?jobid=TEXT&dict or jobs?jobid=TEXT&vu=INTEGER or jobs?jobid=TEXT&result or jobs?jobid=TEXT&timing or jobs?jobid=TEXT&delete" 
+        dict set jsondict error message "Jobs Two Parameter Usage: jobs?jobid=TEXT&status or jobs?jobid=TEXT&db or jobs?jobid=TEXT&bm or jobs?jobid=TEXT&system or jobs?jobid=TEXT&timestamp or jobs?jobid=TEXT&dict or jobs?jobid=TEXT&vu=INTEGER or jobs?jobid=TEXT&result or jobs?jobid=TEXT&timing or jobs?jobid=TEXT&delete" 
         wapp-2-json 2 $jsondict
         return
       }
@@ -1341,6 +1398,31 @@ namespace eval jobs {
       set jobtcount [ list $jobid "Jobid has no transaction counter data" ]
     }
     return $jobtcount
+  }
+
+  proc getjobmetrics { jobid } {
+    set jobmetric [ dict create ]
+    hdbjobs eval {select JOBMETRIC.timestamp, usr, sys, irq, idle from JOBMETRIC WHERE JOBMETRIC.JOBID=$jobid order by JOBMETRIC.timestamp asc} {
+    set metrics "usr% $usr sys% $sys irq% $irq idle% $idle" 
+	if { [dict keys $jobmetric $timestamp] eq {} } {
+    	dict append jobmetric $timestamp $metrics
+		}
+	}
+    if { $jobmetric eq "" } {
+      set jobmetric [ list $jobid "Jobid has no metric data" ]
+    }
+    return $jobmetric
+  }
+
+  proc getjobsystem { jobid } {
+    set jobsystem [ dict create ]
+	hdbjobs eval {select hostname,cpumodel,cpucount FROM JOBSYSTEM WHERE JOBID=$jobid} {
+        dict append jobsystem $cpumodel $cpucount
+	}
+    if { $jobsystem eq "" } {
+      set jobsystem [ list $jobid "Jobid has no system data" ]
+    }
+    return $jobsystem
   }
 
   proc gettopjobs {} {
@@ -1474,7 +1556,7 @@ namespace eval jobs {
             }
             set bar [ticklecharts::chart new]
             set ::ticklecharts::htmlstdout "True" ; 
-            $bar SetOptions -title [ subst {text "$dbdescription TPROC-H Result $jobid @ $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
+            $bar SetOptions -title [ subst {text "$dbdescription TPROC-H Result $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
             $bar Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
             $bar Yaxis -name "Seconds" -position "left" -axisLabel {formatter "<0123>value<0125>"}
             $bar AddBarSeries -name GEOMEAN -data [list "$geomeantime "] -itemStyle [ subst {color $color1 opacity 0.90} ]
@@ -1510,7 +1592,7 @@ namespace eval jobs {
             if { $dbdescription eq "MSSQLServer" } { set dbdescription "SQL Server" }
             set bar [ticklecharts::chart new]
             set ::ticklecharts::htmlstdout "True" ; 
-            $bar SetOptions -title [ subst {text "$dbdescription TPROC-C Result $jobid @ $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
+            $bar SetOptions -title [ subst {text "$dbdescription TPROC-C Result $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
             $bar Xaxis -data [list [ subst {"$dbdescription $vus"}]] -axisLabel [list show "True"]
             $bar Yaxis -name "Transactions" -position "left" -axisLabel {formatter "<0123>value<0125>"}
             $bar AddBarSeries -name NOPM -data [list "$nopm "] -itemStyle [ subst {color $color1 opacity 0.90} ]
@@ -1571,7 +1653,7 @@ namespace eval jobs {
             #Create chart showing timing for each Query 
             set bar [ticklecharts::chart new]
             set ::ticklecharts::htmlstdout "True" ; 
-            $bar SetOptions -title [ subst {text "$dbdescription TPROC-H Power Query Times $jobid @ $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
+            $bar SetOptions -title [ subst {text "$dbdescription TPROC-H Power Query Times $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "45%"}
             $bar Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
             $bar Yaxis -name "Seconds" -position "left" -axisLabel {formatter "<0123>value<0125>"}
             $bar AddBarSeries -name "VU 1 Query Set" -data [list $barseries ] -itemStyle [ subst {color $color1 opacity 0.90} ]
@@ -1594,7 +1676,7 @@ namespace eval jobs {
             #Create chart showing timing for each stored proc
             set bar [ticklecharts::chart new]
             set ::ticklecharts::htmlstdout "True" ; 
-            $bar SetOptions -title [ subst {text "$dbdescription TPROC-C Response Times $jobid @ $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "30%"}
+            $bar SetOptions -title [ subst {text "$dbdescription TPROC-C Response Times $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "30%"}
             $bar Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
             $bar Yaxis -name "Milliseconds" -position "left" -axisLabel {formatter "<0123>value<0125>"}
             $bar AddBarSeries -name P50_MS -data [list "$P50_MS "]    
@@ -1646,7 +1728,7 @@ namespace eval jobs {
           }
           set line [ticklecharts::chart new]
           set ::ticklecharts::htmlstdout "True" ; 
-          $line SetOptions -title [ subst {text "$dbdescription $workload Count $jobid @ $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "40%"}
+          $line SetOptions -title [ subst {text "$dbdescription $workload Count $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "40%"}
           $line Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
           $line Yaxis -name "$axisname" -position "left" -axisLabel {formatter "<0123>value<0125>"}
           $line AddLineSeries -name [ join $header ] -data [ list $lineseries ] -itemStyle [ subst {color $color1 opacity 0.90} ]
@@ -1658,11 +1740,78 @@ namespace eval jobs {
           if { [ string match "*ALL VIRTUAL USERS COMPLETE*" $jobstatus ] } {
             hdbjobs eval {INSERT INTO JOBCHART(jobid,chart,html) VALUES($jobid,'tcount',$html)}
           }
+         return $html
+        }
+      }
+      "metrics" {
+        set date [ join [ hdbjobs eval {SELECT timestamp FROM JOBMAIN WHERE JOBID=$jobid} ]]
+        set chartdata [ getjobmetrics $jobid ]
+        if { [ llength $chartdata ] eq 2 && [ string match [ lindex $chartdata 1 ] "Jobid has no metrics data" ] } {
+          putscli "Chart for jobid $jobid not available, Jobid has no metrics data"
+          return
+        } else {
+          set query [ hdbjobs eval {SELECT COUNT(*) FROM JOBCHART WHERE JOBID=$jobid AND CHART="metrics"} ]
+          if { $query eq 0 } {
+            #No result chart exists create one and insert into JOBCHART table
+          } else {
+            #Return existing results chart from JOBCHART table
+            set html [ join [ hdbjobs eval {SELECT html FROM JOBCHART WHERE JOBID=$jobid AND CHART="metrics"} ]]
+            return $html
+          }
+          hdbjobs eval {SELECT cpucount,cpumodel from JOBSYSTEM WHERE JOBID=$jobid} {
+	  set dbdescription "$cpucount $cpumodel"
+		}
+	if {[ dict size $chartdata ] <= 1} {
+          putscli "Chart for jobid $jobid not available, Jobid has insufficient metrics data"
+	  return
+	}
+	  set axisname "CPU %"
+          set xaxisvals [ dict keys $chartdata ]
+          dict for {tstamp cpuvalues} $chartdata {
+          dict with cpuvalues {
+            lappend usrseries ${usr%}
+            lappend sysseries ${sys%}
+	    #to include interrupt requests uncomment below
+            #lappend irqseries ${irq%}
+          }}
+          #Delete the first and trailing values if usr utilisation is 0, so we start from the first measurement and only chart when running
+          if { [ lindex $usrseries 0 ] eq 0.0 } {
+            set usrseries [ lreplace $usrseries 0 0 ]
+            set sysseries [ lreplace $sysseries 0 0 ]
+	    #to include interrupt requests uncomment below
+            #set irqseries [ lreplace $irqseries 0 0 ]
+            set xaxisvals [ lreplace $xaxisvals 0 0 ]
+          }
+          while { [ lindex $usrseries end ] eq 0 } {
+            set usrseries [ lreplace $usrseries end end ]
+            set sysseries [ lreplace $sysseries end end ]
+	    #to include interrupt requests uncomment below
+            #set irqseries [ lreplace $irqseries end end ]
+            set xaxisvals [ lreplace $xaxisvals end end ]
+          }
+	  if { ![ info exists dbdescription ] } { set dbdescription "Generic CPU" }
+          set line [ticklecharts::chart new]
+          set ::ticklecharts::htmlstdout "True" ; 
+          $line SetOptions -title [ subst {text "$dbdescription $jobid $date"} ] -tooltip {show "True"} -legend {bottom "5%" left "40%"}
+          $line Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
+          $line Yaxis -name "$axisname" -position "left" -axisLabel {formatter "<0123>value<0125>"}
+          $line AddLineSeries -name "usr%" -data [ list $usrseries ] -itemStyle [ subst {color green opacity 0.90} ]
+          $line AddLineSeries -name "sys%" -data [ list $sysseries ] -itemStyle [ subst {color red opacity 0.90} ]
+	  #to include interrupt requests uncomment below
+          #$line AddLineSeries -name "irq%" -data [ list $irqseries ] -itemStyle [ subst {color blue opacity 0.90} ]
+          set html [ $line RenderX -title "$jobid " ]
+          #If we query the metrics chart while the job is running it will not be generated again
+          #meaning the output will be truncated
+          #only save the chart once the job is complete
+          set jobstatus [ hdbjobs eval {SELECT OUTPUT FROM JOBOUTPUT WHERE JOBID=$jobid AND VU=0} ]
+          if { [ string match "*ALL VIRTUAL USERS COMPLETE*" $jobstatus ] } {
+            hdbjobs eval {INSERT INTO JOBCHART(jobid,chart,html) VALUES($jobid,'metrics',$html)}
+          }
           return $html
         }
       }
       default {
-        set html "Error: chart type should be result, timing or tcount"
+        set html "Error: chart type should be metrics, result, tcount or timing"
         return
       }
     }
@@ -1774,7 +1923,7 @@ namespace eval jobs {
         return
       }
     } else {
-      if { [ dict keys $paramdict ] eq "jobid vu" || [ dict keys $paramdict ] eq "jobid status" || [ dict keys $paramdict ] eq "jobid result" || [ dict keys $paramdict ] eq "jobid delete" || [ dict keys $paramdict ] eq "jobid timestamp" || [ dict keys $paramdict ] eq "jobid dict" || [ dict keys $paramdict ] eq "jobid timing" || [ dict keys $paramdict ] eq "jobid db" ||  [ dict keys $paramdict ] eq "jobid bm" || [ dict keys $paramdict ] eq "jobid tcount" } {
+      if { [ dict keys $paramdict ] eq "jobid vu" || [ dict keys $paramdict ] eq "jobid status" || [ dict keys $paramdict ] eq "jobid result" || [ dict keys $paramdict ] eq "jobid delete" || [ dict keys $paramdict ] eq "jobid timestamp" || [ dict keys $paramdict ] eq "jobid dict" || [ dict keys $paramdict ] eq "jobid timing" || [ dict keys $paramdict ] eq "jobid db" ||  [ dict keys $paramdict ] eq "jobid bm" || [ dict keys $paramdict ] eq "jobid tcount"  || [ dict keys $paramdict ] eq "jobid metrics"  ||  [ dict keys $paramdict ] eq "jobid system" } {
         set jobid [ dict get $paramdict jobid ]
         if { [ dict keys $paramdict ] eq "jobid vu" } {
           set vuid [ dict get $paramdict vu ]
@@ -1815,6 +1964,8 @@ namespace eval jobs {
             set joboutput [ hdbjobs eval {DELETE FROM JOBMAIN WHERE JOBID=$jobid} ]
             set joboutput [ hdbjobs eval {DELETE FROM JOBTIMING WHERE JOBID=$jobid} ]
             set joboutput [ hdbjobs eval {DELETE FROM JOBTCOUNT WHERE JOBID=$jobid} ]
+            set joboutput [ hdbjobs eval {DELETE FROM JOBMETRIC WHERE JOBID=$jobid} ]
+            set joboutput [ hdbjobs eval {DELETE FROM JOBSYSTEM WHERE JOBID=$jobid} ]
             set joboutput [ hdbjobs eval {DELETE FROM JOBOUTPUT WHERE JOBID=$jobid} ]
             set joboutput [ hdbjobs eval {DELETE FROM JOBCHART WHERE JOBID=$jobid} ]
             puts "Deleted Jobid $jobid"
@@ -1865,6 +2016,28 @@ namespace eval jobs {
                         puts $jsondict
                       }
                       return
+                  } else {
+                    if { [ dict keys $paramdict ] eq "jobid metrics" } {
+                      set jsondict [ getjobmetrics $jobid ]
+                      #huddle JSON is dict*dict return here
+                      set huddleobj [ huddle compile {dict * dict} $jsondict ]
+                      if { $outputformat eq "JSON" } {
+                        puts [ huddle jsondump $huddleobj ]
+                      } else {
+                        puts $jsondict
+                      }
+                      return
+                  } else {
+                    if { [ dict keys $paramdict ] eq "jobid system" } {
+                      set jsondict [ getjobsystem $jobid ]
+                      #huddle JSON is dict*dict return here
+                      set huddleobj [ huddle compile {list} $jsondict ]
+                      if { $outputformat eq "JSON" } {
+                        puts [ huddle jsondump $huddleobj ]
+                      } else {
+                        puts $jsondict
+                      }
+                      return
                     } else {
                       if { [ dict keys $paramdict ] eq "jobid db" } {
                       #A Timed run will include a query for a version string, add the version if we find it
@@ -1887,6 +2060,8 @@ namespace eval jobs {
                         } else {
                           set joboutput [ list $jobid "Cannot find Jobid output" ]
                           #huddle JSON is list return at end
+                            }
+                          }
                         }
                       }
                     }
@@ -1904,7 +2079,7 @@ namespace eval jobs {
           }
         }
       } else {
-        puts "Jobs Two Parameter Usage: jobs jobid status or jobs jobid db or jobs jobid bm or jobs jobid timestamp or jobs jobid dict or jobs jobid vuid or jobs jobid result or jobs jobid timing or jobs jobid delete"
+        puts "Jobs Two Parameter Usage: jobs jobid status or jobs jobid db or jobs jobid bm or jobid system or jobs jobid timestamp or jobs jobid dict or jobs jobid vuid or jobs jobid result or jobs jobid timing or jobs jobid delete or jobs jobid metrics or jobs jobid system"
         return
       }
     }

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -1811,6 +1811,7 @@ proc tcset {args} {
                     putscli "Failed to set Transaction Counter refresh rate"
                 } else {
                     putscli "Transaction Counter refresh rate set to $refreshrate"
+		    SQLiteUpdateKeyValue "generic"  transaction_counter tc_refresh_rate $refreshrate
                 }
             }
             logtotemp {
@@ -1829,6 +1830,7 @@ proc tcset {args} {
                     putscli "Failed to set Transaction Counter log to temp"
                 } else {
                     putscli "Transaction Counter log to temp set to $logtotemp"
+		    SQLiteUpdateKeyValue "generic"  transaction_counter tc_log_to_temp $logtotemp
                 }
             }
             unique {
@@ -1847,6 +1849,7 @@ proc tcset {args} {
                     putscli "Failed to set Transaction Counter unique log name"
                 } else {
                     putscli "Transaction Counter unique log name set to $unique_log_name"
+		    SQLiteUpdateKeyValue "generic"  transaction_counter tc_unique_log_name $unique_log_name
                 }
             }
             timestamps {
@@ -1865,6 +1868,7 @@ proc tcset {args} {
                     putscli "Failed to set Transaction Counter log timestamps"
                 } else {
                     putscli "Transaction Counter timestamps set to $log_timestamps"
+		    SQLiteUpdateKeyValue "generic"  transaction_counter tc_log_timestamps $log_timestamps
                 }
             }
             default {

--- a/src/generic/genhelp.tcl
+++ b/src/generic/genhelp.tcl
@@ -8,7 +8,7 @@ proc help { args } {
     }
     set helpbanner "HammerDB $hdb_version CLI Help Index\n
 Type \"help command\" for more details on specific commands below\n"
-        set helpcmds [ list buildschema checkschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript giset jobs librarycheck loadscript print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
+        set helpcmds [ list buildschema checkschema deleteschema clearscript savescript customscript custommonitor datagenrun dbset dgset diset distributescript giset jobs librarycheck loadscript metset metstart metstatus metstop print quit steprun switchmode tcset tcstart tcstatus tcstop vucomplete vucreate vudestroy vurun vuset vustatus wsport wsstart wsstatus wsstop ]
     if {[ llength $args ] != 1} {
         puts $helpbanner
         foreach helpcmd $helpcmds { puts "\t$helpcmd" } 
@@ -36,22 +36,25 @@ Type \"help command\" for more details on specific commands below\n"
                     putscli {jobs disable - Usage: jobs disable [ 0 | 1 ]}
                     putscli "0: Enable storage of job output, restart required."
                     putscli "1: Disable storage of job output, restart required.\n"
-                    putscli {jobs jobid - Usage: jobs jobid [bm|db|delete|dict|result|status|tcount|timestamp|timing|vuid]}
+                    putscli {jobs jobid - Usage: jobs jobid [bm|db|delete|dict|metrics|result|status|system|tcount|timestamp|timing|vuid]}
                     putscli "bm: list benchmark for jobid."
                     putscli "db: list database for jobid."
                     putscli "delete: delete jobid."
                     putscli "dict: list dict for jobid."
+                    putscli "metrics: show system metrics for jobid."
                     putscli "result: list result for jobid."
                     putscli "status: list status for jobid."
+                    putscli "system: show system data for jobid."
                     putscli "tcount: list count for jobid."
                     putscli "timestamp: list starting timestamp for jobid."
                     putscli "timing: list xtprof summary timings for jobid."
                     putscli "vuid: list VU output for VU with vuid for jobid.\n"
                     putscli {jobs jobid timing - Usage: jobs jobid timing vuid}
                     putscli "timing vuid: list xtprof timings for vuid for jobid.\n"
-		    putscli {jobs jobid getchart - Usage: jobs jobid getchart [result | timing | tcount]}
+		    putscli {jobs jobid getchart - Usage: jobs jobid getchart [result | timing | tcount | metrics ]}
                     putscli "result: generate html chart for TPROC-C/TPROC-H result."
                     putscli "timing: generate html chart for TPROC-C/TPROC-H timings."
+                    putscli "metrics: generate html chart for TPROC-C/TPROC-H metrics."
                     putscli "tcount: generate html chart for TPROC-C transaction count.\n"
                 }
                 print {
@@ -173,6 +176,22 @@ Changed commandline:keepalive_margin from 10 to 60 for generic"
                 datagenrun {
                     putscli "datagenrun - Usage: datagenrun"
                     putscli "Run Data Generation. Equivalent to the Generate option in the graphical interface."
+                }
+                metset {
+                    putscli "metset - Usage: metset \[agent_hostname|agent_id\]"
+                    putscli "Configure the CPU Metrics options. Equivalent to the Metrics Options window in the graphical interface." 
+                }
+                metstart {
+                    putscli "metstart - Usage: metstart"
+                    putscli "Starts the CPU Metrics and agent if configured to the localhost."
+                }
+                metstatus {
+                    putscli "metstatus - Usage: metstatus"
+                    putscli "Checks the status of the CPU Metrics."
+                }
+                metstop {
+                    putscli "metstop - Usage: metstop"
+                    putscli "Stops the CPU Metrics."
                 }
                 tcset {
                     if $wsmode {

--- a/src/generic/genmetricscli.tcl
+++ b/src/generic/genmetricscli.tcl
@@ -1,0 +1,282 @@
+proc metset {args} {
+    global agent_hostname agent_id 
+    upvar #0 genericdict genericdict
+    if {[ llength $args ] != 2} {
+        putscli {Usage: metset [agent_hostname|agent_id] value}
+    } else {
+        set option [ lindex [ split  $args ]  0 ]
+        set ind [ lsearch {agent_hostname agent_id} $option ]
+        if { $ind eq -1 } {
+            putscli "Error: invalid option"
+            putscli {Usage: metset [agent_hostname|agent_id]  value}
+            return
+        }
+        set val [ lindex [ split  $args ]  1 ]
+    		if { [ interp exists metrics_interp ] } {
+                tk_messageBox -icon warning -message "Stop Metrics before setting configuration"
+                return
+        } 
+        switch  $option {
+            agent_id { 
+                set agent_id $val
+                if { ![string is integer -strict $agent_id] } {
+                    tk_messageBox -message "agent_id be an integer"
+                    putscli -nonewline "setting to value: "
+                    set agent_id 10000
+                } else {
+                if { [catch {dict set genericdict metrics agent_id $agent_id}] } {
+                    putscli "Failed to set Metrics agent id"
+                } else {
+                    putscli "Metrics agent id set to $agent_id"
+		    SQLiteUpdateKeyValue "generic" metrics agent_id $agent_id
+                }
+                }
+            }
+            agent_hostname { 
+                set agent_hostname $val
+                if { [catch {dict set genericdict metrics agent_hostname $agent_hostname}] } {
+                    putscli "Failed to set Metrics agent hostname"
+                } else {
+                    putscli "Metrics agent hostname set to $agent_hostname"
+		    SQLiteUpdateKeyValue "generic" metrics agent_hostname $agent_hostname
+                }
+            }
+            default {
+                putscli "Unknown metset option"
+                putscli {Usage: metset [agent_hostname|agent_id] value}
+            }
+}}}
+
+proc metstart {} {
+		global agent_hostname agent_id 
+    		if { [ interp exists metrics_interp ] } {
+                putscli "CPU metrics are already running on [ info hostname ], call metstop to stop"
+		return
+		} else {
+                upvar #0 genericdict genericdict
+                if {[dict exists $genericdict metrics ]} {
+			set agent_hostname [ dict get $genericdict metrics agent_hostname ]
+			set agent_id [ dict get $genericdict metrics agent_id ]
+		} else {
+			set agent_hostname "localhost"
+			set agent_id "10000"
+		}
+                global tcl_platform
+                set UserDefaultDir [ file dirname [ info script ] ]
+                ::tcl::tm::path add "../$UserDefaultDir/modules"
+                package require comm
+                namespace import comm::*
+                package require socktest
+                namespace import socktest::*
+	        if { $agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ] } { 
+                set result [ sockmesg [ socktest localhost $agent_id 1000 ]]
+                if { $result eq "OK" } {
+                } else {
+                putscli "Starting Local Metrics Agent on [ info hostname ]"
+                if {$tcl_platform(platform)=="windows"} {
+                if {[catch {exec cmd /c "cd /d agent && agent.bat $agent_id" &} message ]} {
+	        putscli "Error starting metrics agent: $message"
+    	        }
+                } else {
+		  if {[catch {exec sh -c "cd agent && ./agent $agent_id >/dev/null 2>/dev/null" &} message ]} {
+                  putscli $message
+                }
+                }}
+    		} else {
+                set result [ sockmesg [ socktest $agent_hostname $agent_id 1000 ]]
+                if { $result eq "OK" } { 
+		#there is a remote agent running we can connect to; 
+		} else {
+                putscli "Remote Metrics Agent is not running on $agent_hostname, $agent_id" 
+                return
+		}
+    		}
+                after 500 {climetrics}
+}}
+
+proc metstatus {} {
+global tcl_platform agent_hostname agent_id
+set UserDefaultDir [ file dirname [ info script ] ]
+::tcl::tm::path add "../$UserDefaultDir/modules"
+package require comm
+namespace import comm::*
+package require socktest
+namespace import socktest::*
+ if { ![ interp exists metrics_interp ] } {
+putscli "CPU Metrics are not running on [ info hostname ]"
+ } else {
+putscli "CPU Metrics are running on [ info hostname ]"
+set result [ sockmesg [ socktest $agent_hostname $agent_id 1000 ]] 
+if { $result eq "OK" } {
+putscli "Metrics Agent running on $agent_hostname:$agent_id"
+} 
+}
+}
+
+proc metstop {} {
+global tcl_platform agent_hostname agent_id 
+set UserDefaultDir [ file dirname [ info script ] ]
+::tcl::tm::path add "../$UserDefaultDir/modules"
+package require comm
+namespace import comm::*
+package require socktest
+namespace import socktest::*
+set result [ sockmesg [ socktest $agent_hostname $agent_id 1000 ]]
+if { $result eq "OK" } {
+	  if { [ interp exists metrics_interp ] } {
+	#A display is already connected so stopping display will close or reinitialize agent
+  	putscli "Stopping Metrics Agent and Display on $agent_hostname:$agent_id"
+	#Delay to make sure agent has finished sending
+         after 10000 {
+		 catch {DisplayMetrics destroy}
+		 catch {interp delete metrics_interp}
+	 }
+  	} else {
+	#A display is not already connected so #set up port to send stop message to agent
+    if { [catch {::comm new STOPMetrics -listen 1 -local 0 -silent "TRUE" -port {}} b] } {
+    tk_messageBox -message "Stopping Metrics Agent and Display on $agent_hostname:$agent_id failed to create port"
+    } else {
+        set displayid [ STOPMetrics self ]
+        set displayhost [ info hostname ]
+        #puts "Metric close port open @ $displayid on $displayhost"
+	if { [catch {::comm send -async "$agent_id $agent_hostname" "catch {Agent STOP \"$displayid $displayhost\"} "} b] } {
+     putscli "Stopping Metrics Agent and Display on $agent_hostname:$agent_id failed to send message $b"
+            } else {
+     putscli "Stopping Metrics Agent on $agent_hostname:$agent_id"
+	    }
+	}
+     catch { STOPMetrics destroy }
+	}
+} else {
+  putscli "No Metrics Agent detected on id: $agent_hostname:$agent_id"
+}
+return
+}
+
+proc climetrics {} {
+    global agent_hostname agent_id
+    if {  [ info exists hostname ] } { ; } else { set hostname "localhost" }
+    if {  [ info exists id ] } { ; } else { set id 0 }
+    putscli "Connecting to Agent to Display CPU Metrics"
+    if { [ interp exists metrics_interp ] } {
+        interp delete metrics_interp
+    }
+    interp create metrics_interp
+    after 0 {interp eval {metrics_interp} [ConfigureNetworkDisplayCLI $agent_id $agent_hostname]}
+    #Agent runs the Display from here so additional threads not required
+    return
+}
+
+
+proc ConfigureNetworkDisplayCLI {agentid agenthostname} {
+    #set up port
+    if { [catch {::comm new DisplayMetrics -listen 1 -local 0 -silent "TRUE" -port {}} b] } {
+        putscli "Creation of Port Failed : $b" 
+    } else {
+        set displayid [ DisplayMetrics self ]
+        set displayhost [ info hostname ]
+        putscli "Metric receive port open @ $displayid on $displayhost"
+        DisplayMetrics hook lost {
+            if { [catch { DisplayMetrics destroy } b] } {
+                putscli "Agent Connection lost but Failed to close network port : $b" 
+            } else {
+                #ed_kill_cpu_metrics
+                putscli "Metrics Connection closed"
+            }
+        }
+        #Test Agent Port
+        namespace import socktest::*
+        putscli "Connecting to HammerDB Agent @ $agenthostname:$agentid" 
+        puts -nonewline "Testing Agent Connectivity..."
+        set result [ sockmesg [ socktest $agenthostname $agentid 1000 ]]
+        #Test is OK so call agent to call back
+        if { $result eq "OK" } {
+            putscli $result
+            putscli "Metrics Connected"
+            if { [catch {::comm send -async "$agentid $agenthostname" "catch {Agent connect \"$displayid $displayhost\"} "} b] } {
+                putscli "Connection to agent lost: $b"
+                catch { DisplayMetrics destroy }
+            }
+        } else {
+            putscli $result
+            putscli "Connection failed verify hostname and id @ $agenthostname:$agentid" 
+            DoDisplay 1 "AGENT CONNECTION FAILED" local
+            return
+        } 
+    }
+}
+
+proc DoDisplay {maxcpu cpu_model caller} {
+global agent_hostname jobid
+	putscli "Started CPU Metrics for $cpu_model:($maxcpu CPUs)"
+	if { [ info exists cpu_model ] && ![ string match "AGENT CONNECTION FAILED" $cpu_model ] } {
+	if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
+        #If we have done set jobid [ vurun ] in script set jobid back
+        if { [ string match Benchmark* $jobid ] } { 
+        set jobid [ regsub {Benchmark.*=} $jobid ""]
+	}		
+        hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES($jobid,$agent_hostname,$cpu_model,$maxcpu) ON CONFLICT(jobid) DO UPDATE SET jobid=excluded.jobid,hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount}
+    	} else {
+	#Started CPU metrics before a job is running, insert a placeholder making sure only one placeholder is current
+        hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES('@@@',$agent_hostname,$cpu_model,$maxcpu) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount}
+	}
+	} else { 
+putscli "AGENT CONNECTION FAILED"
+	}
+}
+
+proc addstats { usr sys irq idle } {
+	global usrlist syslist irqlist idlelist
+foreach x { usrlist syslist irqlist idlelist } y { usr sys irq idle } {
+	lappend $x [ set $y ]
+	}
+}
+
+proc StatsOneLine {line} {
+global jobid usrlist syslist irqlist idlelist agent_hostname
+proc gmean L {
+    expr pow([join $L *],1./[llength $L])
+}
+    #Called by agent remotely
+    #Different formats some include AMPM some don't
+    if { [ llength $line ] eq 12 } {
+        lassign $line when ampm cpu usr nice sys iowait irq soft steal guest idle
+    } else {
+        if { [ llength $line ] eq 11 } {
+            lassign $line when cpu usr nice sys iowait irq soft steal guest idle
+        } else {
+            putscli "CPU Metrics error: expecting 11 or 12 columns in mpstat data but got [ llength $line ]"
+            set cpu 0
+        }
+    }
+    #For the all CPU line add a list and insert the average over 10 seconds into the JOBMETRIC table
+    if {[string match "all" $cpu]} {
+            addstats $usr $sys $irq $idle
+	}
+	if { [ info exists usrlist ] && [ llength $usrlist ] eq 5 } {
+	foreach x { usrlist syslist irqlist idlelist } y { usrgmean sysgmean irqgmean idlegmean } {
+	set $y [format "%3.2f" [ gmean [ set $x ]]]
+	}
+    	if { [ interp exists metrics_interp ] } {
+	putscli "CPU all usr%-$usrgmean sys%-$sysgmean irq%-$irqgmean idle%-$idlegmean"
+	 if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
+         if { [ string match Benchmark* $jobid ] } {
+         set jobid [ regsub {Benchmark.*=} $jobid ""]
+	 }
+        hdbjobs eval {INSERT INTO JOBMETRIC(jobid,usr,sys,irq,idle) VALUES($jobid,$usrgmean,$sysgmean,$irqgmean,$idlegmean)}
+	#Metrics started before job was running, if placeholder in jobsystem update with correct jobid
+        set jobhost [ hdbjobs eval {select hostname from JOBSYSTEM where JOBID=$jobid} ]
+	if {$jobhost eq ""} { 
+	hdbjobs eval {select hostname,cpumodel,cpucount from JOBSYSTEM where JOBID="@@@"} {
+	hdbjobs eval {update JOBSYSTEM set jobid = $jobid where JOBID="@@@"}
+		}
+    	} else {
+	#The jobid is present in the jobsystem table
+        }
+	}
+	}
+	foreach x { usrlist syslist irqlist idlelist } {
+	set $x [list]
+	}
+	}
+}

--- a/src/oracle/oraopt.tcl
+++ b/src/oracle/oraopt.tcl
@@ -862,7 +862,7 @@ proc configoratpch {option} {
 }
 #Configure Embedded Metrics Options
 proc metoraopts {} {
-    global agent_hostname agent_id
+    global agent_hostname agent_id start_display cpu_only
     upvar #0 icons icons
     upvar #0 configoracle configoracle
     #use same parameters as transaction counter
@@ -871,6 +871,8 @@ proc metoraopts {} {
     set oraoptsfields [ dict create connection {system_user {.metric.c1.e4 get} system_password {.metric.c1.e5 get} instance {.metric.c1.e3 get}} ]
     if {  [ info exists agent_hostname ] } { ; } else { set agent_hostname "localhost" }
     if {  [ info exists agent_id ] } { ; } else { set agent_id 0 }
+    if {  [ info exists cpu_only ] } { ; } else { set cpu_only "false" }
+    if {  [ info exists start_display ] } { ; } else { set start_display "true" }
     set old_agent $agent_hostname
     set old_id $agent_id
     catch "destroy .metric"
@@ -899,6 +901,54 @@ proc metoraopts {} {
     ttk::entry $Name -width 30 -textvariable agent_hostname
     grid $Prompt -column 0 -row 8 -sticky e
     grid $Name -column 1 -row 8
+set Name $Parent.f1.e3
+    set Prompt $Parent.f1.p3
+    ttk::label $Prompt -text "Agent Start :"
+    ttk::button $Name -command {
+        if { $agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ] } { 
+	    agstart $agent_id $start_display
+    } else {
+            tk_messageBox -message "Agent hostname must be local to start, start manually on remote hosts"
+    }
+    } -text Start
+    grid $Prompt -column 0 -row 9 -sticky e
+    grid $Name -column 1 -row 9 -sticky w
+        if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
+        $Name configure -state disabled
+    }
+    set Name $Parent.f1.e4
+    set Prompt $Parent.f1.p4
+    ttk::label $Prompt -text "Agent Stop :"
+    ttk::button $Name -command {
+    agstop $agent_hostname $agent_id
+    } -text Stop
+    grid $Prompt -column 0 -row 10 -sticky e
+    grid $Name -column 1 -row 10 -sticky w
+    set Name $Parent.f1.e5
+    set Prompt $Parent.f1.p5
+    ttk::label $Prompt -text "Agent Status :"
+    ttk::button $Name -command {
+    agstatus $agent_hostname $agent_id
+    } -text Status
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky w
+    set Name $Parent.f1.e6
+    set Prompt $Parent.f1.p6
+    ttk::label $Prompt -text "Start Display with Local Agent :"
+    ttk::checkbutton $Name -text "" -variable start_display -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky w
+        if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
+	set start_display false
+        $Name configure -state disabled
+    }
+    #Placeholder if feature desired in GUI for only CPU metrics
+    #set Name $Parent.f1.e7
+    #set Prompt $Parent.f1.p7
+    #ttk::label $Prompt -text "CPU Metrics Only :"
+    #ttk::checkbutton $Name -text "" -variable cpu_only -onvalue "true" -offvalue "false"
+    #grid $Prompt -column 0 -row 12 -sticky e
+    #grid $Name -column 1 -row 12 -sticky w
     set Name $Parent.c1.e3
     set Prompt $Parent.c1.p3
     ttk::label $Prompt -text "Oracle Service Name :"

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -942,7 +942,7 @@ proc configpgtpch {option} {
 }
 
 proc metpgopts {} { 
-    global agent_hostname agent_id bm
+    global agent_hostname agent_id bm start_display cpu_only
     upvar #0 icons icons
     upvar #0 configpostgresql configpostgresql
     setlocaltcountvars $configpostgresql 1
@@ -969,6 +969,8 @@ proc metpgopts {} {
     } 
     if {  [ info exists agent_hostname ] } { ; } else { set agent_hostname "localhost" }
     if {  [ info exists agent_id ] } { ; } else { set agent_id 0 }
+    if {  [ info exists cpu_only ] } { ; } else { set cpu_only "false" }
+    if {  [ info exists start_display ] } { ; } else { set start_display "true" }
     set old_agent $agent_hostname
     set old_id $agent_id
     catch "destroy .metric"
@@ -1045,6 +1047,54 @@ proc metpgopts {} {
     ttk::entry $Name -width 30 -textvariable agent_hostname
     grid $Prompt -column 0 -row 8 -sticky e
     grid $Name -column 1 -row 8
+    set Name $Parent.f1.e9
+    set Prompt $Parent.f1.p9
+    ttk::label $Prompt -text "Agent Start :"
+    ttk::button $Name -command {
+        if { $agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ] } { 
+	    agstart $agent_id $start_display
+    } else {
+            tk_messageBox -message "Agent hostname must be local to start, start manually on remote hosts"
+    }
+    } -text Start
+    grid $Prompt -column 0 -row 9 -sticky e
+    grid $Name -column 1 -row 9 -sticky w
+        if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
+        $Name configure -state disabled
+    }
+    set Name $Parent.f1.e10
+    set Prompt $Parent.f1.p10
+    ttk::label $Prompt -text "Agent Stop :"
+    ttk::button $Name -command {
+    agstop $agent_hostname $agent_id
+    } -text Stop
+    grid $Prompt -column 0 -row 10 -sticky e
+    grid $Name -column 1 -row 10 -sticky w
+    set Name $Parent.f1.e11
+    set Prompt $Parent.f1.p11
+    ttk::label $Prompt -text "Agent Status :"
+    ttk::button $Name -command {
+    agstatus $agent_hostname $agent_id
+    } -text Status
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky w
+    set Name $Parent.f1.e12
+    set Prompt $Parent.f1.p12
+    ttk::label $Prompt -text "Start Display with Local Agent :"
+    ttk::checkbutton $Name -text "" -variable start_display -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 13 -sticky e
+    grid $Name -column 1 -row 13 -sticky w
+        if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
+	set start_display false
+        $Name configure -state disabled
+    }
+    #Placeholder if feature desired in GUI for only CPU metrics
+    #set Name $Parent.f1.e13
+    #set Prompt $Parent.f1.p13
+    #ttk::label $Prompt -text "CPU Metrics Only :"
+    #ttk::checkbutton $Name -text "" -variable cpu_only -onvalue "true" -offvalue "false"
+    #grid $Prompt -column 0 -row 12 -sticky e
+    #grid $Name -column 1 -row 12 -sticky w
     set Name $Parent.b4
     ttk::button $Name -command { destroy .metric } -text Cancel
     pack $Name -anchor w -side right -padx 3 -pady 3


### PR DESCRIPTION
Updates to CPU metrics to include metrics in the CLI and charting so Jobs data includes CPU utilisation. 
Plan is for CPU metrics to be a starting point and further data such as I/O can be added in future. 