### PR TITLE
Add awbreezedark theme option to GUI

### DIFF
--- a/images/icons.tcl
+++ b/images/icons.tcl
@@ -5841,5 +5841,2678 @@ dict set iconssvg thumbupsvg {
 }
 return [ set iconssvg ]
 }
+
+iconicwhitesvg {
+dict set iconssvg newsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="file-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="480"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v8h7v-4h-4v-4h-3zm4 0v3h3l-3-3z" />
+</svg>
+}
+
+dict set iconssvg opensvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="folder-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v2h8v-1h-5v-1h-3zm0 3v4.5c0 .28.22.5.5.5h7c.28 0 .5-.22.5-.5v-4.5h-8z" />
+</svg>
+}
+
+dict set iconssvg savesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="hard-drive-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M.19 0c-.11 0-.19.08-.19.19v3.31c0 .28.22.5.5.5h6c.28 0 .5-.22.5-.5v-3.31c0-.11-.08-.19-.19-.19h-6.63zm-.19 4.91v2.91c0 .11.08.19.19.19h6.63c.11 0 .19-.08.19-.19v-2.91c-.16.06-.32.09-.5.09h-6c-.18 0-.34-.04-.5-.09zm5.5 1.09c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5z" />
+</svg>
+}
+
+dict set iconssvg copysvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="clipboard-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M3.5 0c-.28 0-.5.22-.5.5v.5h-.75c-.14 0-.25.11-.25.25v.75h3v-.75c0-.14-.11-.25-.25-.25h-.75v-.5c0-.28-.22-.5-.5-.5zm-3.25 1c-.14 0-.25.11-.25.25v6.5c0 .14.11.25.25.25h6.5c.14 0 .25-.11.25-.25v-6.5c0-.14-.11-.25-.25-.25h-.75v2h-5v-2h-.75z" />
+</svg>
+}
+
+dict set iconssvg cutsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="cut-scissor-g.svg"
+   id="svg4"
+   version="1.1"
+   clip-rule="evenodd"
+   fill-rule="evenodd"
+   image-rendering="optimizeQuality"
+   text-rendering="geometricPrecision"
+   shape-rendering="geometricPrecision"
+   viewBox="0 0 286955 333333">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="0.01"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M233123 74661c14037-29978 13787-54741 272-74661l-83952 145709 20856 36991 62823-108038zm-179291 0C39795 44683 40045 19920 53560 0l101581 176307c4731 6117 7645 12598 8026 19584 356 6541-1530 8926-2578 14609-879 4767-376 9621 2804 14643l4219 4641c3785 4163 7053 9144 13480 8327 4299-547 7901-4187 11012-9998 4024-4424 8710-7857 14091-10244 5202-2307 11054-3639 17589-3946 20479 1056 38181 10619 51480 33660 16124 26259 14279 48435 2310 68310-9210 12085-20347 17427-33007 17439-19310 19-34998-9246-47139-23675-7694-9146-14092-20126-20835-32374l-24502-31307-2889-7303L53831 74662zm90233 109252c5358 0 9701 4343 9701 9701s-4343 9701-9701 9701-9701-4343-9701-9701 4343-9701 9701-9701zm60350 60295c6921-10582 18571-11691 29697-7781 8930 3139 16619 9826 23131 19870 5488 8465 9733 22113 8644 33947-2109 22911-22509 27251-40318 17241-7913-4449-14214-11051-18763-19984-3079-6045-5665-13217-6634-20456-1072-8007-165-16097 4243-22837zm-78104-25585c-474 2146-1354 4317-2749 6519l-4219 4641c-3785 4163-7053 9144-13480 8327-4299-547-7901-4187-11012-9998-4024-4424-8710-7857-14091-10244-5202-2307-11054-3639-17589-3946-20479 1056-38181 10619-51480 33660-16124 26259-14279 48435-2310 68310 9210 12085 20347 17427 33007 17439 19310 19 34998-9246 47139-23675 7694-9146 14092-20126 20835-32374l28838-36848-959-1623-287-486-11643-19703zm-43772 25585c-6921-10582-18571-11691-29698-7781-8930 3139-16619 9826-23131 19870-5488 8465-9733 22113-8644 33947 2109 22911 22509 27251 40318 17241 7913-4449 14214-11051 18763-19984 3079-6045 5665-13217 6634-20456 1072-8007 165-16097-4243-22837z" />
+</svg>
+}
+
+dict set iconssvg pastesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="copywriting-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v1h8v-1h-8zm0 2v1h5v-1h-5zm0 3v1h8v-1h-8zm0 2v1h6v-1h-6zm7.5 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5z" />
+</svg>
+}
+
+dict set iconssvg searchsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="magnifying-glass-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M3.5 0c-1.93 0-3.5 1.57-3.5 3.5s1.57 3.5 3.5 3.5c.59 0 1.17-.14 1.66-.41a1 1 0 0 0 .13.13l1 1a1.02 1.02 0 1 0 1.44-1.44l-1-1a1 1 0 0 0-.16-.13c.27-.49.44-1.06.44-1.66 0-1.93-1.57-3.5-3.5-3.5zm0 1c1.39 0 2.5 1.11 2.5 2.5 0 .66-.24 1.27-.66 1.72-.01.01-.02.02-.03.03a1 1 0 0 0-.13.13c-.44.4-1.04.63-1.69.63-1.39 0-2.5-1.11-2.5-2.5s1.11-2.5 2.5-2.5z" />
+</svg>
+}
+
+dict set iconssvg ctextsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="code-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     transform="translate(0 1)"
+     d="M5 0l-3 6h1l3-6h-1zm-4 1l-1 2 1 2h1l-1-2 1-2h-1zm5 0l1 2-1 2h1l1-2-1-2h-1z" />
+</svg>
+}
+
+dict set iconssvg testsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="terminal-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M.09 0c-.06 0-.09.04-.09.09v7.81c0 .05.04.09.09.09h7.81c.05 0 .09-.04.09-.09v-7.81c0-.06-.04-.09-.09-.09h-7.81zm1.41.78l1.72 1.72-1.72 1.72-.72-.72 1-1-1-1 .72-.72zm2.5 2.22h3v1h-3v-1z" />
+</svg>
+}
+
+dict set iconssvg lvusersvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="people-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M5.5 0c-.51 0-.95.35-1.22.88.45.54.72 1.28.72 2.13 0 .29-.03.55-.09.81.19.11.38.19.59.19.83 0 1.5-.9 1.5-2s-.67-2-1.5-2zm-3 1c-.83 0-1.5.9-1.5 2s.67 2 1.5 2 1.5-.9 1.5-2-.67-2-1.5-2zm4.75 3.16c-.43.51-1.02.82-1.69.84.27.38.44.84.44 1.34v.66h2v-1.66c0-.52-.31-.97-.75-1.19zm-6.5 1c-.44.22-.75.67-.75 1.19v1.66h5v-1.66c0-.52-.31-.97-.75-1.19-.45.53-1.06.84-1.75.84s-1.3-.32-1.75-.84z" />
+</svg>
+}
+
+dict set iconssvg runworldsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="media-play-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     transform="translate(1 1)"
+     d="M0 0v6l6-3-6-3z" />
+</svg>
+}
+
+dict set iconssvg rungreensvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="media-play-green.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#00cc00;fill-opacity:1"
+     id="path2"
+     transform="translate(1 1)"
+     d="M0 0v6l6-3-6-3z" />
+</svg>
+}
+
+dict set iconssvg boxessvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="spreadsheet-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M.75 0c-.41 0-.75.34-.75.75v5.5c0 .41.34.75.75.75h6.5c.41 0 .75-.34.75-.75v-5.5c0-.41-.34-.75-.75-.75h-6.5zm.25 1h1v1h-1v-1zm2 0h4v1h-4v-1zm-2 2h1v1h-1v-1zm2 0h4v1h-4v-1zm-2 2h1v1h-1v-1zm2 0h4v1h-4v-1z" />
+</svg>
+}
+
+dict set iconssvg pencilsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="graph-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M7.03 0l-3.03 3-1-1-3 3.03 1 1 2-2.03 1 1 4-4-.97-1zm-7.03 7v1h8v-1h-8z" />
+</svg>
+}
+
+dict set iconssvg autopilotsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="loop-square-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M1 0v2h1v-1h4v2h-1l1.5 2.5 1.5-2.5h-1v-3h-6zm.5 2.5l-1.5 2.5h1v3h6v-2h-1v1h-4v-2h1l-1.5-2.5z" />
+</svg>
+}
+
+dict set iconssvg distributesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="share-boxed-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M.75 0c-.41 0-.75.34-.75.75v5.5c0 .41.34.75.75.75h4.5c.41 0 .75-.34.75-.75v-1.25h-1v1h-4v-5h2v-1h-2.25zm5.25 0v1c-2.05 0-3.7 1.54-3.94 3.53.21-.88.99-1.53 1.94-1.53h2v1l2-2-2-2z" />
+</svg>
+}
+
+dict set iconssvg benchmarksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="timer-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M2 0v1h1v.03c-1.7.24-3 1.71-3 3.47 0 1.93 1.57 3.5 3.5 3.5s3.5-1.57 3.5-3.5c0-.45-.1-.87-.25-1.25l-.91.38c.11.29.16.57.16.88 0 1.39-1.11 2.5-2.5 2.5s-2.5-1.11-2.5-2.5 1.11-2.5 2.5-2.5c.3 0 .59.05.88.16l.34-.94c-.23-.08-.47-.12-.72-.16v-.06h1v-1h-3zm5 1.16s-3.65 2.81-3.84 3c-.19.2-.19.49 0 .69.19.2.49.2.69 0 .2-.2 3.16-3.69 3.16-3.69z" />
+</svg>
+}
+
+dict set iconssvg driveroptimsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="script-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M3 0c-.55 0-1 .45-1 1v5.5c0 .28-.22.5-.5.5s-.5-.22-.5-.5v-1.5h-1v2c0 .55.45 1 1 1h5c.55 0 1-.45 1-1v-3h-4v-2.5c0-.28.22-.5.5-.5s.5.22.5.5v1.5h4v-2c0-.55-.45-1-1-1h-4z" />
+</svg>
+}
+
+dict set iconssvg vuseroptimsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="people-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M5.5 0c-.51 0-.95.35-1.22.88.45.54.72 1.28.72 2.13 0 .29-.03.55-.09.81.19.11.38.19.59.19.83 0 1.5-.9 1.5-2s-.67-2-1.5-2zm-3 1c-.83 0-1.5.9-1.5 2s.67 2 1.5 2 1.5-.9 1.5-2-.67-2-1.5-2zm4.75 3.16c-.43.51-1.02.82-1.69.84.27.38.44.84.44 1.34v.66h2v-1.66c0-.52-.31-.97-.75-1.19zm-6.5 1c-.44.22-.75.67-.75 1.19v1.66h5v-1.66c0-.52-.31-.97-.75-1.19-.45.53-1.06.84-1.75.84s-1.3-.32-1.75-.84z" />
+</svg>
+}
+
+dict set iconssvg modesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="layers-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v4h4v-4h-4zm5 2v3h-3v1h4v-4h-1zm2 2v3h-3v1h4v-4h-1z" />
+</svg>
+}
+
+dict set iconssvg optionsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="cog-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M3.5 0l-.5 1.19c-.1.03-.19.08-.28.13l-1.19-.5-.72.72.5 1.19c-.05.1-.09.18-.13.28l-1.19.5v1l1.19.5c.04.1.08.18.13.28l-.5 1.19.72.72 1.19-.5c.09.04.18.09.28.13l.5 1.19h1l.5-1.19c.09-.04.19-.08.28-.13l1.19.5.72-.72-.5-1.19c.04-.09.09-.19.13-.28l1.19-.5v-1l-1.19-.5c-.03-.09-.08-.19-.13-.28l.5-1.19-.72-.72-1.19.5c-.09-.04-.19-.09-.28-.13l-.5-1.19h-1zm.5 2.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5-1.5-.67-1.5-1.5.67-1.5 1.5-1.5z" />
+</svg>
+}
+
+dict set iconssvg driveroptlosvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="caret-right-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     transform="translate(2)"
+     d="M0 0v8l4-4-4-4z" />
+</svg>
+}
+
+dict set iconssvg ticksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="check-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="723"
+     inkscape:window-width="1042"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#00cc00;fill-opacity:1"
+     id="path2"
+     transform="translate(0 1)"
+     d="M6.41 0l-.69.72-2.78 2.78-.81-.78-.72-.72-1.41 1.41.72.72 1.5 1.5.69.72.72-.72 3.5-3.5.72-.72-1.44-1.41z" />
+</svg>
+}
+
+dict set iconssvg crosssvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="x-r.svg"
+   id="svg877"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata883">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs881" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg877"
+     inkscape:window-maximized="0"
+     inkscape:window-y="54"
+     inkscape:window-x="0"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview879"
+     inkscape:window-height="708"
+     inkscape:window-width="1120"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#d00000;fill-opacity:1"
+     id="path875"
+     d="M1.41 0l-1.41 1.41.72.72 1.78 1.81-1.78 1.78-.72.69 1.41 1.44.72-.72 1.81-1.81 1.78 1.81.69.72 1.44-1.44-.72-.69-1.81-1.78 1.81-1.81.72-.72-1.44-1.41-.69.72-1.78 1.78-1.81-1.78-.72-.72z" />
+</svg>
+}
+
+dict set iconssvg clocksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="clock-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4 0c-2.2 0-4 1.8-4 4s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4zm0 1c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm-.5 1v2.22l.16.13.5.5.34.38.72-.72-.38-.34-.34-.34v-1.81h-1z" />
+</svg>
+}
+
+dict set iconssvg runningsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="wrench-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M5.5 0c-1.38 0-2.5 1.12-2.5 2.5 0 .32.08.62.19.91l-2.91 2.88c-.39.39-.39 1.05 0 1.44.2.2.46.28.72.28.26 0 .52-.09.72-.28l2.88-2.91c.28.11.58.19.91.19 1.38 0 2.5-1.12 2.5-2.5 0-.16 0-.32-.03-.47l-.97.97h-2v-2l.97-.97c-.15-.03-.31-.03-.47-.03zm-4.5 6.5c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5z" />
+</svg>
+}
+
+dict set iconssvg oneusersvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="person-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4 0c-1.1 0-2 1.12-2 2.5s.9 2.5 2 2.5 2-1.12 2-2.5-.9-2.5-2-2.5zm-2.09 5c-1.06.05-1.91.92-1.91 2v1h8v-1c0-1.08-.84-1.95-1.91-2-.54.61-1.28 1-2.09 1-.81 0-1.55-.39-2.09-1z" />
+</svg>
+}
+
+dict set iconssvg stopsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="media-stop-r.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#d00000;fill-opacity:1"
+     id="path2"
+     transform="translate(1 1)"
+     d="M0 0v6h6v-6h-6z" />
+</svg>
+}
+
+dict set iconssvg dashboardsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="bar-chart-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v7h8v-1h-7v-6h-1zm5 0v5h2v-5h-2zm-3 2v3h2v-3h-2z" />
+</svg>
+}
+
+dict set iconssvg datagensvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="cloud-upload-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4.5 0c-1.21 0-2.27.86-2.5 2-1.1 0-2 .9-2 2 0 .37.11.71.28 1h2.22l2-2 2 2h1.41c.06-.16.09-.32.09-.5 0-.65-.42-1.29-1-1.5v-.5c0-1.38-1.12-2.5-2.5-2.5zm0 4.5l-2.5 2.5h2v.5a.5.5 0 1 0 1 0v-.5h2l-2.5-2.5z" />
+</svg>
+}
+
+dict set iconssvg savexmlsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="x-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#626266;fill-opacity:1"
+     id="path2"
+     d="M1.41 0l-1.41 1.41.72.72 1.78 1.81-1.78 1.78-.72.69 1.41 1.44.72-.72 1.81-1.81 1.78 1.81.69.72 1.44-1.44-.72-.69-1.81-1.78 1.81-1.81.72-.72-1.44-1.41-.69.72-1.78 1.78-1.81-1.78-.72-.72z" />
+</svg>
+}
+
+dict set iconssvg hmenusvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="menu-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     transform="translate(0 1)"
+     d="M0 0v1h8v-1h-8zm0 2.97v1h8v-1h-8zm0 3v1h8v-1h-8z" />
+</svg>
+}
+
+dict set iconssvg resultssvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="target-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4 0c-2.2 0-4 1.8-4 4s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4zm0 1c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 1c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 1c.56 0 1 .44 1 1s-.44 1-1 1-1-.44-1-1 .44-1 1-1z" />
+</svg>
+}
+
+dict set iconssvg windocksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="fullscreen-enter-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v4l1.5-1.5 1.5 1.5 1-1-1.5-1.5 1.5-1.5h-4zm5 4l-1 1 1.5 1.5-1.5 1.5h4v-4l-1.5 1.5-1.5-1.5z" />
+</svg>
+}
+
+dict set iconssvg winundocksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="fullscreen-exit-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M1 0l-1 1 1.5 1.5-1.5 1.5h4v-4l-1.5 1.5-1.5-1.5zm3 4v4l1.5-1.5 1.5 1.5 1-1-1.5-1.5 1.5-1.5h-4z" />
+</svg>
+}
+
+dict set iconssvg bansvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="ban-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4 0c-2.2 0-4 1.8-4 4s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4zm0 1c.66 0 1.26.21 1.75.56l-4.19 4.19c-.35-.49-.56-1.09-.56-1.75 0-1.66 1.34-3 3-3zm2.44 1.25c.35.49.56 1.09.56 1.75 0 1.66-1.34 3-3 3-.66 0-1.26-.21-1.75-.56l4.19-4.19z" />
+</svg>
+}
+
+dict set iconssvg graphsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="graph-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M7.03 0l-3.03 3-1-1-3 3.03 1 1 2-2.03 1 1 4-4-.97-1zm-7.03 7v1h8v-1h-8z" />
+</svg>
+}
+
+dict set iconssvg repeatsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="reload-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M4 0c-2.2 0-4 1.8-4 4s1.8 4 4 4c1.1 0 2.12-.43 2.84-1.16l-.72-.72c-.54.54-1.29.88-2.13.88-1.66 0-3-1.34-3-3s1.34-3 3-3c.83 0 1.55.36 2.09.91l-1.09 1.09h3v-3l-1.19 1.19c-.72-.72-1.71-1.19-2.81-1.19z" />
+</svg>
+}
+
+dict set iconssvg tasksvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="task-g.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M0 0v7h7v-3.59l-1 1v1.59h-5v-5h3.59l1-1h-5.59zm7 0l-3 3-1-1-1 1 2 2 4-4-1-1z" />
+</svg>
+}
+
+dict set iconssvg errorsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="circle-x-r.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="719"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#d00000;fill-opacity:1"
+     id="path2"
+     d="M4 0c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm-1.5 1.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
+</svg>
+}
+
+dict set iconssvg informationsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   viewBox="0 0 8 8"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="info-b.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="820"
+     inkscape:window-height="996"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="106.25"
+     inkscape:cx="4"
+     inkscape:cy="4"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M3 0c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm-1.5 2.5c-.83 0-1.5.67-1.5 1.5h1c0-.28.22-.5.5-.5s.5.22.5.5-1 1.64-1 2.5c0 .86.67 1.5 1.5 1.5s1.5-.67 1.5-1.5h-1c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-.36 1-1.84 1-2.5 0-.81-.67-1.5-1.5-1.5z"
+     transform="translate(2)"
+     id="path2"
+     style="fill:#062671;fill-opacity:1" />
+</svg>
+}
+
+dict set iconssvg questionsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   viewBox="0 0 8 8"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="question-mark-b.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="820"
+     inkscape:window-height="896"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="106.25"
+     inkscape:cx="4"
+     inkscape:cy="4"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M2.47 0c-.85 0-1.48.26-1.88.66-.4.4-.54.9-.59 1.28l1 .13c.04-.25.12-.5.31-.69.19-.19.49-.38 1.16-.38.66 0 1.02.16 1.22.34.2.18.28.4.28.66 0 .83-.34 1.06-.84 1.5-.5.44-1.16 1.08-1.16 2.25v.25h1v-.25c0-.83.31-1.06.81-1.5.5-.44 1.19-1.08 1.19-2.25 0-.48-.17-1.02-.59-1.41-.43-.39-1.07-.59-1.91-.59zm-.5 7v1h1v-1h-1z"
+     transform="translate(2)"
+     id="path2"
+     style="fill:#062671;fill-opacity:1" />
+</svg>
+}
+
+dict set iconssvg warningsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="warning-r.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="872"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#d00000;fill-opacity:1"
+     id="path2"
+     d="M3.09 0c-.06 0-.1.04-.13.09l-2.94 6.81c-.02.05-.03.13-.03.19v.81c0 .05.04.09.09.09h6.81c.05 0 .09-.04.09-.09v-.81c0-.05-.01-.14-.03-.19l-2.94-6.81c-.02-.05-.07-.09-.13-.09h-.81zm-.09 3h1v2h-1v-2zm0 3h1v1h-1v-1z" />
+</svg>
+}
+
+dict set iconssvg hdbiconsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="hammerDB-icon-SVG-g.svg"
+   version="1.1"
+   id="svg2"
+   xml:space="preserve"
+   width="89.907104"
+   height="114.88928"
+   viewBox="0 0 89.907105 114.88928"><sodipodi:namedview
+     inkscape:current-layer="svg2"
+     inkscape:window-maximized="0"
+     inkscape:window-y="27"
+     inkscape:window-x="17"
+     inkscape:cy="56.020871"
+     inkscape:cx="57.444613"
+     inkscape:zoom="1.3609708"
+     showgrid="false"
+     id="namedview16"
+     inkscape:window-height="681"
+     inkscape:window-width="1748"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0" /><metadata
+     id="metadata8"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+     id="defs6" /><path
+     d="m 83.861533,1.2401157 h -25.30134 c -3.50266,0 -3.97866,1.592005 -3.97866,4.294665 V 45.321451 H 35.166863 V 5.5347807 c 0,-3.817331 -2.07067,-4.294665 -4.61733,-4.294665 H 5.7255329 c -3.02267,0.158667 -4.14,1.433335 -4.14,4.294665 V 109.29877 c 0,3.81734 1.59067,4.296 4.776,4.296 H 35.072193 c 0.93867,-5 2.092,-8.82266 2.092,-8.82266 h 2.98134 V 85.384111 l -0.27867,-5.85334 c -0.248,-4.52132 -3.14533,-6.50799 -6.38667,-6.65466 -5.17733,-0.236 -5.69466,2.56134 -8.97466,3.116 -3.39067,0.56267 -6.51467,0.35334 -6.51467,0.35334 -1.8,0.0987 -3.25867,-1.09867 -3.25867,-2.67467 v -14.37733 c 0,-1.57867 1.45867,-2.75734 3.25867,-2.64 0,0 3.17467,-0.144 6.51467,0.42933 3.344,0.572 3.66666,2.27333 6.73466,3.364 3.076,1.09867 4.28934,-1.33733 6.53067,-2.94933 2.24933,-1.61867 8.34267,-1.68134 12.944,-1.36534 4.6,0.31467 9.19467,1.24134 9.19467,1.24134 20.24133,5.34933 22.512,22.29732 22.512,22.29732 -13.31867,-14.18932 -24.39734,-9.01066 -29.412,-3.21866 -3.33734,3.852 -2.86134,9.404 -2.86134,9.404 h -0.0253 v 18.915999 h 2.04 c 0,0 1.15467,3.82266 2.09067,8.82266 h 29.76933 c 3.02267,0 4.29467,-0.796 4.29467,-4.296 V 5.3761207 c 0,-3.498671 -1.272,-4.136005 -4.456,-4.136005"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.133333"
+     id="path30" /></svg>
+}
+dict set iconssvg deletesvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="delete-g.svg"
+   id="svg22"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg22"
+     inkscape:window-maximized="0"
+     inkscape:window-y="130"
+     inkscape:window-x="910"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="91.75"
+     showgrid="false"
+     id="namedview24"
+     inkscape:window-height="783"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path20"
+     transform="translate(0 1)"
+     d="M2 0l-2 3 2 3h6v-6h-6zm1.5.78l1.5 1.5 1.5-1.5.72.72-1.5 1.5 1.5 1.5-.72.72-1.5-1.5-1.5 1.5-.72-.72 1.5-1.5-1.5-1.5.72-.72z" />
+</svg>
+}
+dict set iconssvg thumbupsvg {
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="thumb-up-g.svg"
+   id="svg865"
+   version="1.1"
+   viewBox="0 0 8 8"
+   height="8"
+   width="8">
+  <metadata
+     id="metadata871">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs869" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg865"
+     inkscape:window-maximized="0"
+     inkscape:window-y="63"
+     inkscape:window-x="57"
+     inkscape:cy="4"
+     inkscape:cx="4"
+     inkscape:zoom="106.25"
+     showgrid="false"
+     id="namedview867"
+     inkscape:window-height="863"
+     inkscape:window-width="820"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path863"
+     d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z" />
+</svg>
+}
+return [ set iconssvg ]
+}
 }
 }

--- a/modules/emu_graph-2.0.tm
+++ b/modules/emu_graph-2.0.tm
@@ -644,10 +644,15 @@ if { ![ info exists ribenable ] } { set ribenable false }
 	    set labelcolors 0
 	}
 
+        if { [ string match "*dark*" $ttk::currentTheme ] } {
+        set graphcolor black
+        } else {
+        set graphcolor white
+        }
 	if { $emu_graph($graph,$tag,lines) } {
 	set colour1 $emu_graph($graph,$tag,colour)
 	#Fix colour 2 to always grade to white
-	set colour2 white
+	set colour2 $graphcolor
         if { [catch {winfo rgb . $colour1} rgb1] } {
             error "invalid color: $colour1"
         }
@@ -656,14 +661,13 @@ if { ![ info exists ribenable ] } { set ribenable false }
         }
 	    ## create the line as a single line item
 	    ## add start and end points
-
 	set ribcoords $coords
 	set coords [concat $x_min_c $y_min_c $coords $x_max_c $y_min_c ]
         set coordscopy2 [ lreplace $coords end-1 end ]
         set coordscopy2 [ lreplace $coordscopy2 0 1 ]
-	set transition [ subst {$canvas gradient create linear -method pad -lineartransition {0 1 0 0} -stops {{0 white} {0.4 $colour1}}}]
+	set transition [ subst {$canvas gradient create linear -method pad -lineartransition {0 1 0 0} -stops {{0 $graphcolor} {0.4 $colour1}}}]
 	set gradcolour1 [ eval $transition ]
-	eval "$canvas create polyline $coords -stroke white -strokewidth 0 -strokelinejoin round -fill $gradcolour1 -fillopacity 0.25 -tag {$tag}"
+	eval "$canvas create polyline $coords -stroke $graphcolor -strokewidth 0 -strokelinejoin round -fill $gradcolour1 -fillopacity 0.25 -tag {$tag}"
 	#$canvas lower $tag
 	$canvas raise $tag
 	if { $ribenable } {
@@ -789,11 +793,19 @@ set padstroke [ pad_stroke ]
     set graphfont      $emu_graph($graph,font)
 
     set canvas         $emu_graph($graph,canvas)
+
+        if { [ string match "*dark*" $ttk::currentTheme ] } {
+        set strokecolor "#626262" 
+        set fillcolor "#c8c8c8"
+        } else {
+        set strokecolor "#c8c8c8"
+        set fillcolor "#626262"
+        }
 	
     # clear up any existing axes
     $canvas delete -withtag axis
     $canvas delete prect
-    $canvas create prect $x_min_c [ expr {$y_min_c + $padstroke} ] $x_max_c [ expr $y_max_c - 30 ] -stroke "#c8c8c8" -tag prect
+    $canvas create prect $x_min_c [ expr {$y_min_c + $padstroke} ] $x_max_c [ expr $y_max_c - 30 ] -stroke $strokecolor -tag prect
                                           
     # y-pos of tick end points and of axis tick labels
     #set ticky [expr {$y_min_c-$ticklen}]
@@ -810,13 +822,13 @@ set padstroke [ pad_stroke ]
 	if {$t >= $x_min} {
 	    #puts "t=$t, next t [expr {$t+$delta_x}]"
 	    set x [x2canvas $graph $t]
-	    $canvas create pline $x  [ expr {$y_min_c + $padstroke} ] $x $ticky -stroke "#c8c8c8" -strokedasharray "3 3 3 3" -strokewidth 1 -tag [list graph$graph axis]
+	    $canvas create pline $x  [ expr {$y_min_c + $padstroke} ] $x $ticky -stroke $strokecolor -strokedasharray "3 3 3 3" -strokewidth 1 -tag [list graph$graph axis]
 if { ($t eq 1) || ($t eq 4) || ($t eq 7) || ($t eq 10) || ($t eq 13) || ($t eq 16) || ($t eq 19) } {
 		set n [ expr {$t * 2 - 1} ]
 		set tind [ lindex [ split $timelist ] $n ]
 		regsub -all {\}} $tind tind
 	    $canvas create text [x2canvas $graph $t] $texty \
-		-fill "#626262" -text $tind -font "$graphfont 7" -tag [list graph$graph axis]\
+		-fill $fillcolor -text $tind -font "$graphfont 7" -tag [list graph$graph axis]\
 		-anchor w
 		}
 	}
@@ -835,11 +847,11 @@ set padstroke [ pad_stroke ]
 	## this is because of a problem with rounding down in nicenum
 	if {$f >= $y_min} {
 	    set y [y2canvas $graph $f]
-	    $canvas create pline  [x2canvas $graph $x_min] [ expr {$y + $padstroke} ] [x2canvas $graph $x_max] [ expr {$y + $padstroke} ] -stroke "#c8c8c8" -strokedasharray "3 3 3 3" -strokewidth 1 -tag [list graph$graph axis]
+	    $canvas create pline  [x2canvas $graph $x_min] [ expr {$y + $padstroke} ] [x2canvas $graph $x_max] [ expr {$y + $padstroke} ] -stroke $strokecolor -strokedasharray "3 3 3 3" -strokewidth 1 -tag [list graph$graph axis]
 	    # and add the label
 		set dispf [ expr {int($f)} ]
 	    $canvas create text $textx $y -text $dispf -anchor e \
-		-fill "#626262" -tag [list graph$graph axis] -font "$graphfont 7"
+		-fill $fillcolor -tag [list graph$graph axis] -font "$graphfont 7"
         }
     }
 $canvas raise prect

--- a/modules/tkcon-2.7.10.tm
+++ b/modules/tkcon-2.7.10.tm
@@ -128,6 +128,7 @@ proc ::tkcon::Init {args} {
     ##
 
     # bg == {} will get bg color from the main toplevel (in InitUI)
+     if { ![ string match "*dark*" $ttk::currentTheme ] } {
     foreach {key default} {
 	bg		White
 	blink		\#FFFF00
@@ -141,6 +142,22 @@ proc ::tkcon::Init {args} {
 	stderr		\#FF0000
     } {
 	if {![info exists COLOR($key)]} { set COLOR($key) $default }
+    }
+    } else {
+    foreach {key default} {
+	bg		black
+	blink		\#FFFF00
+	cursor		white
+	disabled	\#4D4D4D
+	proc		\#008800
+	var		\#FFC0D0
+	prompt		\#8F4433
+	stdin		white
+	stdout		\#00a2ed
+	stderr		\#FF0000
+    } {
+	if {![info exists COLOR($key)]} { set COLOR($key) $default }
+    }
     }
 
     # expandorder could also include 'Methodname' for XOTcl/NSF methods

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -219,22 +219,26 @@ proc ed_start_gui { dbdict icons iconalt } {
 
     set Name $Parent.panedwin
     if { $ttk::currentTheme eq "clearlooks" } {
-    panedwindow $Name -orient horizontal -handlesize 8 -background [ dict get $icons defaultBackground ] } else {
-        if { $ttk::currentTheme in {awarc awbreeze awlight} } {
-        panedwindow $Name -orient horizontal -background [ dict get $icons defaultBackground ] -relief flat } else {
-            panedwindow $Name -orient horizontal -showhandle false
+        panedwindow $Name -orient horizontal -handlesize 8 -background [ dict get $icons defaultBackground ] 
+        } elseif { $ttk::currentTheme in {awarc awbreeze awlight} } {
+        panedwindow $Name -orient horizontal -background [ dict get $icons defaultBackground ] -relief flat 
+        } elseif { $ttk::currentTheme eq "awbreezedark" } {
+        panedwindow $Name -orient horizontal -background  [ dict get $icons defaultBackground ] -relief flat
+        } else {
+        panedwindow $Name -orient horizontal -showhandle false
         }
-    }
     pack $Name -expand yes -fill both
 
     set Name $Parent.panedwin.subpanedwin
     if { $ttk::currentTheme eq "clearlooks" } {
-    panedwindow $Name -orient vertical -handlesize 8 -background [ dict get $icons defaultBackground ]} else {
-        if { $ttk::currentTheme in {awarc awbreeze awawlight} } {
-        panedwindow $Name -orient vertical -background [ dict get $icons defaultBackground ] -relief flat } else {
-            panedwindow $Name -orient vertical -showhandle false
+        panedwindow $Name -orient vertical -handlesize 8 -background [ dict get $icons defaultBackground ]
+        } elseif { $ttk::currentTheme in {awarc awbreeze awawlight} } {
+        panedwindow $Name -orient vertical -background [ dict get $icons defaultBackground ] -relief flat 
+        } elseif { $ttk::currentTheme eq "awbreezedark" } {
+        panedwindow $Name -orient vertical -background [ dict get $icons defaultBackground ] -relief flat 
+        } else {
+        panedwindow $Name -orient vertical -showhandle false
         }
-    }
     pack $Name -expand yes -fill both
 
     set Name $Parent.treeframe
@@ -245,7 +249,7 @@ proc ed_start_gui { dbdict icons iconalt } {
     pack $Parent.treeframe.vbar -anchor center -expand 0 -fill y -ipadx 0 -ipady 0 \
          -padx 0 -pady 0 -side right
     set Name $Parent.treeframe.treeview
-    ttk::treeview $Name -yscrollcommand "$Parent.treeframe.vbar set" -selectmode browse -show [ list tree headings ] 
+    ttk::treeview $Name -yscrollcommand "$Parent.treeframe.vbar set" -selectmode browse -show [ list tree headings ]
     $Name column #0 -stretch 1 -minwidth 1 -width $treewidth
     $Name heading #0 -text "Benchmark"
     $Name configure -padding {0 0 0 0}
@@ -1382,12 +1386,23 @@ proc applyctexthighlight {w} {
 
 proc setctexthighlight {w} {
     upvar #0 dbdict dbdict
+    if { [ string match "*dark*" $ttk::currentTheme ] } {
+    set colour(vars) green
+    set colour(cmds) yellow
+    set colour(functions) magenta
+    #set colour(brackets) lightblue
+    #set colour(comments) purple
+    set colour(brackets) #00a2ed
+    set colour(comments) gray50
+    set colour(strings) red
+    } else {
     set colour(vars) green
     set colour(cmds) blue
     set colour(functions) magenta
     set colour(brackets) gray50
     set colour(comments) black
     set colour(strings) red
+    }
     #Extract list of commands provided by each database for highlighting
     dict for {database attributes} $dbdict {
         dict with attributes {
@@ -1444,18 +1459,32 @@ proc ed_edit {} {
          -padx 0 -pady 0 -side right
 
     set Name $Parent.textFrame.left.text
-    if { $ttk::currentTheme eq "black" } {
+    if { [ string match "*dark*" $ttk::currentTheme ] } {
         set bwidth 0
         set hbgrd LightGray
+	set ctexthighlightbackground LightGray
+	set ctextbackground black
+	set ctextforeground white
+	set ctexthighlightbackground LightGray
+	set ctextinsertbackground white
+	set ctextselectforeground white
     } else {
         set bwidth 2
         set hbgrd [ dict get $icons defaultBackground ]
+        set bwidth 0
+        set hbgrd LightGray
+	set ctexthighlightbackground LightGray
+	set ctextbackground white
+	set ctextforeground black
+	set ctexthighlightbackground LightGray
+	set ctextinsertbackground black
+	set ctextselectforeground black
     }
     if { $highlight eq "true" } {
-        ctext $Name -relief flat -background white -borderwidth $bwidth -foreground black \
+        ctext $Name -relief flat -background $ctextbackground -borderwidth $bwidth -foreground $ctextforeground \
          -highlight 1 \
-         -highlightbackground LightGray -insertbackground black \
-         -selectbackground $hbgrd -selectforeground black \
+         -highlightthickness 0 -highlightbackground $ctexthighlightbackground -insertbackground $ctextinsertbackground \
+         -selectbackground $hbgrd -selectforeground $ctextselectforeground \
          -wrap none \
          -font basic \
          -xscrollcommand "$Parent.textFrame.right.vertScrollbar set" \
@@ -1466,10 +1495,10 @@ proc ed_edit {} {
         setctexthighlight $Name
         easyCtextCommenting $Name
     } else {
-        ctext $Name -relief flat -background white -borderwidth $bwidth -foreground black \
+        ctext $Name -relief flat -background $ctextbackground -borderwidth $bwidth -foreground $ctextforeground  \
          -highlight 0 \
-         -highlightbackground LightGray -insertbackground black \
-         -selectbackground $hbgrd -selectforeground black \
+         -highlightthickness 0 -highlightbackground $ctexthighlightbackground -insertbackground $ctextinsertbackground \
+         -selectbackground $hbgrd -selectforeground $ctextselectforeground \
          -wrap none \
          -font basic \
          -xscrollcommand "$Parent.textFrame.right.vertScrollbar set" \

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -989,7 +989,14 @@ proc ed_loadsave {loadflag} {
     pack $Name -side top -anchor nw -expand yes -fill both
 
     set Name $Parent.list.lb1
-    listbox $Name -background white -yscrollcommand "$Parent.list.sb2 set" -selectmode browse
+    if { [ string match "*dark*" $ttk::currentTheme ] } {
+    set lbbackground black
+    set lbforeground white
+    } else {
+    set lbbackground white
+    set lbforeground black
+    }
+    listbox $Name -background $lbbackground -foreground $lbforeground -yscrollcommand "$Parent.list.sb2 set" -selectmode browse
     pack $Name -anchor center -expand 1 -fill both -ipadx 0 -ipady 0 \
          -padx 2 -pady 2 -side left
     bind $Name <Any-ButtonPress> {ed_loadsaveselbegin %W %y}

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -42,7 +42,7 @@ proc ConfigureNetworkDisplay {agentid agenthostname} {
 proc DoDisplay {maxcpu cpu_model caller} {
     global S CLR cputobars cputotxt cpucoords metframe win_scale_fact jobid agent_hostname
     set CLR(bg) black
-    set CLR(usr) green
+    set CLR(usr) lightgreen
     set CLR(sys) red
     set S(bar,width) [ expr {round((20/1.333333)*$win_scale_fact)} ]
     set S(bar,height) [ expr {round((87/1.333333)*$win_scale_fact)} ]
@@ -76,7 +76,7 @@ proc DoDisplay {maxcpu cpu_model caller} {
     set height [ expr {($S(bar,height)+$S(col,padding))*$maxrows} ]
     set scrollheight [ expr {$height*2} ]
     frame $metframe.f -bd $S(border) -relief flat -bg $CLR(bg)
-    if { $ttk::currentTheme eq "black" } {
+    if { [ string match "*dark*" $ttk::currentTheme ] } {
         set cnv1 [ tkp::canvas $metframe.sv -width 11 -highlightthickness 0 -background #424242 ]
     } else {
         set cnv1 [ tkp::canvas $metframe.sv -width 11 -highlightthickness 0 -background #dcdad5 ]

--- a/src/generic/genmodes.tcl
+++ b/src/generic/genmodes.tcl
@@ -29,24 +29,31 @@ proc start_autopilot {} {
         set Name .ed_mainFrame.$btn
         $Name configure -state disabled
     }
+    if { [ string match "*dark*" $ttk::currentTheme ] } {
+    set apbackground black
+    set apforeground white 
+    } else {
+    set apbackground black
+    set apforeground #626262 
+    }
     set Name .ed_mainFrame.treeframe.treeview  
     $Name state disabled
     ed_stop_autopilot
     set aptime 00d:00h:00m:00s
     .ed_mainFrame.notebook tab .ed_mainFrame.ap  -state normal
     .ed_mainFrame.notebook select .ed_mainFrame.ap
-    pack [ canvas .ed_mainFrame.ap.canv -highlightthickness 0 -background white ] -fill both -expand 1
+    pack [ canvas .ed_mainFrame.ap.canv -highlightthickness 0 -background $apbackground ] -fill both -expand 1
     set Name .ed_mainFrame.ap.canv
-    frame $Name.b -background white
-    label  $Name.b.time -textvar aptime -width 15 -bg white -fg #626262 -font {TkDefaultFont 11 bold}
+    frame $Name.b -background $apbackground
+    label  $Name.b.time -textvar aptime -width 15 -bg $apbackground -fg $apforeground -font {TkDefaultFont 11 bold}
     pack $Name.b.time -side right -fill y -padx 10
     set lenp [ llength $apsequence ]
     ttk::progressbar $Name.b.p -orient horizontal -mode determinate -maximum $lenp
     pack $Name.b.p -side left -fill x -expand 1 -padx 10
     pack $Name.b -side top -fill both -expand 1 -pady 5 -padx 5 -anchor e
-    frame $Name.a -background white
+    frame $Name.a -background $apbackground
     ttk::scrollbar $Name.a.y -command "$Name.a.t yview"
-    text $Name.a.t -yscrollc "$Name.a.y set" -wrap word -padx 2 -pady 3 -highlightthickness 0 -borderwidth 0 -takefocus 0 -background white -font {TkDefaultFont 10}
+    text $Name.a.t -yscrollc "$Name.a.y set" -wrap word -padx 2 -pady 3 -highlightthickness 0 -borderwidth 0 -takefocus 0 -background $apbackground -font {TkDefaultFont 10}
     pack $Name.a.y -side right -fill y
     pack $Name.a.t -side top -fill both -expand 1 -pady 5 -padx 15 -anchor e
     pack $Name.a -side top -fill both -expand 1

--- a/src/generic/gentab.tcl
+++ b/src/generic/gentab.tcl
@@ -81,13 +81,18 @@ proc tablist w {
     grid rowconfigure    $tf 0 -weight 1
     grid columnconfigure $tf 0 -weight 1
     pack $tf -side top -expand yes -fill both
-    if { $ttk::currentTheme in {clearlooks arc breeze awlight}} {
+    if { ![ string match "*dark*" $ttk::currentTheme ] } {
+        $tbl configure -background white
+        $tbl configure -foreground black
         $tbl configure -labelforeground black
         $tbl configure -selectbackground #FF7900
-        $tbl configure -stripebackground [ dict get $icons defaultBackground ]
     } else {
-        $tbl configure -stripebackground [ dict get $icons defaultBackground ]
+        $tbl configure -background black
+        $tbl configure -foreground white
+        $tbl configure -labelforeground white
+        $tbl configure -selectbackground #FF7900
     }
+    $tbl configure -stripebackground [ dict get $icons defaultBackground ]
     $tbl configure -spacing 2
     $tbl columnconfigure 0 -align center
     $tbl columnconfigure 1 -align center

--- a/src/generic/gentc.tcl
+++ b/src/generic/gentc.tcl
@@ -866,11 +866,14 @@ set emug_height [ expr {(150 / 1.333333) * $win_scale_fact} ]
 set axistextoffset [ expr {(20 / 1.333333) * $win_scale_fact * 0.50} ]
 set ticklen [ expr {(10 / 1.333333) * $win_scale_fact * 0.60} ]
 set xref [ expr {(75 / 1.333333) * $win_scale_fact * 0.90} ]
-
-
+if { [ string match "*dark*" $ttk::currentTheme ] } {
+set tcbackground black
+  } else {
+set tcbackground white
+}
 #canvas for black on white numbers
-.ed_mainFrame.tc configure -background white
-pack [ tkp::canvas .ed_mainFrame.tc.c -width $scale_width -height $tcc_height -background white -highlightthickness 0 ] -side top -anchor ne -padx [ list 0 [ expr {$scale_width * 0.05} ] ] -ipadx [ expr {$scale_width * 0.05} ]
+.ed_mainFrame.tc configure -background $tcbackground
+pack [ tkp::canvas .ed_mainFrame.tc.c -width $scale_width -height $tcc_height -background $tcbackground -highlightthickness 0 ] -side top -anchor ne -padx [ list 0 [ expr {$scale_width * 0.05} ] ] -ipadx [ expr {$scale_width * 0.05} ]
 #Adjust width and height in case frame has already been expanded
 set orig_width_percent [ expr {(floor([ expr {( [ winfo width .ed_mainFrame.tc ] - $scale_width) / $scale_width * 100}]) / 100)+1}]
 set orig_height_percent [ expr {(floor([ expr {( [ winfo height .ed_mainFrame.tc ] - $tcg_height) / $tcg_height * 100}]) / 100)+1}]
@@ -878,7 +881,7 @@ set scale_width [ expr {$scale_width * $orig_width_percent * 0.80 } ]
 set tcg_height [ expr {$tcg_height * $orig_height_percent} ]
 set emug_height [ expr {$emug_height * $orig_height_percent} ]
     #Emu graph canas
-   pack [ tkp::canvas .ed_mainFrame.tc.g -width $scale_width -height $tcg_height -background white -highlightthickness 0 ] -fill both -expand 1 -side left  -padx [ list 0 [ expr {$scale_width * 0.05} ] ] -ipadx [ expr {$scale_width * 0.05} ]
+   pack [ tkp::canvas .ed_mainFrame.tc.g -width $scale_width -height $tcg_height -background $tcbackground -highlightthickness 0 ] -fill both -expand 1 -side left  -padx [ list 0 [ expr {$scale_width * 0.05} ] ] -ipadx [ expr {$scale_width * 0.05} ]
     unset -nocomplain tc_scale
     foreach param {scale_width tcc_height tcg_height emug_height axistextoffset ticklen xref} { dict set tc_scale $param [ set $param ] }
     dict set tc_scale width [ winfo width .ed_mainFrame.tc.g ]
@@ -922,7 +925,18 @@ set emug_height [ expr {$emug_height * $orig_height_percent} ]
     #Set Up LCD Pixels for Canvas size X pixels by Y Pixels Pixel On Rim Colour, Pixel On Fill Colour, Pixel Off Rim Colour, Pixel Off Fill Colour
     #Black & White
     #7 x 87 is the number of pixels we create 7 in height and 87 in length. This remains fixed as we scale up pixel size.
-    LCD_Pixels 7 87 #626262 #626262 white white $win_scale_fact
+if { [ string match "*dark*" $ttk::currentTheme ] } {
+    set onrim white
+    set onfill white
+    set offrim black
+    set offfill black
+    } else {
+    set onrim #626262 
+    set onfill #626262 
+    set offrim white
+    set offfill white
+    }
+    LCD_Pixels 7 87 $onrim $onfill $offrim $offfill $win_scale_fact
     #Add same padding
     set varLCDx 3
     set varLCDy 3

--- a/src/generic/gentheme.tcl
+++ b/src/generic/gentheme.tcl
@@ -1,30 +1,40 @@
-proc tilestyle { defaultBackground icons } {
+proc tilestyle { defaultBackground icons theme } {
+	if { ![ string match "*dark*" $theme ] } {
+	set fieldbackground white
+	set foreground black
+	set selectedbackground [ list selected [ dict get $icons defaultBackground ] ]
+	} else {
+	set fieldbackground $defaultBackground
+	set foreground white
+	set selectedbackground [ list selected black ]
+	}
     #Set Tile styles common to both fixed and scaling
     ttk::style configure TFrame -background $defaultBackground
     ttk::style configure Heading -font TkDefaultFont
-    ttk::style configure Treeview -background white
-    ttk::style configure Treeview -fieldbackground white
-    ttk::style map Treeview -background [ list selected [ dict get $icons defaultBackground ] ]
+    ttk::style configure Treeview -background $fieldbackground
+    ttk::style configure Treeview -fieldbackground $fieldbackground
+    ttk::style configure Treeview -borderwidth 0
+    ttk::style map Treeview -background $selectedbackground
     ttk::style map Treeview -foreground [ list selected "#FF7900"]
     ttk::style configure TProgressbar -troughcolor [ dict get $icons defaultBackground ]
     ttk::style configure TProgressbar -lightcolor "#FF7900"
     ttk::style configure TProgressbar -darkcolor "#FF7900"
     ttk::style configure TProgressbar -bordercolor "#FF7900"
     ttk::style configure TSpinbox -selectbackground [ dict get $icons defaultBackground ]
-    ttk::style configure TSpinbox -fieldbackground white
+    ttk::style configure TSpinbox -fieldbackground $fieldbackground
     ttk::style configure TSpinbox -background [ dict get $icons defaultBackground ]
-    ttk::style configure TSpinbox -foreground black
+    ttk::style configure TSpinbox -foreground $foreground
     ttk::style configure TSpinbox -selectforeground "#FF7900"
     ttk::style configure TEntry -selectbackground [ dict get $icons defaultBackground ]
-    ttk::style configure TEntry -fieldbackground white
+    ttk::style configure TEntry -fieldbackground $fieldbackground
     ttk::style configure TEntry -background [ dict get $icons defaultBackground ]
-    ttk::style configure TEntry -foreground black
+    ttk::style configure TEntry -foreground $foreground
     ttk::style configure TEntry -selectforeground "#FF7900"
     ttk::style configure TEntry -borderwidth 0
     ttk::style configure TPanedwindow -background $defaultBackground
     ttk::style configure TButton -relief flat
     ttk::style map TButton -background [ list active "#FF7900" ]
-}
+    }
 
 proc framesizes { win_scale_fact } {
     global tabix tabiy mainx mainy mainminx mainminy mainmaxx mainmaxy
@@ -56,14 +66,13 @@ proc initfixedtheme { theme } {
     }
     ttk::setTheme $theme
     configmessagebox $theme
-    set iconset iconicgray
     set icons [ create_icon_images $iconset ]
     set iconhighlight iconicorange 
     set iconalt [ create_icon_images $iconhighlight ]
     dict set icons defaultBackground $defaultBackground
     dict set icons defaultForeground $defaultForeground
     #set Tile Styles
-    tilestyle $defaultBackground $icons
+    tilestyle $defaultBackground $icons $theme
 }
 
 proc initscaletheme {theme pixelsperpoint} {
@@ -78,10 +87,17 @@ proc initscaletheme {theme pixelsperpoint} {
     ::themeutils::setHighlightColor $theme "#FF7900"
     ::themeutils::setThemeColors $theme graphics.color #FF7900 focus.color #FF7900
     #Set scrollbar colors for awlight and breeze to the same as arc theme
+	if { ![ string match "*dark*" $theme ] } {
     ::themeutils::setThemeColors $theme scrollbar.active #d3d4d8
     ::themeutils::setThemeColors $theme scrollbar.color #b8babf
     ::themeutils::setThemeColors $theme scrollbar.pressed #FF7900
     ::themeutils::setThemeColors $theme scrollbar.trough #eff0f1
+    	} else {
+    ::themeutils::setThemeColors $theme scrollbar.active #d3d4d8
+    ::themeutils::setThemeColors $theme scrollbar.color [ ttk::style lookup TFrame -background ]
+    ::themeutils::setThemeColors $theme scrollbar.pressed #FF7900
+    ::themeutils::setThemeColors $theme scrollbar.trough black
+	}
     ::themeutils::setThemeColors $theme \
         style.progressbar rounded-line \
         style.scale circle-rev \
@@ -124,18 +140,27 @@ proc initscaletheme {theme pixelsperpoint} {
     set iconhighlight iconicorange
     set iconalt [ create_icon_images $iconhighlight ]
     #svg icons
+	if { ![ string match "*dark*" $theme ] } {
     set iconsetsvg iconicgraysvg
+	} else {
+    set iconsetsvg iconicwhitesvg
+	}
+    #set iconsetsvg iconicgraysvg
     set iconssvg [ create_icon_images $iconsetsvg ]
     set iconhighlightsvg iconicorangesvg
     set iconaltsvg [ create_icon_images $iconhighlightsvg ]
     set defaultBackground [ ttk::style lookup TFrame -background ]
-    set defaultForeground black
+	if { ![ string match "*dark*" $theme ] } {
+    	set defaultForeground black
+	} else {
+    	set defaultForeground white
+	}
     dict set icons defaultBackground $defaultBackground
     dict set icons defaultForeground $defaultForeground
     dict set iconssvg defaultBackground $defaultBackground
     dict set iconssvg defaultForeground $defaultForeground
     #Set Tile styles
-    tilestyle $defaultBackground $icons
+    tilestyle $defaultBackground $icons $theme
     if { [ winfo pixels . 1i ] eq 96 } {
         font configure basic -size 10
         set treewidth 161
@@ -449,7 +474,7 @@ if {[dict exists $tmpgendict theme scaling ]} {
         #Using a scaling theme default is awlight on Linux and breeze on Windows
         #alternative themes are "awarc awbreeze awlight"
         set theme [dict get $tmpgendict theme scaletheme ]
-        if { $theme ni {awarc awbreeze awlight} } { 
+        if { $theme ni {awarc awbreeze awbreezedark awlight} } {
             #Options for Windows and Linux in case default is changed in future awtheme
             if {$tcl_platform(platform) == "windows"} {
                 set theme "awbreeze"

--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -331,9 +331,15 @@ proc load_virtual {}  {
         upvar #0 icons icons
         if { [ info exists icons ] } {
             #running in GUI get values from icons
+            if { [ string match "*dark*" $ttk::currentTheme ] } {
+            set textColor white
+            set fillColor black
+            set outlineColor [ dict get $icons defaultBackground ]
+            } else {   
             set textColor black
             set fillColor white
-            set outlineColor [ dict get $icons defaultBackground ] 
+            set outlineColor [ dict get $icons defaultBackground ]
+          }
         } else {
             #running in CLI set placeholder values to avoid variable does not exist
             set textColor black
@@ -376,16 +382,19 @@ proc load_virtual {}  {
         set scryarea [ expr {$yval + $rect_sz_fact}]
         set hdb_buff [ expr {$rect_sz_fact/10} ]
         set txt_buff [ expr {$rect_sz_fact/5} ]
-        set cnv [ canvas $trdwin.cv -background white -highlightthickness 0 -scrollregion \
+        if { [ string match "*dark*" $ttk::currentTheme ] } {
+	set vucnvbackground black
+	set vucnv2background black
+        } else {
+	set vucnvbackground white
+	set vucnv2background #dcdad5
+	}
+        set cnv [ canvas $trdwin.cv -background $vucnvbackground -highlightthickness 0 -scrollregion \
         "$rect_sz_fact $rect_sz_fact $scrxarea $scryarea" -yscrollcommand \
         "$trdwin.cv.cv2.scrollY set" -xscrollcommand "$trdwin.cv.scrollX set" \
         -xscrollincrement 50 -yscrollincrement 25 ]
         pack $cnv -fill both -expand 1
-        if { $ttk::currentTheme eq "black" } {
-            set cnv2 [ canvas $trdwin.cv.cv2 -width 11 -highlightthickness 0 -background #424242 ]
-        } else {
-            set cnv2 [ canvas $trdwin.cv.cv2 -width 11 -highlightthickness 0 -background #dcdad5 ]
-        }
+        set cnv2 [ canvas $trdwin.cv.cv2 -width 11 -highlightthickness 0 -background $vucnv2background ]
         pack $cnv2 -expand 0 -fill y -ipadx 0 -ipady 0 -padx 0 -pady 0 -side right
         set scr1 [ ttk::scrollbar $trdwin.cv.cv2.scrollY -orient vertical -command "$cnv yview" ]
         set scr2 [ ttk::scrollbar $trdwin.cv.scrollX -orient horizontal -command "$cnv xview" ]
@@ -400,7 +409,7 @@ proc load_virtual {}  {
                 if { $countuser < $usercount } {
                     set vuid $threadscreated($countuser)
                     if { $virtual_users eq [ expr $maxvuser - 1 ]  && $countuser eq 0} { set MON "-MONITOR" } else { set MON "" }
-                    if { $ttk::currentTheme in {clearlooks awarc awbreeze awlight}} {
+                    if { $ttk::currentTheme in {clearlooks awarc awbreeze awlight awbreezedark}} {
                         $cnv create text [expr $x+$rect_sz_fact] [expr $y+$hdb_buff] \
         -text "Virtual User [expr $countuser + 1]$MON" -font \
          [ list basic [ expr [ font actual basic -size ] - 1 ] ] -fill $textColor

--- a/src/oracle/oramet.tcl
+++ b/src/oracle/oramet.tcl
@@ -6,7 +6,7 @@ namespace eval oramet {
     variable firstconnect "true"
 
     proc create_metrics_screen { } {
-        global public metframe win_scale_fact
+        global public metframe win_scale_fact defaultBackground
         upvar #0 env e
         set metframe .ed_mainFrame.me
         if {  [ info exists hostname ] } { ; } else { set hostname "localhost" }
@@ -20,8 +20,8 @@ namespace eval oramet {
         set public(p_x) [ expr {round((600/1.333333)*$win_scale_fact)} ]
         set public(p_y) [ expr {round((654/1.333333)*$win_scale_fact)} ]
         if { ![winfo exists .ed_mainFrame.me.m] } {
-            frame $main -background  $public(bg) -borderwidth 0 
-            frame $main.f -background  $public(bg) -borderwidth 0 ;# frame, use frame to put tiled windows
+            frame $main -background  $defaultBackground -borderwidth 0 
+            frame $main.f -background $public(bg) -borderwidth 0 ;# frame, use frame to put tiled windows
             pack $main                           -expand true -fill both 
             pack [ ttk::sizegrip $main.grip ] -side bottom -anchor se
             pack $main.f                         -expand true -fill both  
@@ -186,7 +186,7 @@ namespace eval oramet {
 
     proc ash_init { { display  0 } } {
         upvar #0 env e
-        global public
+        global public defaultBackground
         set cur_proc ash_init 
         if { [ catch {
                 set ash_frame     $public(main).f.a
@@ -296,8 +296,8 @@ namespace eval oramet {
 
                 mon_execute ashtime
                 $public(ash,sqltbl) cellselection clear 0,0 end,end
-                $public(ash,sqltbl) configure -selectbackground #FF7900
-                $public(ash,sqltbl) configure -selectforeground black 
+                $public(ash,sqltbl) configure -selectbackground $public(bg)
+                $public(ash,sqltbl) configure -selectforeground #FF7900
                 $public(ash,sqltbl) configure -activestyle none 
         #} err ] } { ; }
     }
@@ -358,7 +358,7 @@ namespace eval oramet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
          -columns " $collist " \
 	 -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -369,8 +369,9 @@ namespace eval oramet {
             if { [ $public(ash,sestbl) containing $tablelist::y] > -1 } {
                 set id  [ $public(ash,sestbl) cellcget [ $public(ash,sestbl) containing [subst $tablelist::y]],sid -text]
                 $public(ash,sestbl) cellselection clear 0,0 end,end
-                $public(ash,sestbl) configure -selectbackground  white
-                $public(ash,sestbl) configure -selectforeground  black 
+                $public(ash,sestbl) configure -selectbackground  $public(bg)
+                $public(ash,sestbl) configure -selectforeground  #FF7900
+                $public(ash,sestbl) configure -activestyle none 
                 $public(ash,output) delete 0.0 end
                 #$public(ash,output) insert  insert "   working ... "
                 pack forget $public(ash,details_buttons).sql
@@ -386,8 +387,8 @@ namespace eval oramet {
                 clipboard append $id
             } else {
                 $public(ash,sestbl) cellselection clear 0,0 end,end
-                $public(ash,sestbl) configure -selectbackground  white
-                $public(ash,sestbl) configure -selectforeground  black
+                $public(ash,sestbl) configure -selectbackground  $public(bg)
+                $public(ash,sestbl) configure -selectforeground  $public(fg)
             }
         }
         if {[$tbl cget -selectborderwidth] == 0} { $tbl configure -spacing 1 }
@@ -424,7 +425,7 @@ namespace eval oramet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
          -columns " $collist " \
 	 -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -447,22 +448,22 @@ namespace eval oramet {
                 set public(ash,realsqlid) $id
                 ash_sqltxt  $id
                 if { "$public(ash,overtimeid)" == "$id" } {
-                    $public(ash,sqltbl) configure -selectbackground  #FF7900 
-                    $public(ash,sqltbl) configure -selectforeground  black 
+                    $public(ash,sqltbl) configure -selectbackground  $public(bg)
+                    $public(ash,sqltbl) configure -selectforeground  #FF7900 
                     update idletasks
                     sqlovertime $id
                     set public(ash,overtimeid) -1
                 } else { 
-                    $public(ash,sqltbl) configure -selectbackground #FF7900
-                    $public(ash,sqltbl) configure -selectforeground  black 
+                    $public(ash,sqltbl) configure -selectbackground  $public(bg) 
+                    $public(ash,sqltbl) configure -selectforeground  #FF7900 
                     update idletasks
                     set public(ash,overtimeid) $id 
                     sqlovertime clear
                 }
             } else {
                 $public(ash,sqltbl) cellselection clear 0,0 end,end
-                $public(ash,sqltbl) configure -selectbackground  white
-                $public(ash,sqltbl) configure -selectforeground  black 
+                $public(ash,sqltbl) configure -selectbackground $public(bg) 
+                $public(ash,sqltbl) configure -selectforeground #FF7900
                 sqlovertime clear
             }
         }
@@ -505,7 +506,7 @@ namespace eval oramet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
          -columns " $collist " \
 	 -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -542,7 +543,7 @@ namespace eval oramet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
          -columns " $collist " \
 	 -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -577,7 +578,7 @@ namespace eval oramet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
          -columns " $collist " \
 	 -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -588,8 +589,9 @@ namespace eval oramet {
             if { [ $public(ash,evttbl) containing $tablelist::y] > -1 } {
                 set id  [ $public(ash,evttbl) cellcget [ $public(ash,evttbl) containing [subst $tablelist::y]],id -text]
                 $public(ash,evttbl) cellselection clear 0,0 end,end
-                $public(ash,evttbl) configure -selectbackground  white
-                $public(ash,evttbl) configure -selectforeground  black 
+                $public(ash,evttbl) configure -selectbackground  $public(bg)
+                $public(ash,evttbl) configure -selectforeground  #FF7900
+                $public(ash,evttbl) configure -activestyle none 
 
 
                 $public(ash,output) delete 0.0 end
@@ -601,8 +603,8 @@ namespace eval oramet {
                 clipboard append $id
             } else {
                 $public(ash,evttbl) cellselection clear 0,0 end,end
-                $public(ash,evttbl) configure -selectbackground  white
-                $public(ash,evttbl) configure -selectforeground  black
+                $public(ash,evttbl) configure -selectbackground  $public(bg)
+                $public(ash,evttbl) configure -selectforeground  $public(fg)
             }
         }
         if {[$tbl cget -selectborderwidth] == 0} { $tbl configure -spacing 1 }
@@ -627,7 +629,7 @@ namespace eval oramet {
         global public
         set cur_proc  createSesFrame
         if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set delta $public(ashtbl,delta)
                 set total  [$tbl cellcget $row,activity -text]
@@ -643,7 +645,7 @@ namespace eval oramet {
                 }
                 set total [$tbl cellcget $row,activity -text]
                 set act [ format "%3.0f" [ expr ceil(100 *  $total  / ($delta)) ] ]
-                label $w.t$row -text $act -font $public(medfont)
+                label $w.t$row -text $act -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
                 set pc [ expr (($total + 0.0)/($delta )) * (100.0/142)     ]
@@ -655,7 +657,7 @@ namespace eval oramet {
         global public
         set cur_proc  createSqlFrame
         if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set total  [$tbl cellcget $row,activity -text]
                 set colcnt [ $tbl columncount ] 
@@ -669,7 +671,7 @@ namespace eval oramet {
                 }
                 set total [$tbl cellcget $row,activity -text]
                 set aas [ format "%0.0f" [ expr 100 * ($total+0.0) / $public(sqltbl,maxActivity) ] ]
-                label $w.t$row -text $aas -font $public(medfont) 
+                label $w.t$row -text $aas -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
                 set pc [ expr (($total + 0.0)/$public(sqltbl,maxActivity) * (100.0/142) )   ]
@@ -682,7 +684,7 @@ namespace eval oramet {
         global public
         set cur_proc  createevtFrame
         if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set activity [$tbl cellcget $row,activity -text]
                 set total $public(ashevt,total) 
@@ -693,7 +695,7 @@ namespace eval oramet {
                 place $w.w$i -relheight 1.0
                 set i 1
                 set width [ format "%3.0f" $width ] 
-                label $w.w$i -text $width -font $public(medfont)
+                label $w.w$i -text $width -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
                 set pc [ expr (($activity + 0.0)/$total * (100.0/142) )   ]
@@ -1480,7 +1482,7 @@ namespace eval oramet {
         -barmode overlap               \
         -bg $public(bgt)                \
 	-borderwidth  0 \
-        -plotbackground white
+        -plotbackground $public(bg)
                 Blt_ActiveLegend $graph
                 #Crosshairs errors with position error
                 #Blt_Crosshairs $graph
@@ -1506,7 +1508,7 @@ namespace eval oramet {
                                          -color $public(fg)
                 #
                 $graph axis   configure y -title "Active Sessions (AAS)" -min 0.0 -max {} \
-                             -tickfont  $public(smallfont) -titlefont $public(smallfont) \
+                             -tickfont  $public(smallfont) -titlefont $public(smallfont) -titlecolor $public(fg) \
                                          -background $public(bgt) \
                                          -color $public(fg)
 
@@ -1514,7 +1516,7 @@ namespace eval oramet {
 
                 set marker1 [$public(ash,graph) marker create polygon\
            -coords {-Inf Inf Inf Inf Inf -Inf -Inf -Inf} -fill {} \
-           -fill #E0E0E0 \
+           -fill $public(graphselect) \
            -under 1  \
            -hide 1
                 ]
@@ -1599,11 +1601,12 @@ namespace eval oramet {
         set cur_proc   outputsetup
         if { [ catch {
                 set   output    $public(ash,output_frame).txt
-                frame $output   -bd 0  -relief flat -bg $public(bgt)
+                frame $output   -bd 0  -relief flat -bg $public(bg)
                 frame $output.f
                 text $output.w  -yscrollcommand "$output.scrolly set" \
                   -xscrollcommand "$output.scrollx set" \
                   -width $public(cols) -height 26    \
+		  -background $public(bg) \
                   -wrap word \
 		  -font {basic}
                 ttk::scrollbar $output.scrolly -command "$output.w yview"
@@ -3260,8 +3263,15 @@ Order by tcnt, ash.sql_id, ash.cnt
         set public(pale_brown)        #EFD0B2
         set public(pale_ochre)        #FECA58
         set public(pale_brown)        #F0A06A
+	if { [ string match "*dark*" $ttk::currentTheme ] } {
+        set public(fg)        white
+        set public(bg)        black
+	set public(graphselect) $defaultBackground
+        } else {
         set public(fg)        black
-        set public(bg)        $defaultBackground
+        set public(bg)        white
+	set public(graphselect) #E0E0E0
+	}
         set public(bgt)       $defaultBackground
         set public(fga)       yellow
         set public(fgsm)      $public(pale_warmgrey)

--- a/src/postgresql/pgmet.tcl
+++ b/src/postgresql/pgmet.tcl
@@ -4,7 +4,7 @@ namespace eval pgmet {
     variable firstconnect "true"
 
     proc create_metrics_screen { } {
-        global public metframe win_scale_fact
+        global public metframe win_scale_fact defaultBackground
         upvar #0 env e
         set metframe .ed_mainFrame.me
         if { [ info exists hostname ] } { ; } else { set hostname "localhost" }
@@ -18,7 +18,7 @@ namespace eval pgmet {
         set public(p_x) [ expr {round((600/1.333333)*$win_scale_fact)} ]
         set public(p_y) [ expr {round((654/1.333333)*$win_scale_fact)} ]
         if { ![winfo exists .ed_mainFrame.me.m] } {
-            frame $main -background $public(bg) -borderwidth 0 
+            frame $main -background $defaultBackground -borderwidth 0 
             frame $main.f -background $public(bg) -borderwidth 0 ;# frame, use frame to put tiled windows
             pack $main                            -expand true -fill both 
             pack [ ttk::sizegrip $main.grip ]     -side bottom -anchor se
@@ -304,8 +304,8 @@ namespace eval pgmet {
 
                 mon_execute ashtime
                 $public(ash,sqltbl) cellselection clear 0,0 end,end
-                $public(ash,sqltbl) configure -selectbackground #FF7900
-                $public(ash,sqltbl) configure -selectforeground black 
+                $public(ash,sqltbl) configure -selectbackground $public(bg)
+                $public(ash,sqltbl) configure -selectforeground #FF7900
                 $public(ash,sqltbl) configure -activestyle none 
         #} err ] } { ; }
     }
@@ -380,7 +380,8 @@ namespace eval pgmet {
         }
 
         tablelist::tablelist $tbl \
-         -background white \
+         -background $public(bg) \
+         -foreground $public(fg) \
          -columns " $collist " \
          -labelrelief flat \
          -font $public(medfont) -setgrid no \
@@ -406,8 +407,9 @@ namespace eval pgmet {
                 #puts "call ses_tbl, CPU:$CPU, BCPU:$BCPU, LWLock:$LWLock"
 
                 $public(ash,sestbl) cellselection clear 0,0 end,end
-                $public(ash,sestbl) configure -selectbackground  white
-                $public(ash,sestbl) configure -selectforeground  black 
+                $public(ash,sestbl) configure -selectbackground $public(bg) 
+                $public(ash,sestbl) configure -selectforeground #FF7900
+		$public(ash,sestbl) configure -activestyle none
                 $public(ash,output) delete 0.0 end
                 #$public(ash,output) insert  insert "   working ... "
                 pack forget $public(ash,details_buttons).sql
@@ -424,8 +426,8 @@ namespace eval pgmet {
                 clipboard append $id
             } else {
                 $public(ash,sestbl) cellselection clear 0,0 end,end
-                $public(ash,sestbl) configure -selectbackground  white
-                $public(ash,sestbl) configure -selectforeground  black
+                $public(ash,sestbl) configure -selectbackground $public(bg)
+                $public(ash,sestbl) configure -selectforeground $public(fg)
             }
         }
 
@@ -467,7 +469,8 @@ namespace eval pgmet {
         }
 
         tablelist::tablelist $tbl \
-    -background white \
+    -background $public(bg) \
+    -foreground $public(fg) \
     -columns " $collist " \
     -labelrelief flat \
     -font $public(medfont) -setgrid no \
@@ -490,22 +493,22 @@ namespace eval pgmet {
                 set public(ash,realsqlid) $id
                 ash_sqltxt $id
                 if { "$public(ash,overtimeid)" == "$id" } {
-                    $public(ash,sqltbl) configure -selectbackground #FF7900 
-                    $public(ash,sqltbl) configure -selectforeground black 
+                    $public(ash,sqltbl) configure -selectbackground $public(bg)
+                    $public(ash,sqltbl) configure -selectforeground #FF7900 
                     update idletasks
                     sqlovertime $id
                     set public(ash,overtimeid) -1
                 } else { 
-                    $public(ash,sqltbl) configure -selectbackground #FF7900
-                    $public(ash,sqltbl) configure -selectforeground black 
+                    $public(ash,sqltbl) configure -selectbackground $public(bg)
+                    $public(ash,sqltbl) configure -selectforeground #FF7900
                     update idletasks
                     set public(ash,overtimeid) $id 
                     sqlovertime clear
                 }
             } else {
                 $public(ash,sqltbl) cellselection clear 0,0 end,end
-                $public(ash,sqltbl) configure -selectbackground white
-                $public(ash,sqltbl) configure -selectforeground black 
+                $public(ash,sqltbl) configure -selectbackground $public(bg)
+                $public(ash,sqltbl) configure -selectforeground #FF7900
                 sqlovertime clear
             }
         }
@@ -548,7 +551,8 @@ namespace eval pgmet {
             set collist "$collist 0 $col left "
         }
         tablelist::tablelist $tbl \
-    -background white \
+    -background $public(bg) \
+    -foreground $public(fg) \
     -columns " $collist " \
     -labelrelief flat \
     -font $public(medfont) -setgrid no \
@@ -585,7 +589,8 @@ namespace eval pgmet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-    -background white \
+    -background $public(bg) \
+    -foreground $public(fg) \
     -columns " $collist " \
     -labelrelief flat \
     -font $public(medfont) -setgrid no \
@@ -620,7 +625,8 @@ namespace eval pgmet {
             set collist  "$collist  0 $col left "
         }
         tablelist::tablelist $tbl \
-    -background white \
+    -background $public(bg) \
+    -foreground $public(fg) \
     -columns " $collist " \
     -labelrelief flat \
     -font $public(medfont) -setgrid no \
@@ -631,8 +637,9 @@ namespace eval pgmet {
             if { [ $public(ash,evttbl) containing $tablelist::y] > -1 } {
                 set id [ $public(ash,evttbl) cellcget [ $public(ash,evttbl) containing [subst $tablelist::y]],id -text]
                 $public(ash,evttbl) cellselection clear 0,0 end,end
-                $public(ash,evttbl) configure -selectbackground  white
-                $public(ash,evttbl) configure -selectforeground  black 
+                $public(ash,evttbl) configure -selectbackground  $public(bg)
+                $public(ash,evttbl) configure -selectforeground  #FF7900
+                $public(ash,evttbl) configure -activestyle none 
                 $public(ash,output) delete 0.0 end
                 #$public(ash,output) insert insert "   working ... "
                 $public(ash,output) insert insert "   session id $id "
@@ -642,8 +649,8 @@ namespace eval pgmet {
                 clipboard append $id
             } else {
                 $public(ash,evttbl) cellselection clear 0,0 end,end
-                $public(ash,evttbl) configure -selectbackground  white
-                $public(ash,evttbl) configure -selectforeground  black
+                $public(ash,evttbl) configure -selectbackground $public(bg)
+                $public(ash,evttbl) configure -selectforeground $public(fg)
             }
         }
         if {[$tbl cget -selectborderwidth] == 0} { $tbl configure -spacing 1 }
@@ -667,7 +674,7 @@ namespace eval pgmet {
         global public
         set cur_proc  createSesFrame
         if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set delta $public(ashtbl,delta)
                 set total  [$tbl cellcget $row,activity -text]
@@ -683,7 +690,7 @@ namespace eval pgmet {
                 }
                 set total [$tbl cellcget $row,activity -text]
                 set act [ format "%3.0f" [ expr ceil(100 *  $total  / ($delta)) ] ]
-                label $w.t$row -text $act -font $public(medfont)
+                label $w.t$row -text $act -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
                 set pc [ expr (($total + 0.0)/($delta )) * (100.0/142) ]
@@ -694,25 +701,27 @@ namespace eval pgmet {
     proc createSqlFrame {tbl row col w } { 
         global public
         set cur_proc  createSqlFrame
-        if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+        if { [ catch {
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set total  [$tbl cellcget $row,activity -text]
+		set originialtotal $total
                 set colcnt [ $tbl columncount ] 
-                for { set i 5 } { $i <  $colcnt  } { incr  i } {
+                for { set i 4 } { $i <  $colcnt  } { incr  i } {
                     set sz [$tbl cellcget $row,$i -text]
                     set name [ lindex [ $tbl columnconfigure $i -name ] end ]
                     set szpct [ expr {$total * 100 / $public(sqltbl,maxActivity) }]
                     frame $w.w$i -width $szpct -background $public(ashgroup,$name) -borderwidth 0 -relief flat
                     place $w.w$i -relheight 1.0
-                    set total [ expr $total - $sz ]
+		    #catch setting total in case sz invalid and prevents total showing over bar
+                    catch {set total [ expr $total - $sz ]}
                 }
                 set total [$tbl cellcget $row,activity -text]
                 set aas [ format "%0.0f" [ expr 100 * ($total+0.0) / $public(sqltbl,maxActivity) ] ]
-                label $w.t$row -text $aas -font $public(medfont) 
+                label $w.t$row -text $aas -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
-                set pc [ expr (($total + 0.0)/$public(sqltbl,maxActivity) * (100.0/142) )   ]
+                set pc [ expr (($total+0.0)/$public(sqltbl,maxActivity) * (100.0/142) )   ]
                 place $w.t$row -relheight 1.0 -relx $pc
         } err ] } { ; }
     }
@@ -721,7 +730,7 @@ namespace eval pgmet {
         global public
         set cur_proc  createevtFrame
         if { [ catch { 
-                frame $w -width 142 -height 14 -background white -borderwidth 0 -relief flat
+                frame $w -width 142 -height 14 -background $public(bg) -borderwidth 0 -relief flat
                 bindtags $w [lreplace [bindtags $w] 1 1 TablelistBody]
                 set activity [$tbl cellcget $row,activity -text]
                 set total $public(ashevt,total) 
@@ -732,7 +741,7 @@ namespace eval pgmet {
                 place $w.w$i -relheight 1.0
                 set i 1
                 set width [ format "%3.1f" $width ] 
-                label $w.w$i -text $width -font $public(medfont)
+                label $w.w$i -text $width -font $public(medfont) -background $public(bg) -foreground $public(fg)
                 # cell is 140 wide, the bars should all be under 100
                 # put the activity value just above the bar
                 set pc [ expr (($activity + 0.0)/$total * (100.0/142) )   ]
@@ -1626,7 +1635,7 @@ namespace eval pgmet {
       -barmode overlap  \
       -bg $public(bgt)  \
       -borderwidth  0   \
-      -plotbackground white
+      -plotbackground $public(bg)
                 Blt_ActiveLegend $graph
                 #Crosshairs errors with position error
                 #Blt_Crosshairs $graph
@@ -1644,14 +1653,16 @@ namespace eval pgmet {
                 #
                 $graph axis   configure x -minorticks 0  \
                               -stepsize $public(ash,ticksize)  \
-                              -tickfont  $public(smallfont) -titlefont $public(smallfont) \
+                              -tickfont  $public(smallfont) \
+		              -titlefont $public(smallfont) \
+		              -titlecolor $public(fg) \
                               -background $public(bgt) \
                               -command cur_time      \
                               -bd 0      \
                               -color $public(fg)
                 #
                 $graph axis   configure y -title "Active Sessions (AAS)" -min 0.0 -max {} \
-                              -tickfont  $public(smallfont) -titlefont $public(smallfont) \
+                              -tickfont  $public(smallfont) -titlefont $public(smallfont) -titlecolor $public(fg) \
                               -background $public(bgt) \
                               -color $public(fg)
 
@@ -1659,7 +1670,7 @@ namespace eval pgmet {
 
                 set marker1 [$public(ash,graph) marker create polygon\
            -coords {-Inf Inf Inf Inf Inf -Inf -Inf -Inf} -fill {} \
-           -fill #E0E0E0 \
+           -fill $public(graphselect) \
            -under 1  \
            -hide 1
                 ]
@@ -1745,9 +1756,9 @@ namespace eval pgmet {
         set cur_proc   outputsetup
         if { [ catch {
                 set   output    $public(ash,output_frame).txt
-                frame $output   -bd 0  -relief flat -bg $public(bgt)
+                frame $output   -bd 0  -relief flat -bg $public(bg)
                 frame $output.f
-                text $output.w  -background white \
+                text $output.w  -background $public(bg) \
     		    -yscrollcommand "$output.scrolly set" \
                     -xscrollcommand "$output.scrollx set" \
                     -width $public(cols) -height 26    \
@@ -3162,8 +3173,15 @@ namespace eval pgmet {
                     set public(pale_brown)        #EFD0B2
                     set public(pale_ochre)        #FECA58
                     set public(pale_brown)        #F0A06A
+                    if { [ string match "*dark*" $ttk::currentTheme ] } {
+                    set public(fg)        white
+                    set public(bg)        black
+                    set public(graphselect) $defaultBackground
+                    } else {
                     set public(fg)        black
-                    set public(bg)        $defaultBackground
+                    set public(bg)        white
+                    set public(graphselect) #E0E0E0
+                    }
                     set public(bgt)       $defaultBackground
                     set public(fga)       yellow
                     set public(fgsm)      $public(pale_warmgrey)


### PR DESCRIPTION
As discussed in https://github.com/TPC-Council/HammerDB/issues/751 PR adds awbreezedark theme option to both Windows and Linux. PR restores the dark theme option lost when moving to SVG graphics, however new dark theme also now uses SVG graphics so continues to scale on UHD displays for both light and dark options (tested on Surface Book display). 

For testing option can be selected by changing the scaletheme option in genericxml to awbreezedark.
```
<?xml version="1.0" encoding="utf-8"?>
<hammerdb>
   <theme>
        <scaling>auto</scaling>
        <scaletheme>awbreezedark</scaletheme>
        <pixelsperpoint>auto</pixelsperpoint>
   </theme>
...
```
<img width="612" alt="breezedark" src="https://github.com/user-attachments/assets/94cdfb00-3b5b-4371-8c87-de7c531be5ea">
