### PR TITLE
pg_vacuum runs on wrong database

### DIFF
--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2993,7 +2993,7 @@ switch $myposition {
                 } else {
                     pg_result $result -clear
                 }
-                set result [pg_exec $lda "vacuum" ]
+                set result [pg_exec $lda1 "vacuum" ]
                 if {[pg_result $result -status] ni {"PGRES_TUPLES_OK" "PGRES_COMMAND_OK"}} {
                     if { $RAISEERROR } {
                         error "[pg_result $result -error]"
@@ -3432,7 +3432,7 @@ switch $myposition {
                 } else {
                     pg_result $result -clear
                 }
-                set result [pg_exec $lda "vacuum" ]
+                set result [pg_exec $lda1 "vacuum" ]
                 if {[pg_result $result -status] ni {"PGRES_TUPLES_OK" "PGRES_COMMAND_OK"}} {
                     if { $RAISEERROR } {
                         error "[pg_result $result -error]"


### PR DESCRIPTION
Proposed Fix
Change $lda to $lda1 for the vacuum commands at lines 2996 and 3435. The checkpoint command can remain on $lda since CHECKPOINT is a cluster-wide operation.

fix #855