### PR TITLE
Improve message if metstart fails because sysstat not installed

### DIFF
--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -19,7 +19,7 @@ proc ConfigureNetworkDisplay {agentid agenthostname} {
         }
         #Test Agent Port
         namespace import socktest::*
-        puts "Connecting to HammerDB Agent @ $agenthostname:$agentid" 
+        puts "Connecting to HammerDB Agent @ $agenthostname:$agentid"
         puts -nonewline "Testing Agent Connectivity..."
         set result [ sockmesg [ socktest $agenthostname $agentid 1000 ]]
         #Test is OK so call agent to call back
@@ -32,7 +32,10 @@ proc ConfigureNetworkDisplay {agentid agenthostname} {
             }
         } else {
             puts $result
-            puts "Connection failed verify hostname and id @ $agenthostname:$agentid" 
+            puts "Connection failed verify agent hostname and id @ $agenthostname:$agentid"
+                if {$::tcl_platform(platform)!="windows"} {
+                puts "Check sysstat package is installed and mpstat command is available to agent"
+		}
             DoDisplay 1 "AGENT CONNECTION FAILED" local
             return
         } 

--- a/src/generic/genmetricscli.tcl
+++ b/src/generic/genmetricscli.tcl
@@ -196,7 +196,7 @@ proc ConfigureNetworkDisplayCLI {agentid agenthostname} {
         }
         #Test Agent Port
         namespace import socktest::*
-        putscli "Connecting to HammerDB Agent @ $agenthostname:$agentid" 
+        putscli "Connecting to HammerDB Agent @ $agenthostname:$agentid"
         puts -nonewline "Testing Agent Connectivity..."
         set result [ sockmesg [ socktest $agenthostname $agentid 1000 ]]
         #Test is OK so call agent to call back
@@ -209,7 +209,10 @@ proc ConfigureNetworkDisplayCLI {agentid agenthostname} {
             }
         } else {
             putscli $result
-            putscli "Connection failed verify hostname and id @ $agenthostname:$agentid" 
+            putscli "Connection failed verify agent hostname and id @ $agenthostname:$agentid"
+                if {$::tcl_platform(platform)!="windows"} {
+                putscli "Check sysstat package is installed and mpstat command is available to agent"
+                }
             DoDisplay 1 "AGENT CONNECTION FAILED" local
             return
         } 


### PR DESCRIPTION
Improves messaging if metstart command fails because agent fails to start when sysstat is not installed.
Add hint to check mpstat command runs. 
Fix not needed on Windows as mpstat included with HammerDB.