### PR TITLE
Copyright message UTF-8

### DIFF
--- a/hammerdbcli
+++ b/hammerdbcli
@@ -30,7 +30,7 @@ exec ./bin/tclsh9.0 "$0" ${1+"$@"}
 global hdb_version
 set hdb_version "v5.0"
 puts "HammerDB CLI $hdb_version"
-puts "Copyright \251 HammerDB Ltd hosted by tpc.org 2019-2025"
+puts "Copyright \xc2\xa9 HammerDB Ltd hosted by tpc.org 2019-2025"
 if { $argc eq 0 } {
 set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
 if { $argv0 == "" || $argv0 == "tcl" || $argv0 == "auto" } {

--- a/hammerdbws
+++ b/hammerdbws
@@ -34,7 +34,7 @@ global hdb_version
 set hdb_version "v5.0"
 	if { $argv0 != "gui" } {
 puts "HammerDB Web Service $hdb_version"
-puts "Copyright \251 HammerDB Ltd hosted by tpc.org 2019-2025"
+puts "Copyright \xc2\xa9 HammerDB Ltd hosted by tpc.org 2019-2025"
 puts "Type \"help\" for a list of commands"
 	}
 set UserDefaultDir [ file dirname [ info script ] ]


### PR DESCRIPTION
Makes the copyright notice valid UTF-8

Closes: https://github.com/TPC-Council/HammerDB/issues/793