### PR TITLE
Bump Version and ChangeLog for HammerDB 6.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1185,3 +1185,50 @@ expect 5.45.4.1 mariatcl 0.1.1 mysqltcl 3.052.1 oratcl 4.6.1 pgtcl 2.1.1.1
 tclpy 0.4.1 tclpyS 0.4.1 ticklecharts 3.1 tkblt 3.2.24 tkpath 0.3.3.1 twapi 5.0.7
 
 for Linux x86-64 and Windows x64
+
+---------------------------------------------------------------------
+
+Version 6.0 June 2026
+
+Pull Requests & Issues
+
+Add database metrics options for MySQL and MariaDB #885
+Fix Web Service Jobs and Pipelines HTML Formatting #884
+Add I/O Metrics (IOPS/MB/s) to Metrics #880 (#874)
+Fix arithmetic in PostgreSQL stock update #879
+Fix profile compare form and hide unsupported from automation #878
+Fix form warnings for proxy #877
+Add CI/Pipeline Automation for MySQL #876 (#872)
+Add PostgreSQL CI/Pipeline automation #875 (#871)
+Fix pgsentinel discovery for PostgreSQL metrics #870 (#869)
+Improve performance profile comparison, response time reporting, and CI bug fixes #868
+Auto fix PostgreSQL choice of functions or stored procedures #867 (#832)
+Fix Windows clearline in default COLOR #866 (#779)
+Standardise Cluster Connect Pool terminology #865 (#828)
+Add reservoir sampling, extended percentile support to timing profiles and boxplots #864 (#831)
+Add Active Session History (ASH) metrics viewer for MySQL and MariaDB #863 (#842)
+Remove arbitrary upper limit on num_vu for schema build #861
+Add CI/Pipeline capabilities for MariaDB #860 (#845)
+Add Detailed System, Hardware, and Software Fields to Results #859 (#848)
+pg_vacuum runs on wrong database #856 (#855)
+Update ASH metrics for PostgreSQL 18 #854 (#841)
+Update TPROC-H GUI Options for all Scale Factors #835 (#833)
+Improve message if metstart fails because sysstat not installed #830 (#820)
+Add engine independent statistics to MariaDB TPROC-H #829 (#827)
+Disable FK checks for MariaDB/MySQL pre-created database builds #825 (#824)
+Fix invalid command wapp-url #818 (#816)
+Update Tcl/Tk and TkPath versions #810 (#809)
+Enable Web Service to run as SCGI application #808 (#807)
+Update ticklecharts package #805
+Add handling of innodb_snapshot_isolation to MariaDB #797 (#778)
+Add catch to CLI stty command on Linux #796 (#792)
+Fix permission denied on loading database libraries on Windows #795 (#791)
+Copyright message UTF-8 #794 (#793)
+Docker Updates related to version 5.0 #789 (#771)
+Fix steprun replica timing #787 (#782)
+
+Updated Binaries and Packages include:
+
+Tcl9.0.2 TclS9.0.2 Tk9.0.2 TkS 9.0.2 ticklecharts 3.2.8 tkpath 0.4.1
+
+for Linux x86-64 and Windows x64

--- a/agent/agent
+++ b/agent/agent
@@ -59,7 +59,7 @@ namespace import comm::*
 interp recursionlimit {} 3000
 global agentlist S iswin
 set iswin "false"
-set version 5.0
+set version 6.0
 
 if {$tcl_platform(platform) == "windows"} { 
 	package require twapi 

--- a/hammerdb
+++ b/hammerdb
@@ -28,7 +28,7 @@ exit
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v5.0"
+set hdb_version "v6.0"
 set mainGeometry +10+10
 set UserDefaultDir [ file dirname [ info script ] ]
 ::tcl::tm::path add [zipfs root]app/modules "$UserDefaultDir/modules"

--- a/hammerdbcli
+++ b/hammerdbcli
@@ -28,9 +28,9 @@ exec ./bin/tclsh9.0 "$0" ${1+"$@"}
 # License along with this program; If not, see <https://www.gnu.org/licenses/>
 ########################################################################
 global hdb_version
-set hdb_version "v5.0"
+set hdb_version "v6.0"
 puts "HammerDB CLI $hdb_version"
-puts "Copyright \u00A9 HammerDB Ltd hosted by tpc.org 2019-2025"
+puts "Copyright \u00A9 HammerDB Ltd hosted by tpc.org 2019-2026"
 if { $argc eq 0 } {
 set argv0 "" } else { set argv0 [ string tolower [lindex $argv 0 ]] }
 if { $argv0 == "" || $argv0 == "tcl" || $argv0 == "auto" } {

--- a/hammerdbws
+++ b/hammerdbws
@@ -31,10 +31,10 @@ set argv0 "wait"
 set argv0 [ string tolower [lindex $argv 0 ]] 
 }
 global hdb_version
-set hdb_version "v5.0"
+set hdb_version "v6.0"
 	if { $argv0 != "gui" } {
 puts "HammerDB Web Service $hdb_version"
-puts "Copyright \u00A9 HammerDB Ltd hosted by tpc.org 2019-2025"
+puts "Copyright \u00A9 HammerDB Ltd hosted by tpc.org 2019-2026"
 puts "Type \"help\" for a list of commands"
 	}
 set UserDefaultDir [ file dirname [ info script ] ]

--- a/src/generic/gened.tcl
+++ b/src/generic/gened.tcl
@@ -1945,14 +1945,14 @@ proc about { } {
     global hdb_version
     tk_messageBox -title About -message "HammerDB $hdb_version
 Copyright \u00A9 HammerDB Ltd
-Hosted by tpc.org 2019-2025\n"
+Hosted by tpc.org 2019-2026\n"
 }
 
 proc license { } {
     tk_messageBox -title License -message "
 This copyright notice must be included in all distributions.
 \u00A9 HammerDB Ltd
-Hosted by the TPC-Council 2019-2025
+Hosted by the TPC-Council 2019-2026
 
 This program is free software: you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation,


### PR DESCRIPTION
Update version numbers, copyright dates and Changelog for HammerDB v6.0.
Assumes following PRs wil be merged:
```
Add database metrics options for MySQL and MariaDB #885
Fix Web Service Jobs and Pipelines HTML Formatting #884
```
Also anticipating 1 additional PR to v6.0 to add glue for results submission URL - will update Changelog at same time as PR. 
Updating version numbers at this stage, close to release - assists with test builds and any additional bug fix PR after test/validation. 