### PR TITLE
Enable Web Service to run as SCGI application

### DIFF
--- a/hammerdbws
+++ b/hammerdbws
@@ -90,6 +90,9 @@ switch $argv0 {
 "gui" {
         start_webservice gui
 }
+"scgi" {
+        start_webservice scgi
+}
 "wait" {
         start_webservice wait
 }
@@ -105,6 +108,6 @@ switch $argv0 {
 	quit
 }
 default {
-puts stderr "Error starting HammerDB Web Service: argument should be start, stop, gui, wait or nowait"
+puts stderr "Error starting HammerDB Web Service: argument should be start, stop, gui, scgi, wait or nowait"
 }
 }

--- a/src/generic/genws.tcl
+++ b/src/generic/genws.tcl
@@ -54,67 +54,82 @@ proc env {} {
 
 proc wapp-page-env {} {
     wapp-allow-xorigin-params
-    wapp-subst {<link href="%url([wapp-param BASE_URL]/style.css)" rel="stylesheet">}
+    wapp-subst {<link href="%url(/style.css)" rel="stylesheet">}
     wapp-trim {
         <h1>Service Environment</h1>\n<pre>
         <pre>%html([wapp-debug-env])</pre>
     }
 }
 
+
 proc wapp-page-style.css {} {
+    wapp-mimetype text/css
     wapp-allow-xorigin-params
     wapp-subst {
-body {
-  margin-top: 0px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  background-color: transparent;
-  background-repeat: repeat-x;
-  background-attachment: scroll;
-  background-position: left top;
-  font-family: Roboto, sans-serif;
-  font-size: 12px;
-  color: #444444;
+  body {
+  margin: 0;
+  padding: 0;
+  padding-left: 20px;
+  background-color: #f9f9f9;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  color: #333;
+  line-height: 1.6;
 }
+
 h1, h2, h3 {
-  margin-top: 0px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  font-family: Roboto, sans-serif;
-  font-weight: normal;
-  color: #444444;
+  margin: 0 0 0.1em 0;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 500;
+  color: #222;
 }
+
 h1 {
-  font-size: 2em;
+  font-size: 2.5em;
 }
+
 h2 {
   font-size: 2em;
 }
+
 h3 {
-  font-size: 1.6em;
+  font-size: 1.5em;
 }
+
 p, ul, ol {
-  margin-top: 0px;
-  line-height: 125%;
+  margin: 0 0 1em 0;
 }
+
+ul, ol {
+  padding-left: 1.5em;
+  column-count: 1 !important;
+  column-width: auto !important;
+}
+
 table {
-  font-family: Roboto, sans-serif;
-  font-size: 12px;
-  color: #444444;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  color: #333;
   border-collapse: collapse;
-  width: 50%;
+  width: 100%;
+  max-width: 800px;
+  margin: 1em 0;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
 }
 
 td, th {
-  border: 1px solid #dddddd;
+  border: 1px solid #ccc;
   text-align: left;
-  padding: 2px;
+  padding: 10px;
+}
+
+th {
+  background-color: #f0f0f0;
+  font-weight: 600;
 }
 
 tr:nth-child(even) {
-  background-color: #dddddd;
+  background-color: #f9f9f9;
 }
 }
 }
@@ -190,6 +205,9 @@ proc start_webservice { args } {
 switch $args {
 "gui" {
         if [catch {wapp-start [ list --server $ws_port ]} message ] { }
+}
+"scgi" {
+        if [catch {wapp-start [ list --scgi $ws_port ]} message ] { }
 }
 "wait" {
         if [catch {wapp-start [ list --server $ws_port ]} message ] {


### PR DESCRIPTION
Pull request enable HammerDB web service to run as SCGI application tested under Nginx.

```
/etc/nginx/sites-available$ cat hammerdb
server {
    listen 8081;
    server_name _;

    location / {
        include scgi_params;
        scgi_pass 127.0.0.1:8080;

        proxy_hide_header Content-Security-Policy;  # Handle CSP with HammerDB

        proxy_set_header Accept-Encoding "";

        sub_filter_types text/html text/css application/javascript;
        sub_filter_once off;
        sub_filter 'http://' 'https://';
    }
}

/etc/nginx/sites-enabled$ ls -l
hammerdb -> /etc/nginx/sites-available/hammerdb

$ sudo nginx -t
$ sudo nginx -s reload
```
Run HammerDB web service with scgi argument

```
 ./hammerdbws scgi
HammerDB Web Service v5.0
Copyright © HammerDB Ltd hosted by tpc.org 2019-2025
Type "help" for a list of commands
Starting HammerDB Web Service on port 8080
Listening for SCGI requests on TCP port 8080 from IP 127.0.0.1
```
HammerDB content is served through Nginx 

<img width="985" height="997" alt="hammerdb_nginx" src="https://github.com/user-attachments/assets/11f79d62-a01a-4e16-9ad2-76409a503b98" />

Note additional fixes such as malformed JSON due to double quotes in TPROC-H output have also been included.