### PR TITLE
Free thread shared variables after xtprof run

### DIFF
--- a/modules/xtprof-1.0.tm
+++ b/modules/xtprof-1.0.tm
@@ -465,6 +465,10 @@ foreach sproc $sprocorder {
 	}
         puts $fd "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+"
 close $fd
+catch {tsv::unset allvutimings}
+catch {tsv::unset allclicktimings}
+unset -nocomplain sumtimings
+unset -nocomplain monitortimings
 }
     
 proc xttimeprofdump {myposition} {


### PR DESCRIPTION
PR unsets dicts and thread shared variables used to gather timing data for the xtprof time profiler after each run and the timing data has been reported. There is also a check to see if the thread shared variables exist at the start of a run which remains. 
Virtual user independent profiler array is already unset after use.