### PR TITLE
Disable FK checks for MariaDB/MySQL pre-created database builds

### DIFF
--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -106,6 +106,8 @@ proc CreateDatabase { maria_handler db } {
             puts "Database $db exists but is not empty, specify a new or empty database name"
             return false
         }
+	set sql(1) "SET FOREIGN_KEY_CHECKS = 0"
+            mariaexec $maria_handler $sql(1)
     } else {
         puts "CREATING DATABASE $db"
         set sql(1) "SET FOREIGN_KEY_CHECKS = 0"

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -521,6 +521,8 @@ proc CreateDatabase { maria_handler db } {
             puts "Database $db exists but is not empty, specify a new or empty database name"
             return false
         }
+	set sql(1) "SET FOREIGN_KEY_CHECKS = 0"
+            mariaexec $maria_handler $sql(1)
     } else {
         puts "CREATING DATABASE $db"
         set sql(1) "SET FOREIGN_KEY_CHECKS = 0"

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -170,6 +170,8 @@ proc CreateDatabase { mysql_handler db } {
             puts "Database $db exists but is not empty, specify a new or empty database name"
             return false
         }
+	set sql(1) "SET FOREIGN_KEY_CHECKS = 0"
+            mysqlexec $mysql_handler $sql(1)
     } else {
         puts "CREATING DATABASE $db"
         set sql(1) "SET FOREIGN_KEY_CHECKS = 0"

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -502,6 +502,8 @@ proc CreateDatabase { mysql_handler db } {
             puts "Database $db exists but is not empty, specify a new or empty database name"
             return false
         }
+	set sql(1) "SET FOREIGN_KEY_CHECKS = 0"
+            mysqlexec $mysql_handler $sql(1)
     } else {
         puts "CREATING DATABASE $db"
         set sql(1) "SET FOREIGN_KEY_CHECKS = 0"


### PR DESCRIPTION
Add disabling foreign key checks for MariaDB and MySQL databases when the database has been pre-created.
Foreign key checks are already disabled for created databases so PR implements same behaviour.