### PR TITLE
Add Azure Citus and Citus Load Balancer support for PostgreSQL

### DIFF
--- a/DocBook/docs.xml
+++ b/DocBook/docs.xml
@@ -4197,6 +4197,15 @@ GO
                 </row>
 
                 <row>
+                  <entry>Azure Citus</entry>
+
+                  <entry>Prevents CREATE, ALTER and DROP database operations
+                  for Azure Citus (Azure Elastic Cluster) like managed
+                  environment.
+                  </entry>
+                </row>
+
+                <row>
                   <entry>PostgreSQL Superuser</entry>
 
                   <entry>The PostgreSQL Superuser is a user with sufficient

--- a/DocBook/docs.xml
+++ b/DocBook/docs.xml
@@ -4206,6 +4206,19 @@ GO
                 </row>
 
                 <row>
+                  <entry>Citus Load Balancer Port</entry>
+
+                  <entry>The port of the Citus load balancer used to distribute
+                  connections across worker nodes. This setting is enabled when
+                  Azure Citus is enabled. When set and Citus Compatible mode is
+                  also enabled, schema data population and OLTP benchmark
+                  workload connections will be routed through this port instead
+                  of the standard PostgreSQL port. DDL operations are always
+                  routed through the coordinator via the standard PostgreSQL
+                  port. The default value is 5432.</entry>
+                </row>
+
+                <row>
                   <entry>PostgreSQL Superuser</entry>
 
                   <entry>The PostgreSQL Superuser is a user with sufficient

--- a/config/connectpool/pgcpool.xml
+++ b/config/connectpool/pgcpool.xml
@@ -3,6 +3,7 @@
     <c1>
 	<pg_host>host1</pg_host>
         <pg_port>5432</pg_port>
+	<pg_azure_citus>false</pg_azure_citus>
 	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>
@@ -11,6 +12,7 @@
     <c2>
 	<pg_host>host2</pg_host>
         <pg_port>5432</pg_port>
+	<pg_azure_citus>false</pg_azure_citus>
 	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>
@@ -19,6 +21,7 @@
     <c3>
 	<pg_host>host3</pg_host>
         <pg_port>5432</pg_port>
+	<pg_azure_citus>false</pg_azure_citus>
 	<pg_sslmode>prefer</pg_sslmode>
 	<pg_user>tpcc</pg_user>
         <pg_pass>tpcc</pg_pass>

--- a/config/postgresql.xml
+++ b/config/postgresql.xml
@@ -4,6 +4,7 @@
         <pg_host>localhost</pg_host>
         <pg_port>5432</pg_port>
         <pg_sslmode>prefer</pg_sslmode>
+        <pg_azure_citus>false</pg_azure_citus>
     </connection>
 	<tpcc>
         <schema>

--- a/config/postgresql.xml
+++ b/config/postgresql.xml
@@ -5,6 +5,7 @@
         <pg_port>5432</pg_port>
         <pg_sslmode>prefer</pg_sslmode>
         <pg_azure_citus>false</pg_azure_citus>
+        <pg_citus_loadbalancer>5432</pg_citus_loadbalancer>
     </connection>
 	<tpcc>
         <schema>

--- a/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
@@ -9,6 +9,7 @@ diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
 diset('connection','pg_azure_citus','false')
+diset('connection','pg_citus_loadbalancer','5432')
 
 vu = tclpy.eval('numberOfCPUs')
 warehouse = int(vu) * 5

--- a/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-C')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 vu = tclpy.eval('numberOfCPUs')
 warehouse = int(vu) * 5

--- a/scripts/python/postgres/tprocc/pg_tprocc_checkschema.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_checkschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-C')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpcc','pg_superuser','postgres')
 diset('tpcc','pg_superuserpass','postgres')

--- a/scripts/python/postgres/tprocc/pg_tprocc_deleteschema.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_deleteschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-C')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpcc','pg_superuser','postgres')
 diset('tpcc','pg_superuserpass','postgres')

--- a/scripts/python/postgres/tprocc/pg_tprocc_run.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_run.py
@@ -10,6 +10,7 @@ dbset('bm','TPC-C')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpcc','pg_superuser','postgres')
 diset('tpcc','pg_superuserpass','postgres')

--- a/scripts/python/postgres/tproch/pg_tproch_buildschema.py
+++ b/scripts/python/postgres/tproch/pg_tproch_buildschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-H')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 vu = tclpy.eval('numberOfCPUs')
 diset('tpch','pg_scale_fact','1')

--- a/scripts/python/postgres/tproch/pg_tproch_checkschema.py
+++ b/scripts/python/postgres/tproch/pg_tproch_checkschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-H')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpch','pg_tpch_superuser','postgres')
 diset('tpch','pg_tpch_superuserpass','postgres')

--- a/scripts/python/postgres/tproch/pg_tproch_deleteschema.py
+++ b/scripts/python/postgres/tproch/pg_tproch_deleteschema.py
@@ -8,6 +8,7 @@ dbset('bm','TPC-H')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpch','pg_tpch_superuser','postgres')
 diset('tpch','pg_tpch_superuserpass','postgres')

--- a/scripts/python/postgres/tproch/pg_tproch_run.py
+++ b/scripts/python/postgres/tproch/pg_tproch_run.py
@@ -10,6 +10,7 @@ dbset('bm','TPC-H')
 diset('connection','pg_host','localhost')
 diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
+diset('connection','pg_azure_citus','false')
 
 diset('tpch','pg_scale_fact','1')
 diset('tpch','pg_tpch_user','tpch')

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
@@ -8,6 +8,7 @@ dbset bm TPC-C
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 set vu [ numberOfCPUs ]
 set warehouse [ expr {$vu * 5} ]

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
@@ -9,6 +9,7 @@ diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
 diset connection pg_azure_citus false
+diset connection pg_citus_loadbalancer 5432
 
 set vu [ numberOfCPUs ]
 set warehouse [ expr {$vu * 5} ]

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_checkschema.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_checkschema.tcl
@@ -7,6 +7,7 @@ dbset bm TPC-C
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpcc pg_superuser postgres
 diset tpcc pg_superuserpass postgres

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_deleteschema.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_deleteschema.tcl
@@ -7,6 +7,7 @@ dbset bm TPC-C
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpcc pg_superuser postgres
 diset tpcc pg_superuserpass postgres

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_run.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_run.tcl
@@ -9,6 +9,7 @@ dbset bm TPC-C
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpcc pg_superuser postgres
 diset tpcc pg_superuserpass postgres

--- a/scripts/tcl/postgres/tproch/pg_tproch_buildschema.tcl
+++ b/scripts/tcl/postgres/tproch/pg_tproch_buildschema.tcl
@@ -8,6 +8,7 @@ dbset bm TPC-H
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpch pg_scale_fact 1
 diset tpch pg_num_tpch_threads [ numberOfCPUs ]

--- a/scripts/tcl/postgres/tproch/pg_tproch_checkschema.tcl
+++ b/scripts/tcl/postgres/tproch/pg_tproch_checkschema.tcl
@@ -8,6 +8,7 @@ dbset bm TPC-H
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpch pg_tpch_superuser postgres
 diset tpch pg_tpch_superuserpass postgres

--- a/scripts/tcl/postgres/tproch/pg_tproch_deleteschema.tcl
+++ b/scripts/tcl/postgres/tproch/pg_tproch_deleteschema.tcl
@@ -8,6 +8,7 @@ dbset bm TPC-H
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpch pg_tpch_superuser postgres
 diset tpch pg_tpch_superuserpass postgres

--- a/scripts/tcl/postgres/tproch/pg_tproch_run.tcl
+++ b/scripts/tcl/postgres/tproch/pg_tproch_run.tcl
@@ -9,6 +9,7 @@ dbset bm TPC-H
 diset connection pg_host localhost
 diset connection pg_port 5432
 diset connection pg_sslmode prefer
+diset connection pg_azure_citus false
 
 diset tpch pg_scale_fact 1
 diset tpch pg_tpch_user tpch

--- a/src/postgresql/pgmet.tcl
+++ b/src/postgresql/pgmet.tcl
@@ -1939,6 +1939,7 @@ namespace eval pgmet {
         set public(host) $pg_host
         set public(port) $pg_port
         set public(sslmode) $pg_sslmode
+        set public(azure_citus) $pg_azure_citus
         if { $bm eq "TPC-C" } {
             set public(suser) $pg_superuser
             set public(suser_pw) [ quotemeta $pg_superuserpass ]

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -7,7 +7,7 @@ proc build_pgtpch {} {
     upvar #0 configpostgresql configpostgresql
     #set variables to values in dict
     setlocaltpchvars $configpostgresql
-    if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a Scale Factor $pg_scale_fact TPROC-H schema\n in host [string toupper $pg_host:$pg_port] sslmode [string toupper $pg_sslmode] under user [ string toupper $pg_tpch_user ] in database [ string toupper $pg_tpch_dbase ]?" -type yesno ] == yes} {
+    if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a Scale Factor $pg_scale_fact TPROC-H schema\n in host [string toupper $pg_host:$pg_port] sslmode [string toupper $pg_sslmode] in azure_citus [string toupper $pg_azure_citus] under user [ string toupper $pg_tpch_user ] in database [ string toupper $pg_tpch_dbase ]?" -type yesno ] == yes} {
 
         if { $pg_num_tpch_threads eq 1 } {
             set maxvuser 1
@@ -63,9 +63,11 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     return $lda
 }
 
-proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_password user password } {
+proc CreateUserDatabase { lda host port sslmode azure_citus db tspace superuser superuser_password user password } {
     set stmnt_count 1
-    puts "CREATING DATABASE $db under OWNER $user"
+    if { !$azure_citus } {
+        puts "CREATING DATABASE $db under OWNER $user"
+    }
     set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
     if { [pg_result $result -numTuples] == 0 } {
         set sql($stmnt_count) "CREATE USER \"$user\" PASSWORD '$password'"
@@ -77,7 +79,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
     }
     incr stmnt_count;
     set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
-    if { [pg_result $result -numTuples] == 0} {
+    if { [pg_result $result -numTuples] == 0 && !$azure_citus } {
         set sql($stmnt_count) "CREATE DATABASE \"$db\" OWNER \"$user\""
     } else {
         set existing_db [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $db ]
@@ -86,8 +88,14 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
         } else {
             set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
             if { [pg_result $result -numTuples] == 0 } {
-                puts "Using existing empty Database $db for Schema build"
-                set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
+                if { !$azure_citus } {
+                    puts "Using existing empty Database $db for Schema build"
+                    set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
+                } else {
+                    # Azure Citus (Azure Elastic Cluster) mode - database must pre-exist
+                    puts "Azure Citus (Azure Elastic Cluster) mode: Using existing database $db"
+                    puts "Ensure database $db exists and user $user has appropriate permissions"
+                }
             } else {
                 puts "Database with tables $db exists"
                 error "Database $db exists but is not empty, specify a new or empty database name"
@@ -95,7 +103,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
         }
         pg_disconnect $existing_db
     }
-    if { $tspace != "pg_default" } {
+    if { $tspace != "pg_default" && !$azure_citus } {
         incr stmnt_count
         set sql($stmnt_count) "ALTER DATABASE $db SET TABLESPACE $tspace"
     }
@@ -554,7 +562,7 @@ proc CreateIndexes { lda greenplum gpcompress } {
     return
 }
 
-proc do_tpch { host port sslmode scale_fact superuser superuser_password defaultdb db tspace user password greenplum gpcompress num_vu } {
+proc do_tpch { host port sslmode azure_citus scale_fact superuser superuser_password defaultdb db tspace user password greenplum gpcompress num_vu } {
     global dist_names dist_weights weights dists weights
     ###############################################
     #Generating following rows
@@ -611,7 +619,7 @@ proc do_tpch { host port sslmode scale_fact superuser superuser_password default
         if { $lda eq "Failed" } {
             error "error, the database connection to $host could not be established"
         } else {
-            CreateUserDatabase $lda $host $port $sslmode $db $tspace $superuser $superuser_password $user $password
+            CreateUserDatabase $lda $host $port $sslmode $azure_citus $db $tspace $superuser $superuser_password $user $password
             set result [ pg_exec $lda "commit" ]
             pg_result $result -clear
             pg_disconnect $lda
@@ -717,7 +725,7 @@ proc do_tpch { host port sslmode scale_fact superuser superuser_password default
     }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpch $pg_host $pg_port $pg_sslmode $pg_scale_fact $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase $pg_tpch_tspace $pg_tpch_user [ quotemeta $pg_tpch_pass ] $pg_tpch_gpcompat $pg_tpch_gpcompress $pg_num_tpch_threads"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpch $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_scale_fact $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase $pg_tpch_tspace $pg_tpch_user [ quotemeta $pg_tpch_pass ] $pg_tpch_gpcompat $pg_tpch_gpcompress $pg_num_tpch_threads"
     } else { return }
 }
 
@@ -744,6 +752,7 @@ set scale_factor $pg_scale_fact ;#Scale factor of the tpc-h schema
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL Server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
+set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
 set user \"$pg_tpch_user\" ;# PostgreSQL user
 set password \"[ quotemeta $pg_tpch_pass ]\" ;# Password for the PostgreSQL user
 set db \"$pg_tpch_dbase\" ;# Database containing the TPC Schema
@@ -1196,7 +1205,7 @@ proc sub_query { query_no scale_factor myposition } {
 }
 #########################
 #TPCH QUERY SETS PROCEDURE
-proc do_tpch { host port sslmode db user password scale_factor RAISEERROR VERBOSE degree_of_parallel total_querysets myposition } {
+proc do_tpch { host port sslmode azure_citus db user password scale_factor RAISEERROR VERBOSE degree_of_parallel total_querysets myposition } {
     #Queries 17 and 20 are long running on PostgreSQL
     set SKIP_QUERY_17_20 "false" 
     set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
@@ -1327,7 +1336,7 @@ if { $refresh_on } {
         set update_sets 1
         set REFRESH_VERBOSE "false"
         do_refresh $host $port $sslmode $db $user $password $scale_factor $update_sets $trickle_refresh $REFRESH_VERBOSE RF1
-        do_tpch $host $port $sslmode $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets 0
+        do_tpch $host $port $sslmode $azure_citus $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets 0
         do_refresh $host $port $sslmode $db $user $password $scale_factor $update_sets $trickle_refresh $REFRESH_VERBOSE RF2
     } else {
         switch $myposition {
@@ -1335,12 +1344,12 @@ if { $refresh_on } {
                 do_refresh $host $port $sslmode $db $user $password $scale_factor $update_sets $trickle_refresh $REFRESH_VERBOSE BOTH
             }
             default { 
-                do_tpch $host $port $sslmode $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets [ expr $myposition - 1 ]
+                do_tpch $host $port $sslmode $azure_citus $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets [ expr $myposition - 1 ]
             }
         }
     }
 } else {
-    do_tpch $host $port $sslmode $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets $myposition
+    do_tpch $host $port $sslmode $azure_citus $db $user $password $scale_factor $RAISEERROR $VERBOSE $degree_of_parallel $total_querysets $myposition
 }}
 }
 
@@ -1366,6 +1375,7 @@ set redshift_compat \"$pg_rs_compat\" ;# Queries to run against redshift (true o
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL Server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
+set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
 set user \"$pg_tpch_user\" ;# PostgreSQL user
 set password \"[ quotemeta $pg_tpch_pass ]\" ;# Password for the PostgreSQL user
 set db \"$pg_tpch_dbase\" ;# Database containing the TPC Schema
@@ -1549,32 +1559,37 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     return $lda
 }
 
-proc drop_schema { host port sslmode user superuser superuser_password default_dbase dbase } {
+proc drop_schema { host port sslmode azure_citus user superuser superuser_password default_dbase dbase } {
     set suconnect [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_dbase ]
     if { $suconnect eq "Failed" } {
         error "error, the database connection to $host could not be established"
     } else {
-        set result [ pg_exec $suconnect "drop database $dbase"]
-        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-            error "[pg_result $result -error]"
+        if { !$azure_citus } {
+            set result [ pg_exec $suconnect "drop database $dbase"]
+            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+                error "[pg_result $result -error]"
+            } else {
+                puts "$dbase TPROC-H schema has been deleted successfully."
+                pg_result $result -clear
+            }
+            set result [ pg_exec $suconnect "drop role $user"]
+            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+                error "[pg_result $result -error]"
+            } else {
+                puts "$user TPROC-H role has been deleted successfully."
+                pg_result $result -clear
+            }
+            pg_disconnect $suconnect
         } else {
-            puts "$dbase TPROC-H schema has been deleted successfully."
-            pg_result $result -clear
+            puts "Azure Citus (Azure Elastic Cluster) mode: DROP DATABASE not supported"
+            puts "Please manually drop database $dbase and role $user using Azure portal or CLI if permissible"
         }
-        set result [ pg_exec $suconnect "drop role $user"]
-        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-            error "[pg_result $result -error]"
-        } else {
-            puts "$user TPROC-H role has been deleted successfully."
-            pg_result $result -clear
-        }
-        pg_disconnect $suconnect
     }
     return
 }
 }
 
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_tpch_user $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_tpch_user $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase"
     } else { return }
 }
 
@@ -1691,6 +1706,6 @@ proc check_tpch { host port sslmode user superuser superuser_password default_db
     }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch $pg_host $pg_port $pg_sslmode $pg_tpch_user $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase $pg_scale_fact"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpch $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_tpch_user $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $pg_tpch_dbase $pg_scale_fact"
     } else { return }
 }

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -2089,7 +2089,15 @@ proc LoadOrd { lda ware_start count_ware MAXITEMS ORD_PER_DIST DIST_PER_WARE ora
     pg_result $result -clear
     return
 }
-proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_password defaultdb db tspace user password ora_compatible citus_compatible pg_storedprocs partition num_vu } {
+
+proc GetDataPort { port citus_lb_port azure_citus citus_compatible } {
+    if { $azure_citus && $citus_compatible eq "true" && $citus_lb_port > 0 } {
+        return $citus_lb_port
+    }
+    return $port
+}
+
+proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_password defaultdb db tspace user password ora_compatible citus_compatible pg_storedprocs partition num_vu citus_lb_port } {
     set MAXITEMS 100000
     set CUST_PER_DIST 3000
     set DIST_PER_WARE 10
@@ -2120,6 +2128,7 @@ proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_pass
     }
     if { $threaded eq "SINGLE-THREADED" ||  $threaded eq "MULTI-THREADED" && $myposition eq 1 } {
         puts "CREATING [ string toupper $user ] SCHEMA"
+        set schema_start_seconds [clock seconds]
         set lda [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $defaultdb ]
         if { $lda eq "Failed" } {
             error "error, the database connection to $host could not be established"
@@ -2146,9 +2155,22 @@ proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_pass
                 pg_result $result -clear
             }
         }
+        set ddl_elapsed [expr {[clock seconds] - $schema_start_seconds}]
+        puts "DDL phase (create tables) completed in $ddl_elapsed seconds"
         if { $threaded eq "MULTI-THREADED" } {
             tsv::set application load "READY"
-            LoadItems $lda $MAXITEMS
+            set data_load_start [clock seconds]
+            set data_port [GetDataPort $port $citus_lb_port $azure_citus $citus_compatible]
+            if { $data_port ne $port } {
+                puts "Using load balancer port $data_port for data population"
+                set lda_data [ ConnectToPostgres $host $data_port $sslmode $user $password $db ]
+                if { $lda_data eq "Failed" } {
+                    error "error, the load balancer connection to $host:$data_port could not be established"
+                }
+            } else {
+                set lda_data $lda
+            }
+            LoadItems $lda_data $MAXITEMS
             puts "Monitoring Workers..."
             set prevactive 0
             while 1 {
@@ -2167,8 +2189,16 @@ proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_pass
                 if { $dncnt eq [expr  $totalvirtualusers - 1] } { break }
                 after 10000
             }
+            if { $data_port ne $port } {
+                pg_disconnect $lda_data
+            }
+            set data_load_elapsed [expr {[clock seconds] - $data_load_start}]
+            puts "Data population completed in $data_load_elapsed seconds"
         } else {
+            set data_load_start [clock seconds]
             LoadItems $lda $MAXITEMS
+            set data_load_elapsed [expr {[clock seconds] - $data_load_start}]
+            puts "Data population completed in $data_load_elapsed seconds"
         }
     }
     if { $threaded eq "SINGLE-THREADED" ||  $threaded eq "MULTI-THREADED" && $myposition != 1 } {
@@ -2187,7 +2217,11 @@ proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_pass
                 }
                 after 5000 
             }
-            set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
+            set data_port [GetDataPort $port $citus_lb_port $azure_citus $citus_compatible]
+            if { $data_port ne $port } {
+                puts "Worker $myposition: connecting via load balancer port $data_port"
+            }
+            set lda [ ConnectToPostgres $host $data_port $sslmode $user $password $db ]
             if { $lda eq "Failed" } {
                 error "error, the database connection to $host could not be established"
             }
@@ -2210,16 +2244,24 @@ proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_pass
         }
     }
     if { $threaded eq "SINGLE-THREADED" || $threaded eq "MULTI-THREADED" && $myposition eq 1 } {
+        set index_start [clock seconds]
         CreateIndexes $lda
+        set index_elapsed [expr {[clock seconds] - $index_start}]
+        puts "Index creation completed in $index_elapsed seconds"
+        set sproc_start [clock seconds]
         CreateStoredProcs $lda $ora_compatible $citus_compatible $pg_storedprocs
-        GatherStatistics $lda 
+        set sproc_elapsed [expr {[clock seconds] - $sproc_start}]
+        puts "Stored procedures creation completed in $sproc_elapsed seconds"
+        GatherStatistics $lda
+        set total_elapsed [expr {[clock seconds] - $schema_start_seconds}]
+        puts "Schema build total: $total_elapsed seconds (DDL: ${ddl_elapsed}s, Data: ${data_load_elapsed}s, Index: ${index_elapsed}s, StoredProcs: ${sproc_elapsed}s)"
         puts "[ string toupper $user ] SCHEMA COMPLETE"
         pg_disconnect $lda
         return
     }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_count_ware $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_tspace $pg_user [ quotemeta $pg_pass ] $pg_oracompat $pg_cituscompat $pg_storedprocs $pg_partition $pg_num_vu"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_count_ware $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_tspace $pg_user [ quotemeta $pg_pass ] $pg_oracompat $pg_cituscompat $pg_storedprocs $pg_partition $pg_num_vu $pg_citus_loadbalancer"
     } else { return }
 }
 
@@ -2543,10 +2585,17 @@ set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL Server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
 set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
+set citus_compatible \"$pg_cituscompat\" ;# Citus compatible schema
+set citus_lb_port \"$pg_citus_loadbalancer\" ;# Citus load balancer port
 set user \"$pg_user\" ;# PostgreSQL user
 set password \"[ quotemeta $pg_pass ]\" ;# Password for the PostgreSQL user
 set db \"$pg_dbase\" ;# Database containing the TPC Schema
 #OPTIONS
+#Override port if load balancer is configured
+if { \$azure_citus eq \"true\" && \$citus_compatible eq \"true\" && \$citus_lb_port > 0 } {
+    set port \$citus_lb_port
+    puts \"Using Citus load balancer port \$port for benchmark\"
+}
 "
     .ed_mainFrame.mainwin.textFrame.left.text fastinsert end {#LOAD LIBRARIES AND MODULES
 if [catch {package require $library} message] { error "Failed to load $library - $message" }
@@ -2852,6 +2901,8 @@ set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
 set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
+set citus_compatible \"$pg_cituscompat\" ;# Citus compatible schema
+set citus_lb_port \"$pg_citus_loadbalancer\" ;# Citus load balancer port
 set superuser \"$pg_superuser\" ;# Superuser privilege user
 set superuser_password \"[ quotemeta $pg_superuserpass ]\" ;# Password for Superuser
 set default_database \"$pg_defaultdbase\" ;# Default Database for Superuser
@@ -3023,6 +3074,11 @@ switch $myposition {
         }
     }
     default {
+        #Override port if load balancer is configured
+        if { $azure_citus eq "true" && $citus_compatible eq "true" && $citus_lb_port > 0 } {
+            set port $citus_lb_port
+            puts "Using Citus load balancer port $port for benchmark"
+        }
         #TIMESTAMP
         proc gettimestamp { } {
             set tstamp [ clock format [ clock seconds ] -format %Y%m%d%H%M%S ]
@@ -3463,6 +3519,11 @@ switch $myposition {
         }
     }
     default {
+        #Override port if load balancer is configured
+        if { $azure_citus eq "true" && $citus_compatible eq "true" && $citus_lb_port > 0 } {
+            set port $citus_lb_port
+            puts "Using Citus load balancer port $port for benchmark"
+        }
         #TIMESTAMP
         proc gettimestamp { } {
             set tstamp [ clock format [ clock seconds ] -format %Y%m%d%H%M%S ]

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -7,7 +7,7 @@ proc build_pgtpcc {} {
     upvar #0 configpostgresql configpostgresql
     #set variables to values in dict
     setlocaltpccvars $configpostgresql
-    if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a $pg_count_ware Warehouse PostgreSQL TPROC-C schema\nin host [string toupper $pg_host:$pg_port] sslmode [string toupper $pg_sslmode] under user [ string toupper $pg_user ] in database [ string toupper $pg_dbase ]?" -type yesno ] == yes} {
+    if {[ tk_messageBox -title "Create Schema" -icon question -message "Ready to create a $pg_count_ware Warehouse PostgreSQL TPROC-C schema\nin host [string toupper $pg_host:$pg_port] sslmode [string toupper $pg_sslmode] in azure_citus [string toupper $pg_azure_citus] under user [ string toupper $pg_user ] in database [ string toupper $pg_dbase ]?" -type yesno ] == yes} {
         if { $pg_num_vu eq 1 || $pg_count_ware eq 1 } {
             set maxvuser 1
         } else {
@@ -1595,9 +1595,11 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     return $lda
 }
 
-proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_password user password } {
+proc CreateUserDatabase { lda host port sslmode azure_citus db tspace superuser superuser_password user password } {
     set stmnt_count 1
-    puts "CREATING DATABASE $db under OWNER $user"
+    if { !$azure_citus } {
+        puts "CREATING DATABASE $db under OWNER $user"
+    }
     set result [ pg_exec $lda "SELECT 1 FROM pg_roles WHERE rolname = '$user'"]
     if { [pg_result $result -numTuples] == 0 } {
         set sql($stmnt_count) "CREATE USER \"$user\" PASSWORD '$password'"
@@ -1609,7 +1611,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
     }
     
     set result [ pg_exec $lda "SELECT 1 FROM pg_database WHERE datname = '$db'"]
-    if { [pg_result $result -numTuples] == 0} {
+    if { [pg_result $result -numTuples] == 0 && !$azure_citus } {
 	incr stmnt_count;
         set sql($stmnt_count) "CREATE DATABASE \"$db\" OWNER \"$user\""
     } else {
@@ -1619,23 +1621,28 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
         } else {
             set result [ pg_exec $existing_db "SELECT 1 FROM pg_tables WHERE schemaname = 'public'"]
             if { [pg_result $result -numTuples] == 0 } {
+                if { !$azure_citus } {
+                    puts "Using existing empty Database $db for Schema build"
+                    set is_db_owner_query [ pg_exec $existing_db "WITH RECURSIVE cte AS (SELECT oid, 0 AS steps, true AS inherit_option FROM pg_roles WHERE  rolname = '$user' UNION ALL SELECT m.roleid, c.steps + 1, c.inherit_option AND c.inherit_option FROM   cte c JOIN pg_auth_members m ON m.member = c.oid ) SELECT count(*) > 0 AS is_owner FROM cte, pg_database db WHERE cte.oid=db.datdba and db.datname = '$db'"]
 
-  	        puts "Using existing empty Database $db for Schema build"
-    	        set is_db_owner_query [ pg_exec $existing_db "WITH RECURSIVE cte AS (SELECT oid, 0 AS steps, true AS inherit_option FROM pg_roles WHERE  rolname = '$user' UNION ALL SELECT m.roleid, c.steps + 1, c.inherit_option AND c.inherit_option FROM   cte c JOIN pg_auth_members m ON m.member = c.oid ) SELECT count(*) > 0 AS is_owner FROM cte, pg_database db WHERE cte.oid=db.datdba and db.datname = '$db'"]
-
-                if { [pg_result $is_db_owner_query -status] != "PGRES_TUPLES_OK"} {
-                    puts "is_db_owner_query returned [pg_result $is_db_owner_query -status]"
-                    error "[pg_result $is_db_owner_query -error]"
-                } else {
-                    set is_db_owner [pg_result $is_db_owner_query -list]
-                    if { $is_db_owner == f } {
-                         incr stmnt_count;
-                         set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+                    if { [pg_result $is_db_owner_query -status] != "PGRES_TUPLES_OK"} {
+                        puts "is_db_owner_query returned [pg_result $is_db_owner_query -status]"
+                        error "[pg_result $is_db_owner_query -error]"
+                    } else {
+                        set is_db_owner [pg_result $is_db_owner_query -list]
+                        if { $is_db_owner == f } {
+                            incr stmnt_count;
+                            set sql($stmnt_count) "ALTER DATABASE $db OWNER TO $user"
+                        }
                     }
-                }
 
-                puts "Using existing empty Database $db for Schema build"
-                set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
+                    puts "Using existing empty Database $db for Schema build"
+                    set sql($stmnt_count) "ALTER DATABASE \"$db\" OWNER TO \"$user\""
+                } else {
+                    # Azure Citus (Azure Elastic Cluster) mode - database must pre-exist
+                    puts "Azure Citus (Azure Elastic Cluster) mode: Using existing database $db"
+                    puts "Ensure database $db exists and user $user has appropriate permissions"
+                }
             } else {
                 puts "Database with tables $db exists"
                 error "Database $db exists but is not empty, specify a new or empty database name"
@@ -1643,7 +1650,7 @@ proc CreateUserDatabase { lda host port sslmode db tspace superuser superuser_pa
         }
         pg_disconnect $existing_db
     }
-    if { $tspace != "pg_default" } {
+    if { $tspace != "pg_default" && !$azure_citus } {
         incr stmnt_count
         set sql($stmnt_count) "ALTER DATABASE $db SET TABLESPACE $tspace"
     }
@@ -2082,7 +2089,7 @@ proc LoadOrd { lda ware_start count_ware MAXITEMS ORD_PER_DIST DIST_PER_WARE ora
     pg_result $result -clear
     return
 }
-proc do_tpcc { host port sslmode count_ware superuser superuser_password defaultdb db tspace user password ora_compatible citus_compatible pg_storedprocs partition num_vu } {
+proc do_tpcc { host port sslmode azure_citus count_ware superuser superuser_password defaultdb db tspace user password ora_compatible citus_compatible pg_storedprocs partition num_vu } {
     set MAXITEMS 100000
     set CUST_PER_DIST 3000
     set DIST_PER_WARE 10
@@ -2117,7 +2124,7 @@ proc do_tpcc { host port sslmode count_ware superuser superuser_password default
         if { $lda eq "Failed" } {
             error "error, the database connection to $host could not be established"
         } else {
-            CreateUserDatabase $lda $host $port $sslmode $db $tspace $superuser $superuser_password $user $password
+            CreateUserDatabase $lda $host $port $sslmode $azure_citus $db $tspace $superuser $superuser_password $user $password
             set result [ pg_exec $lda "commit" ]
             pg_result $result -clear
             pg_disconnect $lda
@@ -2212,7 +2219,7 @@ proc do_tpcc { host port sslmode count_ware superuser superuser_password default
     }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_sslmode $pg_count_ware $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_tspace $pg_user [ quotemeta $pg_pass ] $pg_oracompat $pg_cituscompat $pg_storedprocs $pg_partition $pg_num_vu"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "do_tpcc $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_count_ware $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_tspace $pg_user [ quotemeta $pg_pass ] $pg_oracompat $pg_cituscompat $pg_storedprocs $pg_partition $pg_num_vu"
     } else { return }
 }
 
@@ -2259,13 +2266,13 @@ proc insert_pgconnectpool_drivescript { testtype timedtype } {
             #Set the parameters to variables named from the keys, this allows us to build the connect strings according to the database
             dict with conparams {
                 #set PostgreSQL connect string
-                set $id [ list $pg_host $pg_port $pg_sslmode $pg_user $pg_pass $pg_dbase ]
+                set $id [ list $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_user $pg_pass $pg_dbase ]
             }
         }
         #For the connect keys c1, c2 etc make a connection
         foreach id [ split $conkeys ] {
-            lassign [ set $id ] 1 2 3 4 5 6
-            dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 $6 ] ]
+            lassign [ set $id ] 1 2 3 4 5 6 7
+            dict set connlist $id [ set lda$id [ ConnectToPostgres $1 $2 $3 $4 $5 $6 $7 ] ]
             if {  [ set lda$id ] eq "Failed" } {
                 puts "error, the database connection to $1 could not be established"
             }
@@ -2535,6 +2542,7 @@ set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL Server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
+set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
 set user \"$pg_user\" ;# PostgreSQL user
 set password \"[ quotemeta $pg_pass ]\" ;# Password for the PostgreSQL user
 set db \"$pg_dbase\" ;# Database containing the TPC Schema
@@ -2843,6 +2851,7 @@ set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
+set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
 set superuser \"$pg_superuser\" ;# Superuser privilege user
 set superuser_password \"[ quotemeta $pg_superuserpass ]\" ;# Password for Superuser
 set default_database \"$pg_defaultdbase\" ;# Default Database for Superuser
@@ -3278,6 +3287,7 @@ set pg_storedprocs \"$pg_storedprocs\" ;#Postgres v11 Stored Procedures
 set host \"$pg_host\" ;# Address of the server hosting PostgreSQL
 set port \"$pg_port\" ;# Port of the PostgreSQL server
 set sslmode \"$pg_sslmode\" ;# SSLMode of the PostgreSQL Server
+set azure_citus \"$pg_azure_citus\" ;# Azure like managed environment
 set superuser \"$pg_superuser\" ;# Superuser privilege user
 set superuser_password \"[ quotemeta $pg_superuserpass ]\" ;# Password for Superuser
 set default_database \"$pg_defaultdbase\" ;# Default Database for Superuser
@@ -3782,32 +3792,37 @@ proc ConnectToPostgres { host port sslmode user password dbname } {
     return $lda
 }
 
-proc drop_schema { host port sslmode user superuser superuser_password default_dbase dbase } {
+proc drop_schema { host port sslmode azure_citus user superuser superuser_password default_dbase dbase } {
     set suconnect [ ConnectToPostgres $host $port $sslmode $superuser $superuser_password $default_dbase ]
     if { $suconnect eq "Failed" } {
         error "error, the database connection to $host could not be established"
     } else {
-        set result [ pg_exec $suconnect "drop database $dbase"]
-        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-            error "[pg_result $result -error]"
+        if { !$azure_citus } {
+            set result [ pg_exec $suconnect "drop database $dbase"]
+            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+                error "[pg_result $result -error]"
+            } else {
+                puts "$dbase TPROC-C schema has been deleted successfully."
+                pg_result $result -clear
+            }
+            set result [ pg_exec $suconnect "drop role $user"]
+            if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
+                error "[pg_result $result -error]"
+            } else {
+                puts "$user TPROC-C role has been deleted successfully."
+                pg_result $result -clear
+            }
+            pg_disconnect $suconnect
         } else {
-            puts "$dbase TPROC-C schema has been deleted successfully."
-            pg_result $result -clear
+            puts "Azure Citus (Azure Elastic Cluster) mode: DROP DATABASE not supported"
+            puts "Please manually drop database $dbase and role $user using Azure portal or CLI if permissible"
         }
-        set result [ pg_exec $suconnect "drop role $user"]
-        if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {
-            error "[pg_result $result -error]"
-        } else {
-            puts "$user TPROC-C role has been deleted successfully."
-            pg_result $result -clear
-        }
-        pg_disconnect $suconnect
     }
     return
 }
 }
 
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_user $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "drop_schema $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_user $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase"
     } else { return }
 }
 
@@ -3963,6 +3978,6 @@ proc check_tpcc { host port sslmode user superuser superuser_password default_db
     }
 }
 }
-        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpcc $pg_host $pg_port $pg_sslmode $pg_user $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_count_ware"
+        .ed_mainFrame.mainwin.textFrame.left.text fastinsert end "check_tpcc $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_user $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_dbase $pg_count_ware"
     } else { return }
 }

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -17,9 +17,9 @@ proc countpgopts { bm } {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.countopt.c1.e3 get} pg_superuserpass {.countopt.c1.e4 get} pg_defaultdbase {.countopt.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.countopt.c1.e3 get} pg_superuserpass {.countopt.c1.e4 get} pg_defaultdbase {.countopt.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.countopt.c1.e3 get} pg_tpch_superuserpass {.countopt.c1.e4 get} pg_tpch_defaultdbase {.countopt.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.countopt.c1.e3 get} pg_tpch_superuserpass {.countopt.c1.e4 get} pg_tpch_defaultdbase {.countopt.c1.e5 get}} ]
     }
     if { [ info exists afval ] } {
         after cancel $afval
@@ -109,9 +109,16 @@ proc countpgopts { bm } {
     grid $Prompt -column 0 -row 7 -sticky e
     grid $Name -column 1 -row 7 -sticky w
 
+    set Prompt $Parent.c1.p6b
+    ttk::label $Prompt -text "Azure Citus (Azure Elastic Cluster) :"
+    set Name $Parent.c1.e6b
+    ttk::checkbutton $Name -text "" -variable pg_azure_citus -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 8 -sticky e
+    grid $Name -column 1 -row 8 -sticky w
+
     set Name $Parent.f1.e7
     ttk::checkbutton $Name -text "Log Output to Temp" -variable tclog -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 8 -sticky w
+    grid $Name -column 1 -row 9 -sticky w
     bind .countopt.f1.e7 <Button> {
         set opst [ .countopt.f1.e7 cget -state ]
         if {$opst != "disabled" && $tclog == 0} {
@@ -126,14 +133,14 @@ proc countpgopts { bm } {
     }
     set Name $Parent.f1.e8
     ttk::checkbutton $Name -text "Use Unique Log Name" -variable uniquelog -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 9 -sticky w
+    grid $Name -column 1 -row 10 -sticky w
     if {$tclog == 0} {
         $Name configure -state disabled
     }
 
     set Name $Parent.f1.e9
     ttk::checkbutton $Name -text "Log Timestamps" -variable tcstamp -onvalue 1 -offvalue 0
-    grid $Name -column 1 -row 10 -sticky w
+    grid $Name -column 1 -row 11 -sticky w
     if {$tclog == 0} {
         $Name configure -state disabled
     }
@@ -206,7 +213,7 @@ proc configpgtpcc {option} {
     setlocaltpccvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.tpc.c1.e1 get} pg_port {.tpc.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.tpc.c1.e3 get} pg_superuserpass {.tpc.c1.e4 get} pg_defaultdbase {.tpc.c1.e5 get} pg_user {.tpc.c1.e6 get} pg_pass {.tpc.c1.e7 get} pg_dbase {.tpc.c1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
+    set pgfields [ dict create connection {pg_host {.tpc.c1.e1 get} pg_port {.tpc.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.tpc.c1.e3 get} pg_superuserpass {.tpc.c1.e4 get} pg_defaultdbase {.tpc.c1.e5 get} pg_user {.tpc.c1.e6 get} pg_pass {.tpc.c1.e7 get} pg_dbase {.tpc.c1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
     set whlist [ get_warehouse_list_for_spinbox ]
     if { $pg_oracompat eq "true" } {
         if { $pg_port eq "5432" } { set pg_port "5444" }
@@ -355,6 +362,12 @@ proc configpgtpcc {option} {
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 13 -sticky e
     grid $Name -column 1 -row 13 -sticky w
+    set Prompt $Parent.c1.p9d
+    ttk::label $Prompt -text "Azure Citus (Azure Elastic Cluster) :"
+    set Name $Parent.c1.e9d
+    ttk::checkbutton $Name -text "" -variable pg_azure_citus -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky w
     if { $option eq "all" || $option eq "build" } {
         set Prompt $Parent.f1.p10
         ttk::label $Prompt -text "Number of Warehouses :"
@@ -371,8 +384,8 @@ proc configpgtpcc {option} {
                 .tpc.f1.e11a configure -state enabled
             }
         }
-        grid $Prompt -column 0 -row 14 -sticky e
-        grid $Name -column 1 -row 14 -sticky ew
+        grid $Prompt -column 0 -row 15 -sticky e
+        grid $Name -column 1 -row 15 -sticky ew
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e11
@@ -384,14 +397,14 @@ proc configpgtpcc {option} {
         }
         event add <<Any-Button-Any-Key>> <Any-ButtonRelease>
         event add <<Any-Button-Any-Key>> <KeyRelease>
-        grid $Prompt -column 0 -row 15 -sticky e
-        grid $Name -column 1 -row 15 -sticky ew
+        grid $Prompt -column 0 -row 16 -sticky e
+        grid $Name -column 1 -row 16 -sticky ew
         set Prompt $Parent.f1.p11a
         ttk::label $Prompt -text "Partition Order Line Table :"
         set Name $Parent.f1.e11a
         ttk::checkbutton $Name -text "" -variable pg_partition -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 16 -sticky e
-        grid $Name -column 1 -row 16 -sticky w
+        grid $Prompt -column 0 -row 17 -sticky e
+        grid $Name -column 1 -row 17 -sticky w
         if {$pg_count_ware < 200 } {
             $Name configure -state disabled
         }
@@ -651,7 +664,7 @@ proc configpgtpch {option} {
     setlocaltpchvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.pgtpch.c1.e1 get} pg_port {.pgtpch.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.pgtpch.c1.e3 get} pg_tpch_superuserpass {.pgtpch.c1.e4 get} pg_tpch_defaultdbase {.pgtpch.c1.e5 get} pg_tpch_user {.pgtpch.c1.e6 get} pg_tpch_pass {.pgtpch.c1.e7 get} pg_tpch_dbase {.pgtpch.c1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
+    set pgfields [ dict create connection {pg_host {.pgtpch.c1.e1 get} pg_port {.pgtpch.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.pgtpch.c1.e3 get} pg_tpch_superuserpass {.pgtpch.c1.e4 get} pg_tpch_defaultdbase {.pgtpch.c1.e5 get} pg_tpch_user {.pgtpch.c1.e6 get} pg_tpch_pass {.pgtpch.c1.e7 get} pg_tpch_dbase {.pgtpch.c1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
     catch "destroy .pgtpch"
     ttk::toplevel .pgtpch
     wm transient .pgtpch .ed_mainFrame
@@ -732,6 +745,12 @@ proc configpgtpch {option} {
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 10 -sticky e
     grid $Name -column 1 -row 10 -sticky w
+    set Prompt $Parent.c1.p8c
+    ttk::label $Prompt -text "Azure Citus (Azure Elastic Cluster) :"
+    set Name $Parent.c1.e8c
+    ttk::checkbutton $Name -text "" -variable pg_azure_citus -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky w
     if { $option eq "all" || $option eq "build" } {
         set Name $Parent.f1.e8a
         set Prompt $Parent.f1.p8a
@@ -751,24 +770,24 @@ proc configpgtpch {option} {
                 .pgtpch.f1.e10 configure -state normal
             }
         }
-        grid $Prompt -column 0 -row 11 -sticky e
-        grid $Name -column 1 -row 11 -sticky w
+        grid $Prompt -column 0 -row 12 -sticky e
+        grid $Name -column 1 -row 12 -sticky w
         set Prompt $Parent.f1.p10
         ttk::label $Prompt -text "Greenplum Compressed Columns :"
         set Name $Parent.f1.e10
         ttk::checkbutton $Name -text "" -variable pg_tpch_gpcompress -onvalue "true" -offvalue "false"
-        grid $Prompt -column 0 -row 12 -sticky e
-        grid $Name -column 1 -row 12 -sticky w
+        grid $Prompt -column 0 -row 13 -sticky e
+        grid $Name -column 1 -row 13 -sticky w
         if {$pg_tpch_gpcompat == "false" } {
             $Name configure -state disabled
         }
         set Name $Parent.f1.e11
         set Prompt $Parent.f1.p11
         ttk::label $Prompt -text "Scale Factor :"
-        grid $Prompt -column 0 -row 13 -sticky e
+        grid $Prompt -column 0 -row 14 -sticky e
         set Name $Parent.f1.f2
         ttk::frame $Name -width 30
-        grid $Name -column 1 -row 13 -sticky ew
+        grid $Name -column 1 -row 14 -sticky ew
         # top row
         set rcnt 1
         foreach item {1} {
@@ -815,8 +834,8 @@ proc configpgtpch {option} {
         ttk::label $Prompt -text "Virtual Users to Build Schema :"
         set Name $Parent.f1.e12
         ttk::spinbox $Name -from 1 -to 512 -textvariable pg_num_tpch_threads
-        grid $Prompt -column 0 -row 14 -sticky e
-        grid $Name -column 1 -row 14 -sticky ew
+        grid $Prompt -column 0 -row 15 -sticky e
+        grid $Name -column 1 -row 15 -sticky ew
     }
     if { $option eq "all" || $option eq "drive" } {
         if { $option eq "all" } {
@@ -966,9 +985,9 @@ proc metpgopts {} {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode} tpcc {pg_superuser {.metric.c1.e3 get} pg_superuserpass {.metric.c1.e4 get} pg_defaultdbase {.metric.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.metric.c1.e3 get} pg_superuserpass {.metric.c1.e4 get} pg_defaultdbase {.metric.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode} tpch {pg_tpch_superuser {.metric.c1.e3 get} pg_tpch_superuserpass {.metric.c1.e4 get} pg_tpch_defaultdbase {.metric.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.metric.c1.e3 get} pg_tpch_superuserpass {.metric.c1.e4 get} pg_tpch_defaultdbase {.metric.c1.e5 get}} ]
     }
     if { $bm eq "TPC-C" } {
         if { $pg_oracompat eq "true" } {
@@ -1049,18 +1068,24 @@ proc metpgopts {} {
     ttk::checkbutton $Name -text "" -variable pg_sslmode -onvalue "prefer" -offvalue "disable"
     grid $Prompt -column 0 -row 6 -sticky e
     grid $Name -column 1 -row 6 -sticky w
+    set Prompt $Parent.c1.p6a
+    ttk::label $Prompt -text "Azure Citus (Azure Elastic Cluster) :"
+    set Name $Parent.c1.e6a
+    ttk::checkbutton $Name -text "" -variable pg_azure_citus -onvalue "true" -offvalue "false"
+    grid $Prompt -column 0 -row 7 -sticky e
+    grid $Name -column 1 -row 7 -sticky w
     set Name $Parent.f1.e7
     set Prompt $Parent.f1.p7
     ttk::label $Prompt -text "Agent ID :"
     ttk::entry $Name -width 30 -textvariable agent_id
-    grid $Prompt -column 0 -row 7 -sticky e
-    grid $Name -column 1 -row 7
+    grid $Prompt -column 0 -row 8 -sticky e
+    grid $Name -column 1 -row 8
     set Name $Parent.f1.e8
     set Prompt $Parent.f1.p8
     ttk::label $Prompt -text "Agent Hostname :"
     ttk::entry $Name -width 30 -textvariable agent_hostname
-    grid $Prompt -column 0 -row 8 -sticky e
-    grid $Name -column 1 -row 8
+    grid $Prompt -column 0 -row 9 -sticky e
+    grid $Name -column 1 -row 9
     set Name $Parent.f1.e9
     set Prompt $Parent.f1.p9
     ttk::label $Prompt -text "Agent Start :"
@@ -1071,8 +1096,8 @@ proc metpgopts {} {
             tk_messageBox -message "Agent hostname must be local to start, start manually on remote hosts"
     }
     } -text Start
-    grid $Prompt -column 0 -row 9 -sticky e
-    grid $Name -column 1 -row 9 -sticky w
+    grid $Prompt -column 0 -row 10 -sticky e
+    grid $Name -column 1 -row 10 -sticky w
         if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
         $Name configure -state disabled
     }
@@ -1082,22 +1107,22 @@ proc metpgopts {} {
     ttk::button $Name -command {
     agstop $agent_hostname $agent_id
     } -text Stop
-    grid $Prompt -column 0 -row 10 -sticky e
-    grid $Name -column 1 -row 10 -sticky w
+    grid $Prompt -column 0 -row 11 -sticky e
+    grid $Name -column 1 -row 11 -sticky w
     set Name $Parent.f1.e11
     set Prompt $Parent.f1.p11
     ttk::label $Prompt -text "Agent Status :"
     ttk::button $Name -command {
     agstatus $agent_hostname $agent_id
     } -text Status
-    grid $Prompt -column 0 -row 11 -sticky e
-    grid $Name -column 1 -row 11 -sticky w
+    grid $Prompt -column 0 -row 12 -sticky e
+    grid $Name -column 1 -row 12 -sticky w
     set Name $Parent.f1.e12
     set Prompt $Parent.f1.p12
     ttk::label $Prompt -text "Start Display with Local Agent :"
     ttk::checkbutton $Name -text "" -variable start_display -onvalue "true" -offvalue "false"
-    grid $Prompt -column 0 -row 13 -sticky e
-    grid $Name -column 1 -row 13 -sticky w
+    grid $Prompt -column 0 -row 14 -sticky e
+    grid $Name -column 1 -row 14 -sticky w
         if { !($agent_hostname eq "localhost" || $agent_hostname eq [ info hostname ]) } { 
 	set start_display false
         $Name configure -state disabled

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -17,9 +17,9 @@ proc countpgopts { bm } {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.countopt.c1.e3 get} pg_superuserpass {.countopt.c1.e4 get} pg_defaultdbase {.countopt.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer $pg_citus_loadbalancer} tpcc {pg_superuser {.countopt.c1.e3 get} pg_superuserpass {.countopt.c1.e4 get} pg_defaultdbase {.countopt.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.countopt.c1.e3 get} pg_tpch_superuserpass {.countopt.c1.e4 get} pg_tpch_defaultdbase {.countopt.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.countopt.c1.e1 get} pg_port {.countopt.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer $pg_citus_loadbalancer} tpch {pg_tpch_superuser {.countopt.c1.e3 get} pg_tpch_superuserpass {.countopt.c1.e4 get} pg_tpch_defaultdbase {.countopt.c1.e5 get}} ]
     }
     if { [ info exists afval ] } {
         after cancel $afval
@@ -213,7 +213,7 @@ proc configpgtpcc {option} {
     setlocaltpccvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.tpc.c1.e1 get} pg_port {.tpc.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.tpc.c1.e3 get} pg_superuserpass {.tpc.c1.e4 get} pg_defaultdbase {.tpc.c1.e5 get} pg_user {.tpc.c1.e6 get} pg_pass {.tpc.c1.e7 get} pg_dbase {.tpc.c1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
+    set pgfields [ dict create connection {pg_host {.tpc.c1.e1 get} pg_port {.tpc.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer {.tpc.c1.e9e get}} tpcc {pg_superuser {.tpc.c1.e3 get} pg_superuserpass {.tpc.c1.e4 get} pg_defaultdbase {.tpc.c1.e5 get} pg_user {.tpc.c1.e6 get} pg_pass {.tpc.c1.e7 get} pg_dbase {.tpc.c1.e8 get} pg_tspace {.tpc.f1.e8a get} pg_total_iterations {.tpc.f1.e15 get} pg_rampup {.tpc.f1.e21 get} pg_duration {.tpc.f1.e22 get} pg_async_client {.tpc.f1.e26 get} pg_async_delay {.tpc.f1.e27 get} pg_count_ware $pg_count_ware pg_vacuum $pg_vacuum pg_dritasnap $pg_dritasnap pg_oracompat $pg_oracompat pg_cituscompat $pg_cituscompat pg_storedprocs $pg_storedprocs pg_partition $pg_partition pg_num_vu $pg_num_vu pg_total_iterations $pg_total_iterations pg_raiseerror $pg_raiseerror pg_keyandthink $pg_keyandthink pg_driver $pg_driver pg_rampup $pg_rampup pg_duration $pg_duration pg_allwarehouse $pg_allwarehouse pg_timeprofile $pg_timeprofile pg_async_scale $pg_async_scale pg_connect_pool $pg_connect_pool pg_async_verbose $pg_async_verbose}]
     set whlist [ get_warehouse_list_for_spinbox ]
     if { $pg_oracompat eq "true" } {
         if { $pg_port eq "5432" } { set pg_port "5444" }
@@ -366,8 +366,24 @@ proc configpgtpcc {option} {
     ttk::label $Prompt -text "Azure Citus (Azure Elastic Cluster) :"
     set Name $Parent.c1.e9d
     ttk::checkbutton $Name -text "" -variable pg_azure_citus -onvalue "true" -offvalue "false"
+    bind $Parent.c1.e9d <Button> {
+        if {$pg_azure_citus eq "true"} {
+            .tpc.c1.e9e configure -state disabled
+        } else {
+            .tpc.c1.e9e configure -state normal
+        }
+    }
     grid $Prompt -column 0 -row 14 -sticky e
     grid $Name -column 1 -row 14 -sticky w
+    set Prompt $Parent.c1.p9e
+    ttk::label $Prompt -text "Citus Load Balancer Port :"
+    set Name $Parent.c1.e9e
+    ttk::entry $Name -width 30 -textvariable pg_citus_loadbalancer
+    grid $Prompt -column 0 -row 15 -sticky e
+    grid $Name -column 1 -row 15 -sticky ew
+    if { $pg_azure_citus ne "true" } {
+        $Name configure -state disabled
+    }
     if { $option eq "all" || $option eq "build" } {
         set Prompt $Parent.f1.p10
         ttk::label $Prompt -text "Number of Warehouses :"
@@ -664,7 +680,7 @@ proc configpgtpch {option} {
     setlocaltpchvars $configpostgresql
     #set matching fields in dialog to temporary dict
     variable pgfields
-    set pgfields [ dict create connection {pg_host {.pgtpch.c1.e1 get} pg_port {.pgtpch.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.pgtpch.c1.e3 get} pg_tpch_superuserpass {.pgtpch.c1.e4 get} pg_tpch_defaultdbase {.pgtpch.c1.e5 get} pg_tpch_user {.pgtpch.c1.e6 get} pg_tpch_pass {.pgtpch.c1.e7 get} pg_tpch_dbase {.pgtpch.c1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
+    set pgfields [ dict create connection {pg_host {.pgtpch.c1.e1 get} pg_port {.pgtpch.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer $pg_citus_loadbalancer} tpch {pg_tpch_superuser {.pgtpch.c1.e3 get} pg_tpch_superuserpass {.pgtpch.c1.e4 get} pg_tpch_defaultdbase {.pgtpch.c1.e5 get} pg_tpch_user {.pgtpch.c1.e6 get} pg_tpch_pass {.pgtpch.c1.e7 get} pg_tpch_dbase {.pgtpch.c1.e8 get} pg_tpch_tspace {.pgtpch.f1.e8a get} pg_num_tpch_threads {.pgtpch.f1.e12 get} pg_total_querysets {.pgtpch.f1.e14 get} pg_degree_of_parallel {.pgtpch.f1.e16a get} pg_update_sets {.pgtpch.f1.e18 get} pg_trickle_refresh {.pgtpch.f1.e19 get} pg_scale_fact $pg_scale_fact pg_tpch_gpcompat $pg_tpch_gpcompat pg_tpch_gpcompress $pg_tpch_gpcompress pg_raise_query_error $pg_raise_query_error pg_verbose $pg_verbose pg_refresh_on $pg_refresh_on pg_refresh_verbose $pg_refresh_verbose pg_cloud_query $pg_cloud_query pg_rs_compat $pg_rs_compat}]
     catch "destroy .pgtpch"
     ttk::toplevel .pgtpch
     wm transient .pgtpch .ed_mainFrame
@@ -985,9 +1001,9 @@ proc metpgopts {} {
         if {[dict exists configpostgresql tpcc pg_oracompat ]} {
             set pg_oracompat [ dict get configpostgresql tpcc pg_oracompat ]
         }
-        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpcc {pg_superuser {.metric.c1.e3 get} pg_superuserpass {.metric.c1.e4 get} pg_defaultdbase {.metric.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer $pg_citus_loadbalancer} tpcc {pg_superuser {.metric.c1.e3 get} pg_superuserpass {.metric.c1.e4 get} pg_defaultdbase {.metric.c1.e5 get}} ]
     } else {
-        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus} tpch {pg_tpch_superuser {.metric.c1.e3 get} pg_tpch_superuserpass {.metric.c1.e4 get} pg_tpch_defaultdbase {.metric.c1.e5 get}} ]
+        set pgoptsfields [ dict create connection {pg_host {.metric.c1.e1 get} pg_port {.metric.c1.e2 get} pg_sslmode $pg_sslmode pg_azure_citus $pg_azure_citus pg_citus_loadbalancer $pg_citus_loadbalancer} tpch {pg_tpch_superuser {.metric.c1.e3 get} pg_tpch_superuserpass {.metric.c1.e4 get} pg_tpch_defaultdbase {.metric.c1.e5 get}} ]
     }
     if { $bm eq "TPC-C" } {
         if { $pg_oracompat eq "true" } {

--- a/src/postgresql/pgotc.tcl
+++ b/src/postgresql/pgotc.tcl
@@ -17,7 +17,7 @@ proc tcount_pg {bm interval masterthread} {
             }
             return $lda
         }
-        proc read_more { MASTER library pg_host pg_port pg_sslmode pg_superuser pg_superuserpass pg_defaultdbase pg_tpch_superuser pg_tpch_superuserpass pg_tpch_defaultdbase interval old tce bm } {
+        proc read_more { MASTER library pg_host pg_port pg_sslmode pg_azure_citus pg_superuser pg_superuserpass pg_defaultdbase pg_tpch_superuser pg_tpch_superuserpass pg_tpch_defaultdbase interval old tce bm } {
             set timeout 0
             set iconflag 0
             if { $interval <= 0 } { set interval 10 } 
@@ -50,7 +50,7 @@ proc tcount_pg {bm interval masterthread} {
             } else { 
                 namespace import tcountcommon::* 
             }
-            set tc_lda [ ConnectToPostgres $pg_host $pg_port $pg_sslmode $tmp_pg_su $tmp_pg_supass $tmp_pg_defdb ]
+            set tc_lda [ ConnectToPostgres $pg_host $pg_port $pg_sslmode $pg_azure_citus $tmp_pg_su $tmp_pg_supass $tmp_pg_defdb ]
             if { [string match {*connection*} $tc_lda] } {
                 tsv::set application tc_errmsg $tc_lda
                 eval [subst {thread::send $MASTER show_tc_errmsg}]
@@ -131,5 +131,5 @@ proc tcount_pg {bm interval masterthread} {
     catch {eval [ subst {thread::send $tc_threadID {lappend ::auto_path [zipfs root]app/lib}}]}
     catch {eval [ subst {thread::send $tc_threadID {::tcl::tm::path add [zipfs root]app/modules modules}}]}
     #Call Transaction Counter to start read_more loop
-    eval [ subst {thread::send -async $tc_threadID { read_more $masterthread $library $pg_host $pg_port $pg_sslmode $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $interval $old tce $bm }}] 
+    eval [ subst {thread::send -async $tc_threadID { read_more $masterthread $library $pg_host $pg_port $pg_sslmode $pg_azure_citus $pg_superuser [ quotemeta $pg_superuserpass ] $pg_defaultdbase $pg_tpch_superuser [ quotemeta $pg_tpch_superuserpass ] $pg_tpch_defaultdbase $interval $old tce $bm }}]
 } 


### PR DESCRIPTION
This PR adds support for Azure Citus (Azure Elastic Cluster) environments and Citus load balancer port routing for PostgreSQL TPC-C workloads.

### Changes
**Azure Citus support (pg_azure_citus)**
- 
Add pg_azure_citus connection setting to prevent CREATE, ALTER and DROP database operations in Azure Citus managed environments
- Add pg_citus_loadbalancer connection setting for specifying the Citus load balancer port
- Update connection options UI to expose Azure Citus and load balancer port settings
- Add corresponding XML config entries in [`config/postgresql.xml`](https://github.com/TPC-Council/HammerDB/pull/862/changes#diff-adfd032ccd56fec58c14d88cd524a6d9b69b944410c3cd37d6333eee6c8c7e0b)

**Citus load balancer port routing (pg_citus_loadbalancer)**
- Route data population workers through the load balancer port during schema build when Azure Citus and Citus Compatible modes are enabled
- Route OLTP benchmark worker VUs through the load balancer port for non-timed, timed sync, and timed async driver scripts
- DDL operations remain routed through the coordinator via the standard PostgreSQL port
- Add GetDataPort helper to determine the correct port based on configuration

**Documentation**
- Add DocBook documentation entry for the Citus Load Balancer Port setting
- Configuration
- Two new connection settings under [`config/postgresql.xml`](https://github.com/TPC-Council/HammerDB/pull/862/changes#diff-adfd032ccd56fec58c14d88cd524a6d9b69b944410c3cd37d6333eee6c8c7e0b)

### How it works

When `pg_azure_citus` and `pg_cituscompat` are both enabled and `pg_citus_loadbalancer` is set to a non-zero value:
- Schema build: Monitor VU performs DDL on the coordinator (standard port), worker VUs populate data through the load balancer port
- OLTP benchmark: Worker VUs connect through the load balancer port; monitor VU uses the coordinator port for admin tasks (DRITA snapshots, vacuum, transaction counting)