### PR TITLE
Fix permission denied on loading database libraries on Windows

### DIFF
--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -457,35 +457,35 @@ proc vuset { args } {
                 remote_command [ concat vuset vu $val ]
             }
             delay {
-                set conpause $val
-                if { ![string is integer -strict $conpause] } {
-                    tk_messageBox -message "User Delay(ms) must be an integer"
-                    puts -nonewline "setting to value: "
-                    set conpause 500
-                } else {
-                    if { $conpause < 1 } { tk_messageBox -message "User Delay(ms) must be 1 or greater"
-                        puts -nonewline "setting to value: "
-                        set conpause 500
-                    }
-                }
-		dict set genericdict $dct "user_delay" $conpause
-                SQLiteUpdateKeyValue $db $dct "user_delay" $conpause
-                remote_command [ concat vuset delay $val ]
-            }
-            repeat {
                 set delayms $val
                 if { ![string is integer -strict $delayms] } {
-                    tk_messageBox -message "Repeat Delay(ms) must be an integer"
+                    tk_messageBox -message "User Delay(ms) must be an integer"
                     puts -nonewline "setting to value: "
                     set delayms 500
                 } else {
-                    if { $delayms < 1 } { tk_messageBox -message "Repeat Delay(ms) must be 1 or greater"
+                    if { $delayms < 0 } { tk_messageBox -message "User Delay(ms) must be 0 or greater"
                         puts -nonewline "setting to value: "
                         set delayms 500
                     }
                 }
-		dict set genericdict $dct "repeat_delay" $delayms
-                SQLiteUpdateKeyValue $db $dct "repeat_delay" $delayms
+		dict set genericdict $dct "user_delay" $delayms
+                SQLiteUpdateKeyValue $db $dct "user_delay" $delayms
+                remote_command [ concat vuset delay $val ]
+            }
+            repeat {
+                set conpause $val
+                if { ![string is integer -strict $conpause] } {
+                    tk_messageBox -message "Repeat Delay(ms) must be an integer"
+                    puts -nonewline "setting to value: "
+                    set conpause 500
+                } else {
+                    if { $conpause < 0 } { tk_messageBox -message "Repeat Delay(ms) must be 0 or greater"
+                        puts -nonewline "setting to value: "
+                        set conpause 500
+                    }
+                }
+		dict set genericdict $dct "repeat_delay" $conpause
+                SQLiteUpdateKeyValue $db $dct "repeat_delay" $conpause
                 remote_command [ concat vuset repeat $val ]
             }
             iterations {
@@ -848,7 +848,7 @@ proc print { args } {
                 pdict 2 $genericdict
             }
             vuconf {
-                foreach i { "Virtual Users" "User Delay(ms)" "Repeat Delay(ms)" "Iterations" "Show Output" "Log Output" "Unique Log Name" "No Log Buffer" "Log Timestamps" } j { virtual_users conpause delayms ntimes suppo optlog unique_log_name no_log_buffer log_timestamps } {
+                foreach i { "Virtual Users" "User Delay(ms)" "Repeat Delay(ms)" "Iterations" "Show Output" "Log Output" "Unique Log Name" "No Log Buffer" "Log Timestamps" } j { virtual_users delayms conpause ntimes suppo optlog unique_log_name no_log_buffer log_timestamps } {
                     puts "$i = [ set $j ]"
                 }
             }

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -1927,7 +1927,7 @@ proc vuser_options {} {
             set ntimes 1
         }
         #Save new values to SQLite
-	set genericdict [ dict replace $genericdict virtual_user_options [ subst { virtual_users $virtual_users user_delay $conpause repeat_delay $delayms iterations $ntimes show_output $suppo log_to_temp $optlog unique_log_name $unique_log_name no_log_buffer $no_log_buffer log_timestamps $log_timestamps }] ]
+	set genericdict [ dict replace $genericdict virtual_user_options [ subst { virtual_users $virtual_users user_delay $delayms repeat_delay $conpause iterations $ntimes show_output $suppo log_to_temp $optlog unique_log_name $unique_log_name no_log_buffer $no_log_buffer log_timestamps $log_timestamps }] ]
         Dict2SQLite "generic" $genericdict
         remote_command [ concat vuser_slave_ops $maxvuser $virtual_users $delayms $conpause $ntimes $suppo $optlog ]
         destroy .vuserop


### PR DESCRIPTION
As detailed in #791 a virtual user can report permission denied on Windows when loading a database library. 

This occurs when the virtual user thread attempts to open the library while it is still being created as Windows can only open libraries from a file system. 

Issue does not occur on Linux. 

Fix implements retry logic when loading a database library and if permission denied is received will clear up and retry the load.
 
Testing also showed that on occasions the package require failed but the package commands exist so test also checks if command exists and does the same clean up and retry. 

Tests show that with delay values of 0, libraries now load. 

PR also fixes mismatch of delay values introduced by https://github.com/TPC-Council/HammerDB/commit/5ff2f8aa0c98af733b4281308a4163e6cfee1928