### PR TITLE
Fix form warnings for proxy

### DIFF
--- a/modules/pipelines-1.0.tm
+++ b/modules/pipelines-1.0.tm
@@ -537,6 +537,16 @@ proc __url_encode {s} {
 
     proc wapp-page-pipelines {} {
         set B [wapp-param BASE_URL]
+        set xfproto [wapp-param HTTP_X_FORWARDED_PROTO]
+        set xfhost  [wapp-param HTTP_X_FORWARDED_HOST]
+        set host  [wapp-param HTTP_HOST]
+        if {$xfproto ne ""} {
+        if {$xfhost ne ""} {
+           set B "$xfproto://$xfhost"
+           } elseif {$host ne ""} {
+          set B "$xfproto://$host"
+          }
+        }
 	set windows_host [expr {$::tcl_platform(platform) eq "windows"}]
 
         # parse query


### PR DESCRIPTION
In the webservice when clicking on Run Benchmark and it is running under nginx it warns that the data it is about to submit is unsafe as it uses the http url instead of https. This PR fixes that issues so no warning is given.