### PR TITLE
Remove arbitrary upper limit on num_vu for schema build

### DIFF
--- a/src/db2/db2opt.tcl
+++ b/src/db2/db2opt.tcl
@@ -498,7 +498,7 @@ proc configdb2tpcc {option} {
         "default" {
             ttk::button $Name -command {
                 set db2_count_ware [ verify_warehouse $db2_count_ware 100000 ]
-                set db2_num_vu [ verify_build_threads $db2_num_vu $db2_count_ware 1024 ]
+                set db2_num_vu [ verify_build_threads $db2_num_vu $db2_count_ware ]
                 copyfieldstoconfig configdb2 [ subst $db2fields ] tpcc
                 Dict2SQLite "db2" $configdb2
                 unset db2fields
@@ -740,7 +740,7 @@ proc configdb2tpch {option} {
         }
         "default" {
             ttk::button $Name -command {
-                set db2_num_tpch_threads [ verify_build_threads $db2_num_tpch_threads 512 512 ]
+                set db2_num_tpch_threads [ verify_build_threads $db2_num_tpch_threads 512 ]
                 copyfieldstoconfig configdb2 [ subst $db2fields ] tpch
                 Dict2SQLite "db2" $configdb2
                 unset db2fields

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -1173,8 +1173,8 @@ proc buildschema {} {
         set vukey [ lsearch [ join [ set $dictname ]] *num_vu ]
         set vuname [ lsearch -inline [ join [ set $dictname ]] *num_vu ]
         set buildvu [ lindex [ join [ set $dictname ]] [ expr $vukey + 1]]
-        if { ![string is integer -strict $buildvu ] || $buildvu < 1 || $buildvu > 1024 } {
-            puts "Error: Number of virtual users to build schema must be an integer less than 1024"
+        if { ![string is integer -strict $buildvu ] || $buildvu < 1 } {
+            puts "Error: Number of virtual users to build schema must be a positive integer"
             return
         }
         if { $buildvu > $buildcw } {
@@ -1208,8 +1208,8 @@ proc buildschema {} {
         set vukey [ lsearch [ join [ set $dictname ]] *num_tpch_threads ]
         set vuname [ lsearch -inline [ join [ set $dictname ]] *num_tpch_threads ]
         set buildvu [ lindex [ join [ set $dictname ]] [ expr $vukey + 1]]
-        if { ![string is integer -strict $buildvu ] || $buildvu < 1 || $buildvu > 1024 } {
-            puts "Error: Number of virtual users to build schema must be an integer less than 1024"
+        if { ![string is integer -strict $buildvu ] || $buildvu < 1 } {
+            puts "Error: Number of virtual users to build schema must be a positive integer"
             return
         }
         set validvalues {1 10 30 100 300 1000 3000 10000 30000 100000}

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -3078,7 +3078,7 @@ proc dgopts {} {
     set Prompt $Parent.f1.p4
     ttk::label $Prompt -text "Virtual Users to Generate Data :"
     set Name $Parent.f1.e4
-    ttk::spinbox $Name -from 1 -to 1024 -textvariable gen_num_vu
+    ttk::spinbox $Name -from 1 -to 100000 -textvariable gen_num_vu
     bind .dgopt.f1.e4 <Any-ButtonRelease> {
         if { $bm eq "TPC-C" } {
             if {$gen_num_vu > $gen_count_ware} {
@@ -3666,9 +3666,9 @@ proc verify_warehouse { count_ware maximum } {
     return $count_ware
 }
 
-proc verify_build_threads { num_vu count_ware maximum } {
-    if { ![string is integer -strict $num_vu] || $num_vu < 1 || $num_vu > $maximum } {
-        tk_messageBox -message "The number of virtual users must be a positive integer less than or equal to $maximum"
+proc verify_build_threads { num_vu count_ware } {
+    if { ![string is integer -strict $num_vu] || $num_vu < 1 } {
+        tk_messageBox -message "The number of virtual users must be a positive integer"
         set num_vu 1
     }
     if { $num_vu > $count_ware } { set num_vu $count_ware }

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -607,7 +607,7 @@ proc configmariatpcc {option} {
         set Prompt $Parent.f1.p9
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e9
-        ttk::spinbox $Name -from 1 -to 512 -textvariable maria_num_vu
+        ttk::spinbox $Name -from 1 -to 100000 -textvariable maria_num_vu
 
         bind .tpc.f1.e9 <<Any-Button-Any-Key>> {
             if {$maria_num_vu > $maria_count_ware} {
@@ -913,7 +913,7 @@ proc configmariatpcc {option} {
         "default" {
             ttk::button $Name -command {
                 set maria_count_ware [ verify_warehouse $maria_count_ware 100000 ]
-                set maria_num_vu [ verify_build_threads $maria_num_vu $maria_count_ware 1024 ]
+                set maria_num_vu [ verify_build_threads $maria_num_vu $maria_count_ware ]
                 copyfieldstoconfig configmariadb [ subst $mariafields ] tpcc
                 Dict2SQLite "mariadb" $configmariadb
                 unset mariafields
@@ -1302,7 +1302,7 @@ proc configmariatpch {option} {
         }
         "default" {
             ttk::button $Name -command {
-                set maria_num_tpch_threads [ verify_build_threads $maria_num_tpch_threads 512 512 ]
+                set maria_num_tpch_threads [ verify_build_threads $maria_num_tpch_threads 512 ]
                 copyfieldstoconfig configmariadb [ subst $mariafields ] tpch
                 Dict2SQLite "mariadb" $configmariadb
                 unset mariafields

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -484,7 +484,7 @@ proc configmssqlstpcc {option} {
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e11
-        ttk::spinbox $Name -from 1 -to 512 -textvariable mssqls_num_vu
+        ttk::spinbox $Name -from 1 -to 100000 -textvariable mssqls_num_vu
         bind .tpc.f1.e11 <<Any-Button-Any-Key>> {
             if {$mssqls_num_vu > $mssqls_count_ware} {
                 set mssqls_num_vu $mssqls_count_ware
@@ -713,7 +713,7 @@ proc configmssqlstpcc {option} {
 		set mssqls_msi_object_id "null" 
 	        }
                 set mssqls_count_ware [ verify_warehouse $mssqls_count_ware 100000 ]
-                set mssqls_num_vu [ verify_build_threads $mssqls_num_vu $mssqls_count_ware 1024 ]
+                set mssqls_num_vu [ verify_build_threads $mssqls_num_vu $mssqls_count_ware ]
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpcc
                 Dict2SQLite "mssqlserver" $configmssqlserver
                 unset mssqlsfields
@@ -1097,7 +1097,7 @@ proc configmssqlstpch {option} {
 		tk_messageBox -message "MSI Object ID is not a valid format" 
 		set mssqls_msi_object_id "null" 
 	        }
-                set mssqls_num_tpch_threads [ verify_build_threads $mssqls_num_tpch_threads 512 512 ]
+                set mssqls_num_tpch_threads [ verify_build_threads $mssqls_num_tpch_threads 512 ]
                 copyfieldstoconfig configmssqlserver [ subst $mssqlsfields ] tpch
                 Dict2SQLite "mssqlserver" $configmssqlserver
                 unset mssqlsfields

--- a/src/mysql/mysqlopt.tcl
+++ b/src/mysql/mysqlopt.tcl
@@ -629,7 +629,7 @@ proc configmysqltpcc {option} {
         set Prompt $Parent.f1.p9
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e9
-        ttk::spinbox $Name -from 1 -to 512 -textvariable mysql_num_vu
+        ttk::spinbox $Name -from 1 -to 100000 -textvariable mysql_num_vu
         bind .tpc.f1.e9 <<Any-Button-Any-Key>> {
             if {$mysql_num_vu > $mysql_count_ware} {
                 set mysql_num_vu $mysql_count_ware
@@ -898,7 +898,7 @@ proc configmysqltpcc {option} {
         "default" {
             ttk::button $Name -command {
                 set mysql_count_ware [ verify_warehouse $mysql_count_ware 100000 ]
-                set mysql_num_vu [ verify_build_threads $mysql_num_vu $mysql_count_ware 1024 ]
+                set mysql_num_vu [ verify_build_threads $mysql_num_vu $mysql_count_ware ]
                 copyfieldstoconfig configmysql [ subst $myfields ] tpcc
                 Dict2SQLite "mysql" $configmysql
                 unset myfields
@@ -1334,7 +1334,7 @@ proc configmysqltpch {option} {
         }
         "default" {
             ttk::button $Name -command {
-                set mysql_num_tpch_threads [ verify_build_threads $mysql_num_tpch_threads 512 512 ]
+                set mysql_num_tpch_threads [ verify_build_threads $mysql_num_tpch_threads 512 ]
                 copyfieldstoconfig configmysql [ subst $myfields ] tpch
                 Dict2SQLite "mysql" $configmysql
                 unset myfields

--- a/src/oracle/oraopt.tcl
+++ b/src/oracle/oraopt.tcl
@@ -361,7 +361,7 @@ proc configoratpcc {option} {
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e11
-        ttk::spinbox $Name -from 1 -to 512 -textvariable num_vu
+        ttk::spinbox $Name -from 1 -to 100000 -textvariable num_vu
         bind .tpc.f1.e11 <<Any-Button-Any-Key>> {
             if {$num_vu > $count_ware} {
                 set num_vu $count_ware
@@ -575,7 +575,7 @@ proc configoratpcc {option} {
         "default" {
             ttk::button $Name -command {
                 set count_ware [ verify_warehouse $count_ware 100000 ]
-                set num_vu [ verify_build_threads $num_vu $count_ware 1024 ]
+                set num_vu [ verify_build_threads $num_vu $count_ware ]
                 copyfieldstoconfig configoracle [ subst $orafields ] tpcc
                 Dict2SQLite "oracle" $configoracle
                 unset orafields
@@ -860,7 +860,7 @@ proc configoratpch {option} {
         }
         "default" {
             ttk::button $Name -command {
-                set num_tpch_threads [ verify_build_threads $num_tpch_threads 512 512 ]
+                set num_tpch_threads [ verify_build_threads $num_tpch_threads 512 ]
                 copyfieldstoconfig configoracle [ subst $orafields ] tpch
                 Dict2SQLite "oracle" $configoracle
                 unset orafields

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -376,7 +376,7 @@ proc configpgtpcc {option} {
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e11
-        ttk::spinbox $Name -from 1 -to 512 -textvariable pg_num_vu
+        ttk::spinbox $Name -from 1 -to 100000 -textvariable pg_num_vu
         bind .tpc.f1.e11 <<Any-Button-Any-Key>> {
             if {$pg_num_vu > $pg_count_ware} {
                 set pg_num_vu $pg_count_ware
@@ -629,7 +629,7 @@ proc configpgtpcc {option} {
         "default" {
             ttk::button $Name -command {
                 set pg_count_ware [ verify_warehouse $pg_count_ware 100000 ]
-                set pg_num_vu [ verify_build_threads $pg_num_vu $pg_count_ware 1024 ]
+                set pg_num_vu [ verify_build_threads $pg_num_vu $pg_count_ware ]
                 copyfieldstoconfig configpostgresql [ subst $pgfields ] tpcc
                 Dict2SQLite "postgresql" $configpostgresql
                 unset pgfields
@@ -940,7 +940,7 @@ proc configpgtpch {option} {
         }
         "default" {
             ttk::button $Name -command {
-                set pg_num_tpch_threads [ verify_build_threads $pg_num_tpch_threads 512 512 ]
+                set pg_num_tpch_threads [ verify_build_threads $pg_num_tpch_threads 512 ]
                 copyfieldstoconfig configpostgresql [ subst $pgfields ] tpch
                 Dict2SQLite "postgresql" $configpostgresql
                 unset pgfields


### PR DESCRIPTION
Remove the hardcoded upper limit on the number of virtual users for schema building across all database backends. The warehouse/scale-factor count constraint already provides a natural upper bound, making the arbitrary numeric cap redundant. This will help speedup the data population by utilizing a bigger set of workers.

Changes:
- verify_build_threads: remove maximum parameter, validate positive integer only
- gencli.tcl: remove 1024 cap from TPC-C and TPC-H CLI validation
- All database spinboxes: set upper bound to 100000 (matching max warehouse count)
- Update all verify_build_threads callers to drop the third argument