### PR TITLE
MSSQL TPCH Load does not work for Single User

### DIFF
--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -1396,6 +1396,7 @@ proc do_tpch { server port scale_fact odbc_driver authentication uid pwd tcp azu
             set ord_chunk [ split [ start_end $sup_rows $myposition $ord_mult $num_vu ] ":" ]
             tsv::lreplace common thrdlst $myposition $myposition active
         } else {
+            set myposition 1
             set sf_chunk "1 $sup_rows"
             set cust_chunk "1 [ expr {$sup_rows * $cust_mult} ]"
             set part_chunk "1 [ expr {$sup_rows * $part_mult} ]"


### PR DESCRIPTION
When loading the MSSQL TPCH load with a single user the myposition variable is not defined. When load_orders is called with that argument the error "Error in Virtual User 1: Error: can't read "myposition": no such variable" is thrown.

Added a line when threaded is 'Single Threaded' to set myposition to 1.