### PR TITLE
Fix arithmetic in PostgreSQL stock update

### DIFF
--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -85,7 +85,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             integrity_viol			EXCEPTION;
             PRAGMA EXCEPTION_INIT(integrity_viol,-1);
             BEGIN
-            --assignment below added due to error in appendix code
             no_o_all_local := 0;
             SELECT c_discount, c_last, c_credit, w_tax
             INTO no_c_discount, no_c_last, no_c_credit, no_w_tax
@@ -114,7 +113,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             no_ol_supply_w_id := no_w_id;
             ELSE
             no_ol_supply_w_id := no_w_id;
-            --no_all_local is actually used before this point so following not beneficial
             no_o_all_local := 0;
             WHILE ((no_ol_supply_w_id = no_w_id) AND (no_max_w_id != 1))
             LOOP
@@ -260,7 +258,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             --#2.4.1.5.3
             o_quantity_array(loop_counter) := round(DBMS_RANDOM.value(low => 1, high => 10));
 
-            -- Take advantage of the fact that I'm looping to populate the array used to record order lines at the end
             ol_line_number_array(loop_counter) := loop_counter;
             END LOOP;
 
@@ -269,7 +266,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             INSERT INTO ORDERS (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (no_d_next_o_id, no_d_id, no_w_id, no_c_id, timestamp, no_o_ol_cnt, no_o_all_local);
             INSERT INTO NEW_ORDER (no_o_id, no_d_id, no_w_id) VALUES (no_d_next_o_id, no_d_id, no_w_id);
 
-            -- The HammerDB implementation doesn't do the check for ORIGINAL (which should be done against i_data and s_data)
             IF no_d_id = 1 THEN
             FORALL i IN 1 .. no_o_ol_cnt
             UPDATE stock_item
@@ -352,7 +348,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             RETURNING s_dist_10, s_quantity, i_price * o_quantity_array(i) BULK COLLECT INTO district_info, s_quantity_array,amount_array;
             END IF;
 
-            -- Oracle return the TAX information to the client, presumably to do the calculation there.  HammerDB doesn't return it at all so I'll just calculate it here and do nothing with it
             order_amount := 0;
             FOR loop_counter IN 1 .. no_o_ol_cnt
             LOOP
@@ -364,7 +359,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
             VALUES (no_d_next_o_id, no_d_id, no_w_id, ol_line_number_array(i), o_id_array(i), w_id_array(i), o_quantity_array(i), amount_array(i), district_info(i));
 
-            -- Rollback 1% of transactions
             IF DBMS_RANDOM.value < 0.01 THEN
             dbms_output.put_line('Rolling back');
             ROLLBACK;
@@ -373,7 +367,7 @@ proc CreateStoredProcs { lda timesten num_part } {
             END IF;
 
             EXCEPTION
-            WHEN not_serializable OR deadlock OR snapshot_too_old OR integrity_viol --OR no_data_found
+            WHEN not_serializable OR deadlock OR snapshot_too_old OR integrity_viol
             THEN
             ROLLBACK;
         END; }
@@ -541,8 +535,6 @@ proc CreateStoredProcs { lda timesten num_part } {
             FORALL c IN 1.. ordcnt
             UPDATE customer
             SET c_balance = c_balance + sums(c)
-            -- Added this in for the refactor but it's not in the original (although it should be) so I've removed it, to be true to the original
-            --, c_delivery_cnt = c_delivery_cnt + 1
             WHERE c_w_id = d_w_id
             AND c_d_id = dist_id_array(c)
             AND c_id = order_c_id(c);
@@ -625,8 +617,6 @@ proc CreateStoredProcs { lda timesten num_part } {
 
         UPDATE customer
         SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
         WHERE rowid = cust_rowid
         RETURNING c_id, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,
@@ -639,8 +629,6 @@ proc CreateStoredProcs { lda timesten num_part } {
         ELSE
         UPDATE customer
         SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
         WHERE c_id = p_c_id AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id
         RETURNING rowid, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,
@@ -763,15 +751,6 @@ proc CreateStoredProcs { lda timesten num_part } {
         WHERE c_id = os_c_id AND c_d_id = os_d_id AND c_w_id = os_w_id;
         END IF;
 
-        -- The following statement in the TPC-C specification appendix is incorrect
-        -- as it does not include the where clause and does not restrict the
-        -- results set giving an ORA-01422.
-        -- The statement has been modified in accordance with the
-        -- descriptive specification as follows:
-        -- The row in the ORDER table with matching O_W_ID (equals C_W_ID),
-        -- O_D_ID (equals C_D_ID), O_C_ID (equals C_ID), and with the largest
-        -- existing O_ID, is selected. This is the most recent order placed by that
-        -- customer. O_ID, O_ENTRY_D, and O_CARRIER_ID are retrieved.
         BEGIN
         SELECT o_id, o_carrier_id, o_entry_d
         INTO os_o_id, os_o_carrier_id, os_entdate

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -500,7 +500,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 stock_dist_array	CHAR(24)[];
                 s_quantity_array	SMALLINT[];
                 price_array			NUMERIC(5,2)[];
-                amount_array		NUMERIC(5,2)[];
+                amount_array		NUMERIC(6,2)[];
                 BEGIN
                 no_o_all_local := 1;
                 SELECT c_discount, c_last, c_credit, w_tax
@@ -554,7 +554,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -569,7 +569,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -584,7 +584,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -599,7 +599,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -614,7 +614,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -629,7 +629,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -644,7 +644,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -659,7 +659,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -674,7 +674,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -689,7 +689,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1037,7 +1037,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 stock_dist_array	CHAR(24)[];
                 s_quantity_array	SMALLINT[];
                 price_array			NUMERIC(5,2)[];
-                amount_array		NUMERIC(5,2)[];
+                amount_array		NUMERIC(6,2)[];
                 BEGIN
                 no_o_all_local := 1;
                 SELECT c_discount, c_last, c_credit, w_tax
@@ -1091,7 +1091,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1106,7 +1106,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1121,7 +1121,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1136,7 +1136,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1151,7 +1151,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1166,7 +1166,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1181,7 +1181,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1196,7 +1196,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1211,7 +1211,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1226,7 +1226,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update


### PR DESCRIPTION
PR fixes the arithmetic in the PostgreSQL TPROC-C stock update. Tested without impact on performance. 
Also remove stale/misleading comments from Oracle stored procedures as the HammerDB implementation was originally written from the example code rather than the text description in the specification and some of the details diverge between the examples and description. Intention is not to implement any changes that break backward compatibility in performance results.