### PR TITLE
Fix profile compare form and hide unsupported from automation

### DIFF
--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -1647,7 +1647,7 @@ proc wapp-page-jobs {} {
         }
         wapp-subst {<h3 class="title">TPROC-C Performance Profiles</h3>}
         wapp-subst {<p style="margin:0 0 6px 0; opacity:0.75;">Select one <b>Base</b> profile and one <b>New</b> profile, click <b>Compare Profiles</b> to compare.</p>}
-        wapp-subst {<form method="GET" action="%html([wapp-param BASE_URL]/jobs)">}
+        wapp-subst {<form method="GET" action="%html(/jobs)">}
         wapp-subst {<input type="hidden" name="cmd" value="profilediff">}
         wapp-subst {<div style="display:inline-block; max-width:100%;">}
         wapp-subst {<div style="overflow-x:auto;">}

--- a/modules/pipelines-1.0.tm
+++ b/modules/pipelines-1.0.tm
@@ -869,6 +869,8 @@ return
         wapp-subst {<p><b>Database</b></p>}
         wapp-subst "<select class='aut-ctl' name='db' onchange=\"window.location='%html($B)/pipelines?db=' + encodeURIComponent(this.value)\">"
         foreach {pfx label} [ list ora Oracle mssqls "SQL Server" db2 Db2 mysql MySQL pg PostgreSQL maria MariaDB ] {
+            # Hide DBs until support is enabled
+            if {$pfx in {ora mssqls db2}} continue
             set sel ""
             if {$dbprefix eq $pfx} { set sel " selected" }
             wapp-subst "<option value='%html($pfx)'$sel>%html($label)</option>"


### PR DESCRIPTION
Implements a similar fix to #877 for the Jobs page so profile comparisons do not warn about unsecure data by making the page reference relative. 
Also comments out Oracle, SQL Server and Db2 from the initial dropdown for CI/Automation so only MySQL, PostgreSQL and MariaDB are visible.