### PR TITLE
Fix virtual user state across mixed automated, GUI and CLI runs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1193,6 +1193,7 @@ Version 6.0 June 2026
 Pull Requests & Issues
 
 Fix virtual user state across mixed automated, GUI and CLI runs #892
+Simplify artifact submit process #891
 Update TPROC-C automated schema sizing #889
 Add TPROC-H version and metrics to result sharing #888
 Add database metrics options for MySQL and MariaDB #885

--- a/ChangeLog
+++ b/ChangeLog
@@ -1192,6 +1192,7 @@ Version 6.0 June 2026
 
 Pull Requests & Issues
 
+Fix virtual user state across mixed automated, GUI and CLI runs #892
 Update TPROC-C automated schema sizing #889
 Add TPROC-H version and metrics to result sharing #888
 Add database metrics options for MySQL and MariaDB #885

--- a/agent/agent
+++ b/agent/agent
@@ -435,7 +435,16 @@ if { [ string match "*STOP*" $buffer ] } {
 puts "Closing HammerDB Metric Agent"
 ::Agent destroy
 exit
-}	
+}
+set display "$id $host"
+if {[llength $agentlist] > 0} {
+    puts "HammerDB Metric Agent busy: rejecting display request from $display"
+    catch {
+        Agent send $display DoDisplay 1 [ list "AGENT BUSY - STREAM IN USE" ] local
+        Agent send $display update
+    }
+    return
+}
 lappend agentlist "$id $host"
 puts "New display accepted @ $id $host"
 #Start Gathering and Sending Metrics

--- a/agent/agent
+++ b/agent/agent
@@ -220,13 +220,38 @@ return $sysinfo
 
 proc DetectCloudInstance {} {
 #Detect cloud environment by checking metadata services
-#AWS
+#AWS - IMDSv2
 if { [catch {
     package require http
-    set tok [::http::geturl "http://169.254.169.254/latest/meta-data/instance-type" -timeout 1000]
-    set itype [::http::data $tok]
+    set tok [::http::geturl "http://169.254.169.254/latest/api/token" \
+        -method PUT \
+        -timeout 500 \
+        -headers [list X-aws-ec2-metadata-token-ttl-seconds 60]]
+    set token [string trim [::http::data $tok]]
+    set code [::http::ncode $tok]
     ::http::cleanup $tok
-    if { $itype ne "" } { return "AWS $itype" }
+    if { $code eq "200" && $token ne "" } {
+        set tok [::http::geturl "http://169.254.169.254/latest/meta-data/instance-type" \
+            -timeout 500 \
+            -headers [list X-aws-ec2-metadata-token $token]]
+        set itype [string trim [::http::data $tok]]
+        set code [::http::ncode $tok]
+        ::http::cleanup $tok
+        if { $code eq "200" && $itype ne "" } {
+            return "AWS $itype"
+        }
+    }
+} err] } { ; }
+#AWS - IMDSv1 fallback
+if { [catch {
+    package require http
+    set tok [::http::geturl "http://169.254.169.254/latest/meta-data/instance-type" -timeout 500]
+    set itype [string trim [::http::data $tok]]
+    set code [::http::ncode $tok]
+    ::http::cleanup $tok
+    if { $code eq "200" && $itype ne "" } {
+        return "AWS $itype"
+    }
 } err] } { ; }
 #Azure
 if { [catch {

--- a/src/generic/genci.tcl
+++ b/src/generic/genci.tcl
@@ -914,6 +914,11 @@ proc cilisten {args} {
         }
     }
 
+    # Enable temp logging here so the web log tail receives all VU output
+    catch {
+        vuset logtotemp 1
+    }
+
     if {[catch {
         set ci_optlog [dict get $cidict common ci_log_to_temp]
     }]} {

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -444,6 +444,9 @@ proc ed_kill_metrics {args} {
         interp delete metrics_interp
     }
     catch { DisplayMetrics destroy } 
+    catch { destroy .ed_mainFrame.me }
+    frame .ed_mainFrame.me
+    .ed_mainFrame.notebook insert 3 .ed_mainFrame.me -text "Metrics"
     if ![ string match "*.ed_mainFrame.me*" [ .ed_mainFrame.notebook tabs ]] {
         #transaction counter has been detached so reattach before disabling
         Attach .ed_mainFrame.notebook .ed_mainFrame.me 3
@@ -460,6 +463,9 @@ proc ed_kill_cpu_metrics {args} {
             interp delete metrics_interp
         }
         catch { DisplayMetrics destroy } 
+        catch { destroy .ed_mainFrame.me }
+        frame .ed_mainFrame.me
+        .ed_mainFrame.notebook insert 3 .ed_mainFrame.me -text "Metrics"
     } else {
         ed_status_message -show "... Stopping Metrics ..."
         ed_metrics_button
@@ -467,6 +473,9 @@ proc ed_kill_cpu_metrics {args} {
             interp delete metrics_interp
         }
         catch { DisplayMetrics destroy } 
+        catch { destroy .ed_mainFrame.me }
+        frame .ed_mainFrame.me
+        .ed_mainFrame.notebook insert 3 .ed_mainFrame.me -text "Metrics"
         if ![ string match "*.ed_mainFrame.me*" [ .ed_mainFrame.notebook tabs ]] {
             #transaction counter has been detached so reattach before disabling
             Attach .ed_mainFrame.notebook .ed_mainFrame.me 3

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -514,7 +514,7 @@ return
   }}
   if { $start_display } {
   after 500 {metrics}
-  tk_messageBox -message "Starting Metrics Agent and Display on [ info hostname ]"
+  puts "Starting Metrics Agent and Display on [ info hostname ]"
   catch "destroy .metric"
   } else {
   tk_messageBox -message "Starting Metrics Agent on [ info hostname ]"

--- a/src/generic/genvu.tcl
+++ b/src/generic/genvu.tcl
@@ -141,7 +141,7 @@ proc stacktrace {} {
 }
 
 proc load_virtual {}  {
-    global _ED ed_loadsave argv argv0 argc embed_args threadscreated threadsbytid masterthread maxvuser virtual_users lprefix winterps suppo optlog table Parent ntimes tids tc_threadID dbmon_threadID opmode vuser_create_ok rdbms bm
+    global _ED ed_loadsave argv argv0 argc embed_args threadscreated threadsbytid masterthread maxvuser virtual_users lprefix winterps suppo optlog table Parent ntimes tids tc_threadID dbmon_threadID opmode vuser_create_ok rdbms bm apmode
     set vuser_create_ok true
     set thlist [ thread::names ]
     if { [ info exists tc_threadID ] } {
@@ -152,7 +152,8 @@ proc load_virtual {}  {
     }
     #Additional thread for Database Metrics initially Oracle only
     #Additional thread for Database Metrics PostgreSQL added
-    if { $rdbms eq "Oracle" || $rdbms eq "PostgreSQL" } {
+    #Additional thread for Database Metrics MySQL and MariaDB added
+    if { $rdbms eq "Oracle" || $rdbms eq "PostgreSQL" || $rdbms eq "MySQL" || $rdbms eq "MariaDB" } {
         if { [ info exists dbmon_threadID ] } {
             if { [ thread::exists $dbmon_threadID ] || [ tsv::get application themonitor ] eq "NOWVUSER" } {
                 set idx [ lsearch $thlist $dbmon_threadID ]
@@ -217,6 +218,16 @@ proc load_virtual {}  {
     if { [ info exists suppo ] } { ; } else { set suppo 0 }
     if { [ info exists optlog ] } { ; } else { set optlog 0 }
     if { [ info exists ntimes ] && $ntimes > 1 } { ; } else { set ntimes 1 }
+    # In the GUI, a normal Create Virtual Users should not inherit a profile id
+    # from a previous autopilot/profile run. Autopilot manages profile ids itself.
+    upvar #0 genericdict genericdict
+    upvar #0 icons icons
+    if { ![ info exists apmode ] } { set apmode "disabled" }
+    if { [ info exists icons ] && $apmode eq "disabled" } {
+        catch {
+            dict set genericdict commandline jobs_profile_id 0
+        }
+    }
     #For web version build_schema is not at the end of the stacktrace, modified to find build anywhere in trace
     set result [ lsearch [ lindex [ split [ join [ stacktrace ] ] ] ] "build_schema" ]
     if { $result != -1 }  {
@@ -375,7 +386,7 @@ proc load_virtual {}  {
         if { [ info exists tc_threadID ] } { 
             if { $threadID eq $tc_threadID } { unset -nocomplain tc_threadID }
         }
-        if { ($rdbms eq "Oracle" || $rdbms eq "PostgreSQL") && [ info exists dbmon_threadID ] } { 
+        if { ($rdbms eq "Oracle" || $rdbms eq "PostgreSQL" || $rdbms eq "MySQL" || $rdbms eq "MariaDB") && [ info exists dbmon_threadID ] } { 
             if { $threadID eq $dbmon_threadID } { 
                 tsv::set application themonitor "NOWVUSER"
                 unset -nocomplain dbmon_threadID
@@ -490,7 +501,7 @@ proc load_virtual {}  {
     }
     configtable 
     if { $optlog == 1 } {
-        global flog opmode apmode unique_log_name no_log_buffer log_timestamps
+        global flog opmode unique_log_name no_log_buffer log_timestamps
         if { [ info exists opmode ] } { ; } else { set opmode "Local" }
         if { [ info exists apmode ] } { ; } else { set apmode "disabled" }
         if { [ info exists unique_log_name ] } { ; } else { set unique_log_name 0 }
@@ -514,19 +525,11 @@ proc load_virtual {}  {
                 puts $flog "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-"
             }
             if { $opmode != "Replica" } {
-                if { $apmode eq "disabled" } {
-                    tk_messageBox -title "Logging Active" -message "Logging activated\nto $filename"
-                } else {
                     puts "Logging activated to $filename"
-                }
             }
         } else {
             if { $opmode != "Replica" } {
-                if { $apmode eq "disabled" } {
-                    tk_messageBox -icon error -message "Could not create Logfile"
-                } else {
                     puts "Could not create Logfile"
-                }
             }
         }
     }


### PR DESCRIPTION
Testing mixed environments from automated web driven workloads then GUI and vice versa allows state to become mixed and require resetting. Not functional errors but improve UX. 
- Enables logtotemp in the CI listener so browser/webhook-dispatched jobs produce output in the web log tail.
- Removes the blocking GUI tk_messageBox when virtual-user logging is enabled, replacing it with console output.
- Adds MySQL and MariaDB to the database metrics-thread exclusion logic, so dbmon threads are not mistaken for active virtual users.
- Clears stale jobs_profile_id during normal GUI Create Virtual Users when autopilot is disabled, preventing a previous profile/autopilot run from being used in a single GUI run which will not be part of profile.