### PR TITLE
Add catch to CLI stty command on Linux

### DIFF
--- a/modules/tclreadline-1.2.1.tm
+++ b/modules/tclreadline-1.2.1.tm
@@ -738,7 +738,7 @@ proc TclReadLine::rawInput {} {
     if {[string match windows $::tcl_platform(platform)]} {
         enableRaw
     } else {
-        stty raw -echo
+        catch { exec stty raw -echo }
     }
 }
 
@@ -748,7 +748,7 @@ proc TclReadLine::lineInput {} {
     if {[string match windows $::tcl_platform(platform)]} {
         disableRaw
     } else {
-        stty -raw echo
+        catch { exec stty -raw echo }
     }
 }
 


### PR DESCRIPTION
Adds catch to stty command for terminal reset so error not received if command cannot be found and/or is not needed when running from external script. 