### PR TITLE
Replace bcp executable with bulk insert for SQL Server builds

### DIFF
--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -468,19 +468,23 @@ proc CreateDateScheme { odbc } {
 # network packet size depends on server configuration, default of 4096 is used if 16000 is not allowed
 proc bcpComm {odbc tableName filePath uid pwd server} {
     upvar 3 location location
-    if { $location eq "local" } {
+    upvar 3 authentication authentication
+    if { $location eq "local" && [ string toupper $authentication ] != "SQL" } {
     if [catch {$odbc evaldirect [ subst {bulk insert $tableName from "$filePath" with (DATAFILETYPE = 'char', FIELDTERMINATOR = '|',ROWS_PER_BATCH=500000)}]} message ] {
            error "Bulk Insert error : $message"
     }
     } else {
-    upvar 3 authentication authentication
     if {[ string toupper $authentication ] eq "WINDOWS" } {
         exec bcp $tableName IN $filePath -b 500000 -a 16000 -T -S $server -c  -t "\\|"
     } else {
     upvar #0 tcl_platform tcl_platform
-            if {$tcl_platform(platform) == "windows"} {
+    if {$tcl_platform(platform) == "windows"} {
 #bcp on Windows uses ODBC driver 17 that does not support the -u option and may need updating when bcp driver changes
+if {[ string toupper $authentication ] eq "ENTRA" } {
+        exec bcp $tableName IN $filePath -b 500000 -a 16000 -G -S $server -c  -t "\\|"
+        } else {
         exec bcp $tableName IN $filePath -b 500000 -a 16000 -U $uid -P $pwd -S $server -c  -t "\\|"
+	}
         } else {
 #bcp on Linux can use ODBC driver 18 and trust the server certificate with -u option
     upvar 3 trust_cert trust_cert


### PR DESCRIPTION
As discussed in https://github.com/TPC-Council/HammerDB/issues/594 using the bcp executable for bulk loads provides excellent performance, however we need to provide login details for bcp that results in extending the function for different connection options. for example on Linux only ODBC driver 18 can trust the server certificate with -u option. 

It would be better if we could use bcp under the existing connection. https://github.com/TPC-Council/HammerDB/issues/594 suggests extending the tdbc::odbc interface to include the bcp_init, bcp_exec commands etc, however bulk insert https://learn.microsoft.com/en-us/sql/t-sql/statements/bulk-insert-transact-sql?view=sql-server-ver16 looks like it already allows us to do this. 

This PR replaces calling the bcp executable with a bulk insert statement instead. Tests show this change further improves load performance. 




