### PR TITLE
Standardise Cluster Connect Pool terminology

### DIFF
--- a/modules/tpcccommon-1.0.tm
+++ b/modules/tpcccommon-1.0.tm
@@ -174,7 +174,7 @@ namespace eval tpcccommon {
       async_time [ expr $as_thkt * 1000 ]
     }
   }
-  #Find a Valid XML Connect Pool Config Directory,don't look in zipped fs as user needs to edit
+  #Find a Valid Cluster Connect Pool Config Directory,don't look in zipped fs as user needs to edit
   proc find_cpool_dir {} {
   if [ catch {set ISConfigDir [ file join  {*}[ lrange [ file split [ file normalize [ file dirname [ info script ] ]]] 0 end-2 ] config connectpool ]} message ] { set ISConfigDir "" }
   set PWConfigDir [ file join [ pwd ] config connectpool ]
@@ -187,19 +187,19 @@ namespace eval tpcccommon {
   }
   return "FNF"
   }
-  #XML Connect Data
+  #Cluster Connect Data
   proc get_connect_xml { prefix } {
     if [catch {package require xml} ] { error "Failed to load xml package in tpcccommon module" } 
     set cpooldir [ find_cpool_dir ]
     if { $cpooldir eq "FNF" } {
-      error "Connect Pool specified but cannot find XML connectpool directory or connect pool XML files"
+      error "Cluster Connect Pool specified but cannot find connectpool directory or XML files"
 	} else {
     set connect "$cpooldir/$prefix\cpool.xml"
     if { [ file exists $connect ] } { 
       set cpool [ ::XML::To_Dict_Ml $connect ] 
       return $cpool
     } else {
-      error "Connect Pool specified but file $connect does not exist" 
+      error "Cluster Connect Pool specified but file $connect does not exist" 
      }
    }
  }

--- a/src/db2/db2opt.tcl
+++ b/src/db2/db2opt.tcl
@@ -470,7 +470,7 @@ proc configdb2tpcc {option} {
         }
         set Name $Parent.c1.e26
         set Prompt $Parent.c1.p26
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable db2_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 26 -sticky e
         grid $Name -column 1 -row 26 -sticky ew

--- a/src/mariadb/mariaopt.tcl
+++ b/src/mariadb/mariaopt.tcl
@@ -863,7 +863,7 @@ proc configmariatpcc {option} {
 
         set Name $Parent.c1.e25
         set Prompt $Parent.c1.p25
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable maria_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 38 -sticky e
         grid $Name -column 1 -row 38 -sticky ew

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -678,7 +678,7 @@ proc configmssqlstpcc {option} {
         }
         set Name $Parent.c1.e26
         set Prompt $Parent.c1.p26
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mssqls_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 37 -sticky e
         grid $Name -column 1 -row 37 -sticky ew

--- a/src/mysql/mysqlopt.tcl
+++ b/src/mysql/mysqlopt.tcl
@@ -851,7 +851,7 @@ proc configmysqltpcc {option} {
         }
         set Name $Parent.c1.e25
         set Prompt $Parent.c1.p25
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable mysql_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 37 -sticky e
         grid $Name -column 1 -row 37 -sticky ew

--- a/src/oracle/oraopt.tcl
+++ b/src/oracle/oraopt.tcl
@@ -548,7 +548,7 @@ proc configoratpcc {option} {
         }
         set Name $Parent.c1.e29
         set Prompt $Parent.c1.p29
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 31 -sticky e
         grid $Name -column 1 -row 31 -sticky ew

--- a/src/postgresql/pgopt.tcl
+++ b/src/postgresql/pgopt.tcl
@@ -602,7 +602,7 @@ proc configpgtpcc {option} {
         }
         set Name $Parent.c1.e29
         set Prompt $Parent.c1.p29
-        ttk::label $Prompt -text "XML Connect Pool :"
+        ttk::label $Prompt -text "Cluster Connect Pool :"
         ttk::checkbutton $Name -text "" -variable pg_connect_pool -onvalue "true" -offvalue "false"
         grid $Prompt -column 0 -row 34 -sticky e
         grid $Name -column 1 -row 34 -sticky ew


### PR DESCRIPTION
This change standardises the user-facing terminology to “Cluster Connect Pool” across the UI and supporting code to highlight that typical usage is for clusters.