### PR TITLE
Bug Fix, wrong timeout value assignment in xtprof module.

### DIFF
--- a/modules/xtprof-1.0.tm
+++ b/modules/xtprof-1.0.tm
@@ -269,7 +269,7 @@ set xtjob_storage 0
 if { [ string is entier $xtgather_timeout ] } { 
 set xtto [expr {$xtgather_timeout * 60}]
 } else {
-set xttto 600
+set xtto 600
 #Set xtgather_timout in case decided to print this value in future
 set xtgather_timeout 10
 }


### PR DESCRIPTION
Fixed typo in variable name `xtto` causing incorrect timeout assignment in xtprof module.