### PR TITLE
feat: Add Detailed System, Hardware, and Software Fields to Results (#848)

### DIFF
--- a/agent/agent
+++ b/agent/agent
@@ -117,6 +117,125 @@ puts "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-"
     }
 }
 
+proc DiscoverSystemWindows {} {
+global S cpu_model sysinfo
+set sysinfo [dict create]
+dict set sysinfo cpumodel $cpu_model
+dict set sysinfo cpucount $S(cpus)
+#OS Name and Version
+if { [catch {
+    set osver [twapi::get_os_version]
+    set osdesc [twapi::get_os_description]
+    dict set sysinfo os_name "$osdesc (Build [join $osver .])"
+} err] } {
+    dict set sysinfo os_name "Windows (version unavailable)"
+}
+#System Vendor and Type via WMI
+if { [catch {
+    set wmi [twapi::_wmi]
+    set items [$wmi ExecQuery "SELECT Manufacturer,Model FROM Win32_ComputerSystem"]
+    $items -iterate item {
+        dict set sysinfo system_vendor [$item -get Manufacturer]
+        dict set sysinfo system_type [$item -get Model]
+        $item destroy
+    }
+    $items destroy
+    $wmi destroy
+} err] } {
+    dict set sysinfo system_vendor "Unknown"
+    dict set sysinfo system_type "Unknown"
+}
+#Total Physical Memory via WMI
+if { [catch {
+    set wmi [twapi::_wmi]
+    set items [$wmi ExecQuery "SELECT TotalPhysicalMemory FROM Win32_ComputerSystem"]
+    $items -iterate item {
+        set totalmem [$item -get TotalPhysicalMemory]
+        set totalmem_gb [format "%.1f" [expr {$totalmem / 1073741824.0}]]
+        dict set sysinfo memory "${totalmem_gb} GB"
+        $item destroy
+    }
+    $items destroy
+    $wmi destroy
+} err] } {
+    dict set sysinfo memory "Unknown"
+}
+#NIC Information via WMI
+if { [catch {
+    set wmi [twapi::_wmi]
+    set items [$wmi ExecQuery "SELECT Description,Speed FROM Win32_NetworkAdapter WHERE NetConnectionStatus=2"]
+    set niclist [list]
+    $items -iterate item {
+        set nicdesc [$item -get Description]
+        if { [catch {set nicspeed [$item -get Speed]}] } {
+            set nicspeed "Unknown"
+        } else {
+            set nicspeed "[format "%.0f" [expr {$nicspeed / 1000000000.0}]] Gbps"
+        }
+        lappend niclist "$nicdesc ($nicspeed)"
+        $item destroy
+    }
+    $items destroy
+    $wmi destroy
+    dict set sysinfo nic [join $niclist "; "]
+} err] } {
+    dict set sysinfo nic "Unknown"
+}
+#Disk/Storage via WMI
+if { [catch {
+    set wmi [twapi::_wmi]
+    set items [$wmi ExecQuery "SELECT Model,Size FROM Win32_DiskDrive"]
+    set disklist [list]
+    $items -iterate item {
+        set diskmodel [$item -get Model]
+        if { [catch {set disksize [$item -get Size]}] } {
+            set disksize "Unknown"
+        } else {
+            set disksize "[format "%.0f" [expr {$disksize / 1073741824.0}]] GB"
+        }
+        lappend disklist "$diskmodel ($disksize)"
+        $item destroy
+    }
+    $items destroy
+    $wmi destroy
+    dict set sysinfo storage [join $disklist "; "]
+} err] } {
+    dict set sysinfo storage "Unknown"
+}
+#Cloud Instance Detection
+dict set sysinfo cloud_instance [DetectCloudInstance]
+return $sysinfo
+}
+
+proc DetectCloudInstance {} {
+#Detect cloud environment by checking metadata services
+#AWS
+if { [catch {
+    package require http
+    set tok [::http::geturl "http://169.254.169.254/latest/meta-data/instance-type" -timeout 1000]
+    set itype [::http::data $tok]
+    ::http::cleanup $tok
+    if { $itype ne "" } { return "AWS $itype" }
+} err] } { ; }
+#Azure
+if { [catch {
+    package require http
+    set tok [::http::geturl "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text" -timeout 1000 -headers [list Metadata true]]
+    set vmsize [::http::data $tok]
+    ::http::cleanup $tok
+    if { $vmsize ne "" } { return "Azure $vmsize" }
+} err] } { ; }
+#GCP
+if { [catch {
+    package require http
+    set tok [::http::geturl "http://metadata.google.internal/computeMetadata/v1/instance/machine-type" -timeout 1000 -headers [list Metadata-Flavor Google]]
+    set mtype [::http::data $tok]
+    ::http::cleanup $tok
+    if { $mtype ne "" } { return "GCP [file tail $mtype]" }
+} err] } { ; }
+return "Not Detected"
+}
+
 proc HowManyProcessorsLinux {} {
 global cpu_model
     set fin [open /proc/cpuinfo r]
@@ -133,6 +252,134 @@ global cpu_model
     break
 	}
     }
+}
+
+proc DiscoverSystemLinux {} {
+global S cpu_model sysinfo
+set sysinfo [dict create]
+dict set sysinfo cpumodel $cpu_model
+dict set sysinfo cpucount $S(cpus)
+#OS Name and Version
+if { [catch {
+    if { [file exists /etc/os-release] } {
+        set fin [open /etc/os-release r]
+        set data [read $fin]
+        close $fin
+        foreach line [split $data "\n"] {
+            if { [string match "PRETTY_NAME=*" $line] } {
+                regexp {PRETTY_NAME="?([^"]*)"?} $line all os_name
+                dict set sysinfo os_name $os_name
+                break
+            }
+        }
+    } else {
+        set os_name [exec uname -s -r]
+        dict set sysinfo os_name $os_name
+    }
+} err] } {
+    dict set sysinfo os_name "Linux (version unavailable)"
+}
+#System Vendor and Type
+if { [catch {
+    if { [file exists /sys/class/dmi/id/sys_vendor] } {
+        set fin [open /sys/class/dmi/id/sys_vendor r]
+        set vendor [string trim [read $fin]]
+        close $fin
+        dict set sysinfo system_vendor $vendor
+    } else {
+        dict set sysinfo system_vendor "Unknown"
+    }
+} err] } {
+    dict set sysinfo system_vendor "Unknown"
+}
+if { [catch {
+    if { [file exists /sys/class/dmi/id/product_name] } {
+        set fin [open /sys/class/dmi/id/product_name r]
+        set product [string trim [read $fin]]
+        close $fin
+        dict set sysinfo system_type $product
+    } else {
+        dict set sysinfo system_type "Unknown"
+    }
+} err] } {
+    dict set sysinfo system_type "Unknown"
+}
+#Total Memory from /proc/meminfo
+if { [catch {
+    set fin [open /proc/meminfo r]
+    set data [read $fin]
+    close $fin
+    foreach line [split $data "\n"] {
+        if { [string match "MemTotal:*" $line] } {
+            regexp {MemTotal:\s+(\d+)\s+kB} $line all memkb
+            set memgb [format "%.1f" [expr {$memkb / 1048576.0}]]
+            dict set sysinfo memory "${memgb} GB"
+            break
+        }
+    }
+} err] } {
+    dict set sysinfo memory "Unknown"
+}
+#NIC Information
+if { [catch {
+    set niclist [list]
+    set netdir "/sys/class/net"
+    if { [file exists $netdir] } {
+        foreach iface [glob -nocomplain -directory $netdir *] {
+            set ifname [file tail $iface]
+            if { $ifname eq "lo" } continue
+            set speed "Unknown"
+            if { [file exists "$iface/speed"] } {
+                catch {
+                    set fin [open "$iface/speed" r]
+                    set spd [string trim [read $fin]]
+                    close $fin
+                    if { [string is integer -strict $spd] && $spd > 0 } {
+                        if { $spd >= 1000 } {
+                            set speed "[expr {$spd / 1000}] Gbps"
+                        } else {
+                            set speed "${spd} Mbps"
+                        }
+                    }
+                }
+            }
+            lappend niclist "$ifname ($speed)"
+        }
+    }
+    if { [llength $niclist] > 0 } {
+        dict set sysinfo nic [join $niclist "; "]
+    } else {
+        dict set sysinfo nic "Unknown"
+    }
+} err] } {
+    dict set sysinfo nic "Unknown"
+}
+#Disk/Storage from lsblk
+if { [catch {
+    set disklist [list]
+    set lsblkout [exec lsblk -dnbo NAME,SIZE,MODEL 2>/dev/null]
+    foreach line [split $lsblkout "\n"] {
+        set line [string trim $line]
+        if { $line eq "" } continue
+        set parts [regexp -all -inline {\S+} $line]
+        set dname [lindex $parts 0]
+        set dsize [lindex $parts 1]
+        set dmodel [join [lrange $parts 2 end]]
+        if { $dmodel eq "" } { set dmodel $dname }
+        set dsizegb [format "%.0f" [expr {$dsize / 1073741824.0}]]
+        lappend disklist "$dmodel (${dsizegb} GB)"
+    }
+    if { [llength $disklist] > 0 } {
+        dict set sysinfo storage [join $disklist "; "]
+    } else {
+        dict set sysinfo storage "Unknown"
+    }
+} err] } {
+    dict set sysinfo storage "Unknown"
+}
+#Cloud Instance Detection
+dict set sysinfo cloud_instance [DetectCloudInstance]
+return $sysinfo
 }
 
 proc ConfigureNetworkAgent { port restart } {
@@ -224,11 +471,25 @@ puts "Error Sending Data: $b"
 }
 
 proc StartMetrics {} {
-global agentlist S cpu_model iswin
+global agentlist S cpu_model iswin sysinfo
 puts "Prepared CPU metrics for $cpu_model"
+#Discover system information before sending metrics
+if {$iswin} {
+    if { [catch { set sysinfo [DiscoverSystemWindows] } err] } {
+        puts "System discovery failed: $err"
+        set sysinfo [dict create cpumodel $cpu_model cpucount $S(cpus)]
+    }
+} else {
+    if { [catch { set sysinfo [DiscoverSystemLinux] } err] } {
+        puts "System discovery failed: $err"
+        set sysinfo [dict create cpumodel $cpu_model cpucount $S(cpus)]
+    }
+}
+puts "System discovery complete: [dict size $sysinfo] fields gathered"
 foreach f $agentlist {
-puts -nonewline "Sending CPU metrics to $f ..."
+puts -nonewline "Sending system discovery and CPU metrics to $f ..."
 if { [catch {
+Agent send $f DoDiscovery [list $sysinfo] agent
 Agent send $f DoDisplay $S(cpus) [ list $cpu_model] agent
 Agent send $f update
 	} b] } {

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -110,7 +110,7 @@ namespace eval jobs {
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBMETRIC table in SQLite in-memory database : $message"
           return
-        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, system_vendor TEXT, system_type TEXT, os_name TEXT, memory TEXT, nic TEXT, storage TEXT, cloud_instance TEXT, other_software TEXT, extra TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBSYSTEM table in SQLite in-memory database : $message"
           return
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBOUTPUT(jobid TEXT, vu INTEGER, output TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
@@ -148,7 +148,7 @@ namespace eval jobs {
             } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
              puts "Error creating JOBMETRIC table in SQLite on-disk database : $message"
              return
-            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, system_vendor TEXT, system_type TEXT, os_name TEXT, memory TEXT, nic TEXT, storage TEXT, cloud_instance TEXT, other_software TEXT, extra TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
               puts "Error creating JOBSYSTEM table in SQLite on-disk database : $message"
               return
             } elseif [catch {hdbjobs eval {CREATE TABLE JOBOUTPUT(jobid TEXT, vu INTEGER, output TEXT)}} message ] {
@@ -182,7 +182,26 @@ namespace eval jobs {
               catch {hdbjobs eval {CREATE INDEX JOBCHART_IDX ON JOBCHART(jobid)}}
               puts "Upgraded database $sqlite_db with Job Charts"
 		}
-           }}}}}
+           }
+	   #Upgrade existing JOBSYSTEM table with new system discovery columns if not present
+           if { [catch {
+               set colinfo [hdbjobs eval {PRAGMA table_info(JOBSYSTEM)}]
+               set colnames [list]
+               foreach {cid name type notnull dfltval pk} $colinfo {
+                   lappend colnames $name
+               }
+               foreach newcol {system_vendor system_type os_name memory nic storage cloud_instance other_software extra} {
+                   if { $newcol ni $colnames } {
+                       hdbjobs eval "ALTER TABLE JOBSYSTEM ADD COLUMN $newcol TEXT"
+                   }
+               }
+               if { "system_vendor" ni $colnames } {
+                   puts "Upgraded database $sqlite_db JOBSYSTEM table with system discovery fields"
+               }
+           } message] } {
+               puts "Error upgrading JOBSYSTEM table with system discovery fields: $message"
+           }
+	   }}}}
       tsv::set commandline sqldb $sqlite_db
     }
   }
@@ -1611,8 +1630,8 @@ namespace eval jobs {
                             } else {
                               if { [ dict keys $paramdict ] eq "jobid system" } {
 				set joboutput [ list "No system data available" ]
-                                hdbjobs eval {SELECT hostname,cpucount,cpumodel FROM JOBSYSTEM WHERE JOBID=$jobid} {
-				set joboutput [ list $hostname $cpucount $cpumodel ]
+                                hdbjobs eval {SELECT hostname,cpucount,cpumodel,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra FROM JOBSYSTEM WHERE JOBID=$jobid} {
+				set joboutput [ list $hostname $cpucount $cpumodel $system_vendor $system_type $os_name $memory $nic $storage $cloud_instance $other_software $extra ]
 				}
                               } else {
                                 set joboutput [ list $jobid "Cannot find Jobid output" ]
@@ -1718,8 +1737,19 @@ namespace eval jobs {
 
   proc getjobsystem { jobid } {
     set jobsystem [ dict create ]
-	hdbjobs eval {select hostname,cpumodel,cpucount FROM JOBSYSTEM WHERE JOBID=$jobid} {
-        dict append jobsystem $cpumodel $cpucount
+	hdbjobs eval {select hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra FROM JOBSYSTEM WHERE JOBID=$jobid} {
+        dict set jobsystem hostname $hostname
+        dict set jobsystem cpumodel $cpumodel
+        dict set jobsystem cpucount $cpucount
+        dict set jobsystem system_vendor $system_vendor
+        dict set jobsystem system_type $system_type
+        dict set jobsystem os_name $os_name
+        dict set jobsystem memory $memory
+        dict set jobsystem nic $nic
+        dict set jobsystem storage $storage
+        dict set jobsystem cloud_instance $cloud_instance
+        dict set jobsystem other_software $other_software
+        dict set jobsystem extra $extra
 	}
     if { $jobsystem eq "" } {
       set jobsystem [ list $jobid "Jobid has no system data" ]
@@ -2423,8 +2453,12 @@ namespace eval jobs {
                   } else {
                     if { [ dict keys $paramdict ] eq "jobid system" } {
                       set jsondict [ getjobsystem $jobid ]
-                      #huddle JSON is dict*dict return here
-                      set huddleobj [ huddle compile {list} $jsondict ]
+                      #huddle JSON is dict return here
+                      if { [llength $jsondict] == 2 && [lindex $jsondict 1] eq "Jobid has no system data" } {
+                        set huddleobj [ huddle compile {list} $jsondict ]
+                      } else {
+                        set huddleobj [ huddle compile {dict * string} $jsondict ]
+                      }
                       if { $outputformat eq "JSON" } {
                         puts [ huddle jsondump $huddleobj ]
                       } else {

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -42,8 +42,49 @@ proc ConfigureNetworkDisplay {agentid agenthostname} {
     }
 }
 
+proc DoDiscovery {sysinfo_data caller} {
+    global jobid agent_hostname discovery_data
+    #Store the system discovery data from agent for later insertion
+    set discovery_data $sysinfo_data
+    set cpumodel ""
+    set cpucount 0
+    set system_vendor ""
+    set system_type ""
+    set os_name ""
+    set memory ""
+    set nic ""
+    set storage ""
+    set cloud_instance ""
+    set other_software ""
+    set extra ""
+    if { [catch {
+        if { [dict exists $sysinfo_data cpumodel] } { set cpumodel [dict get $sysinfo_data cpumodel] }
+        if { [dict exists $sysinfo_data cpucount] } { set cpucount [dict get $sysinfo_data cpucount] }
+        if { [dict exists $sysinfo_data system_vendor] } { set system_vendor [dict get $sysinfo_data system_vendor] }
+        if { [dict exists $sysinfo_data system_type] } { set system_type [dict get $sysinfo_data system_type] }
+        if { [dict exists $sysinfo_data os_name] } { set os_name [dict get $sysinfo_data os_name] }
+        if { [dict exists $sysinfo_data memory] } { set memory [dict get $sysinfo_data memory] }
+        if { [dict exists $sysinfo_data nic] } { set nic [dict get $sysinfo_data nic] }
+        if { [dict exists $sysinfo_data storage] } { set storage [dict get $sysinfo_data storage] }
+        if { [dict exists $sysinfo_data cloud_instance] } { set cloud_instance [dict get $sysinfo_data cloud_instance] }
+        if { [dict exists $sysinfo_data other_software] } { set other_software [dict get $sysinfo_data other_software] }
+        if { [dict exists $sysinfo_data extra] } { set extra [dict get $sysinfo_data extra] }
+    } err] } {
+        puts "Error parsing system discovery data: $err"
+        return
+    }
+    #Insert system discovery data into JOBSYSTEM table
+    if { $cpumodel ne "" } {
+        if { [info exists jobid] && $jobid ne "" && $jobid != 0 } {
+            hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount,system_vendor=excluded.system_vendor,system_type=excluded.system_type,os_name=excluded.os_name,memory=excluded.memory,nic=excluded.nic,storage=excluded.storage,cloud_instance=excluded.cloud_instance,other_software=excluded.other_software,extra=excluded.extra}
+        } else {
+            hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES('@@@',$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount,system_vendor=excluded.system_vendor,system_type=excluded.system_type,os_name=excluded.os_name,memory=excluded.memory,nic=excluded.nic,storage=excluded.storage,cloud_instance=excluded.cloud_instance,other_software=excluded.other_software,extra=excluded.extra}
+        }
+    }
+}
+
 proc DoDisplay {maxcpu cpu_model caller} {
-    global S CLR cputobars cputotxt cpucoords metframe win_scale_fact jobid agent_hostname
+    global S CLR cputobars cputotxt cpucoords metframe win_scale_fact jobid agent_hostname discovery_data
     set CLR(bg) black
     set CLR(usr) lightgreen
     set CLR(sys) red
@@ -90,8 +131,9 @@ proc DoDisplay {maxcpu cpu_model caller} {
     tkp::canvas $metframe.f.header -highlightthickness 0 -bd 0 -width $width -height $S(hdscl) -bg $CLR(bg)
     $metframe.f.header create text [ expr {$width/2 - $S(hdralign)} ] $S(txtalign) -text "$cpu_model ($maxcpu CPUs)" -fill $CLR(usr) -font {basic} -tags "cpumodel"
     pack $metframe.f.header
-    #Store CPU model in Job
+    #Store CPU model in Job - only if DoDiscovery has not already stored system data
     	if { [ info exists cpu_model ] && ![ string match "AGENT CONNECTION FAILED" $cpu_model ] } {
+	if { ![info exists discovery_data] || $discovery_data eq "" } {
     	if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
 	hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES($jobid,$agent_hostname,$cpu_model,$maxcpu) ON CONFLICT(jobid) DO UPDATE SET jobid=excluded.jobid,hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount}
 
@@ -99,6 +141,7 @@ proc DoDisplay {maxcpu cpu_model caller} {
 	#Started CPU metrics before a job is running, insert a placeholder making sure only one placeholder is current
 	hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES('@@@',$agent_hostname,$cpu_model,$maxcpu) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount}
 	}
+    }
     }
     #Height for all objects is the height of the bar and text multiplied by all cpus add header
     set canvforbars $cnvpth.c 
@@ -183,8 +226,8 @@ proc gmean L {
 	if {$placehold eq ""} {
 	#The jobid is not present in the jobsystem table and there is no placeholder
 	#Likely metrics are continual running for multiple jobs so find system data from previous job
-	hdbjobs eval {select hostname,cpumodel,cpucount from JOBSYSTEM where hostname=$agent_hostname LIMIT 1} {
-	hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount)}}
+	hdbjobs eval {select hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra from JOBSYSTEM where hostname=$agent_hostname LIMIT 1} {
+	hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra)}}
 	} else {
 	hdbjobs eval {select hostname,cpumodel,cpucount from JOBSYSTEM where JOBID="@@@"} {
 	hdbjobs eval {update JOBSYSTEM set jobid = $jobid where JOBID="@@@"}

--- a/src/generic/genmetricscli.tcl
+++ b/src/generic/genmetricscli.tcl
@@ -219,12 +219,56 @@ proc ConfigureNetworkDisplayCLI {agentid agenthostname} {
     }
 }
 
+proc DoDiscovery {sysinfo_data caller} {
+global agent_hostname jobid discovery_data
+    set discovery_data $sysinfo_data
+    set cpumodel ""
+    set cpucount 0
+    set system_vendor ""
+    set system_type ""
+    set os_name ""
+    set memory ""
+    set nic ""
+    set storage ""
+    set cloud_instance ""
+    set other_software ""
+    set extra ""
+    if { [catch {
+        if { [dict exists $sysinfo_data cpumodel] } { set cpumodel [dict get $sysinfo_data cpumodel] }
+        if { [dict exists $sysinfo_data cpucount] } { set cpucount [dict get $sysinfo_data cpucount] }
+        if { [dict exists $sysinfo_data system_vendor] } { set system_vendor [dict get $sysinfo_data system_vendor] }
+        if { [dict exists $sysinfo_data system_type] } { set system_type [dict get $sysinfo_data system_type] }
+        if { [dict exists $sysinfo_data os_name] } { set os_name [dict get $sysinfo_data os_name] }
+        if { [dict exists $sysinfo_data memory] } { set memory [dict get $sysinfo_data memory] }
+        if { [dict exists $sysinfo_data nic] } { set nic [dict get $sysinfo_data nic] }
+        if { [dict exists $sysinfo_data storage] } { set storage [dict get $sysinfo_data storage] }
+        if { [dict exists $sysinfo_data cloud_instance] } { set cloud_instance [dict get $sysinfo_data cloud_instance] }
+        if { [dict exists $sysinfo_data other_software] } { set other_software [dict get $sysinfo_data other_software] }
+        if { [dict exists $sysinfo_data extra] } { set extra [dict get $sysinfo_data extra] }
+    } err] } {
+        putscli "Error parsing system discovery data: $err"
+        return
+    }
+    if { $cpumodel ne "" } {
+        putscli "System Discovery: $system_vendor $system_type | OS: $os_name | Memory: $memory"
+        if { [info exists jobid] && $jobid ne "" && $jobid != 0 } {
+            if { [string match Benchmark* $jobid] } {
+                set jobid [regsub {Benchmark.*=} $jobid ""]
+            }
+            hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount,system_vendor=excluded.system_vendor,system_type=excluded.system_type,os_name=excluded.os_name,memory=excluded.memory,nic=excluded.nic,storage=excluded.storage,cloud_instance=excluded.cloud_instance,other_software=excluded.other_software,extra=excluded.extra}
+        } else {
+            hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES('@@@',$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount,system_vendor=excluded.system_vendor,system_type=excluded.system_type,os_name=excluded.os_name,memory=excluded.memory,nic=excluded.nic,storage=excluded.storage,cloud_instance=excluded.cloud_instance,other_software=excluded.other_software,extra=excluded.extra}
+        }
+    }
+}
+
 proc DoDisplay {maxcpu cpu_model caller} {
-global agent_hostname jobid
+global agent_hostname jobid discovery_data
 	putscli "Started CPU Metrics for $cpu_model:($maxcpu CPUs)"
 	if { [ info exists cpu_model ] && ![ string match "AGENT CONNECTION FAILED" $cpu_model ] } {
+	#Only insert CPU-only data if DoDiscovery has not already stored system data
+	if { ![info exists discovery_data] || $discovery_data eq "" } {
 	if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
-        #If we have done set jobid [ vurun ] in script set jobid back
         if { [ string match Benchmark* $jobid ] } { 
         set jobid [ regsub {Benchmark.*=} $jobid ""]
 	}		
@@ -232,6 +276,7 @@ global agent_hostname jobid
     	} else {
 	#Started CPU metrics before a job is running, insert a placeholder making sure only one placeholder is current
         hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES('@@@',$agent_hostname,$cpu_model,$maxcpu) ON CONFLICT(jobid) DO UPDATE SET hostname=excluded.hostname,cpumodel=excluded.cpumodel,cpucount=excluded.cpucount}
+	}
 	}
 	} else { 
 putscli "AGENT CONNECTION FAILED"
@@ -284,8 +329,8 @@ proc gmean L {
         if {$placehold eq ""} {
         #The jobid is not present in the jobsystem table and there is no placeholder
         #Likely metrics are continual running for multiple jobs so find system data from previous job
-        hdbjobs eval {select hostname,cpumodel,cpucount from JOBSYSTEM where hostname=$agent_hostname LIMIT 1} {
-        hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount)}}
+        hdbjobs eval {select hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra from JOBSYSTEM where hostname=$agent_hostname LIMIT 1} {
+        hdbjobs eval {INSERT INTO JOBSYSTEM(jobid,hostname,cpumodel,cpucount,system_vendor,system_type,os_name,memory,nic,storage,cloud_instance,other_software,extra) VALUES($jobid,$agent_hostname,$cpumodel,$cpucount,$system_vendor,$system_type,$os_name,$memory,$nic,$storage,$cloud_instance,$other_software,$extra)}}
         } else {
         hdbjobs eval {select hostname,cpumodel,cpucount from JOBSYSTEM where JOBID="@@@"} {
         hdbjobs eval {update JOBSYSTEM set jobid = $jobid where JOBID="@@@"}


### PR DESCRIPTION
## Summary

Implements **Issue #848: TPC-OSS Alignment - Add Detailed System, Hardware, and Software Fields to Results**.

Extends the HammerDB metrics agent to gather detailed system hardware and software information from the SUT (System Under Test) beyond the existing CPU model and count, storing it in an extended JOBSYSTEM table for retrieval via CLI, GUI, and Web Service.

## Changes

### Agent (`agent/agent`)
- Added `DiscoverSystemWindows` proc using WMI/TWAPI to collect: system vendor, system type, OS name/version, total memory, NIC details, disk/storage, and cloud instance type
- Added `DiscoverSystemLinux` proc using `/proc`, `/sys/class/dmi`, `/sys/class/net`, `lsblk`, and `/etc/os-release`
- Added `DetectCloudInstance` proc for automatic AWS/Azure/GCP detection via metadata services
- Modified `StartMetrics` to call discovery and send `DoDiscovery` with full system info before `DoDisplay`

### Schema (`modules/jobs-1.0.tm`)
- Extended JOBSYSTEM table with 9 new columns: `system_vendor`, `system_type`, `os_name`, `memory`, `nic`, `storage`, `cloud_instance`, `other_software`, `extra`
- Added ALTER TABLE upgrade path for existing on-disk databases (following the JOBCHART upgrade pattern)
- Updated `getjobsystem` to return all new fields as a structured dict
- Updated Web Service JSON API system endpoint to include new fields

### GUI/CLI Metrics (`src/generic/genmetrics.tcl`, `src/generic/genmetricscli.tcl`)
- Added `DoDiscovery` proc to receive and store extended system data from agent
- `DoDisplay` falls back to CPU-only insert when `DoDiscovery` has not been called (backward compatibility with older agents)
- Updated `StatsOneLine` to propagate all system fields when copying data across continuous job runs

## Testing

Tested on both **Windows** and **Linux** with the following setup:
- **Windows devbox** (Azure Standard_D16as_v5, Windows Enterprise 10.0, 64 GB RAM): Built from source using Bawt build system, ran agent with `DiscoverSystemWindows` — gathered 9 fields including Azure cloud instance detection
- **Linux VM** (Azure Standard_D8as_v5, Ubuntu 24.04.3 LTS, PostgreSQL 18.2): Ran `DiscoverSystemLinux` — gathered 9 fields including OS, memory (31.3 GB), NIC (50 Gbps), storage, Azure instance type
- **Cross-machine test**: Agent on Windows devbox → CLI on Linux VM via SSH tunnel, TPC-C benchmark (10564 NOPM), CPU metrics streaming, system discovery data transmitted via `DoDiscovery`
- **Schema upgrade**: Verified ALTER TABLE migration preserves existing data in on-disk databases
- **Backward compatibility**: Production v5.0 binary reads upgraded schema without errors; `DoDisplay` fallback works when `DoDiscovery` is absent
- **Web Service**: Verified `/jobs?jobid=XXX&system` endpoint returns all 12 fields as JSON

## New JOBSYSTEM Columns

| Column | Type | Source (Linux) | Source (Windows) |
|--------|------|----------------|------------------|
| system_vendor | TEXT | `/sys/class/dmi/id/sys_vendor` | WMI Win32_ComputerSystem |
| system_type | TEXT | `/sys/class/dmi/id/product_name` | WMI Win32_ComputerSystem |
| os_name | TEXT | `/etc/os-release` | `twapi::get_os_description` |
| memory | TEXT | `/proc/meminfo` | WMI Win32_ComputerSystem |
| nic | TEXT | `/sys/class/net/*/speed` | WMI Win32_NetworkAdapter |
| storage | TEXT | `lsblk -dnbo` | WMI Win32_DiskDrive |
| cloud_instance | TEXT | Cloud metadata APIs | Cloud metadata APIs |
| other_software | TEXT | User-configurable | User-configurable |
| extra | TEXT | User-configurable | User-configurable |

Resolves #848