### PR TITLE
Fix SQL Server GUI Scale Factor Option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1192,6 +1192,7 @@ Version 6.0 June 2026
 
 Pull Requests & Issues
 
+Fix SQL Server GUI Scale Factor Option #894
 Fix AWS cloud metadata detection #893
 Fix virtual user state across mixed automated, GUI and CLI runs #892
 Simplify artifact submit process #891

--- a/src/mssqlserver/mssqlsopt.tcl
+++ b/src/mssqlserver/mssqlsopt.tcl
@@ -929,7 +929,7 @@ proc configmssqlstpch {option} {
         foreach item {1} {
             set Name $Parent.f1.f2.r$rcnt
             set width [string length $item]
-            ttk::radiobutton $Name -variable db2_scale_fact -text $item -value $item -width $width
+            ttk::radiobutton $Name -variable mssqls_scale_fact -text $item -value $item -width $width
             grid $Name -column $rcnt -row 0 -sticky w
             incr rcnt
         }
@@ -937,7 +937,7 @@ proc configmssqlstpch {option} {
         foreach item {10 30} {
             set Name $Parent.f1.f2.r$rcnt
             set width [string length $item]
-            ttk::radiobutton $Name -variable db2_scale_fact -text $item -value $item -width $width
+            ttk::radiobutton $Name -variable mssqls_scale_fact -text $item -value $item -width $width
             grid $Name -column $rcnt -row 0 -sticky w
             incr rcnt
         }
@@ -945,7 +945,7 @@ proc configmssqlstpch {option} {
         foreach item {100 300} {
             set Name $Parent.f1.f2.r$rcnt
             set width [string length $item]
-            ttk::radiobutton $Name -variable db2_scale_fact -text $item -value $item -width $width
+            ttk::radiobutton $Name -variable mssqls_scale_fact -text $item -value $item -width $width
             grid $Name -column $rcnt -row 0 -sticky w
             incr rcnt
         }
@@ -954,7 +954,7 @@ proc configmssqlstpch {option} {
         foreach item {1000 3000} {
             set Name $Parent.f1.f2.ra$rcnt
             set width [string length $item]
-            ttk::radiobutton $Name -variable db2_scale_fact -text $item -value $item -width $width
+            ttk::radiobutton $Name -variable mssqls_scale_fact -text $item -value $item -width $width
             grid $Name -column $rcnt -row 1 -sticky w
             incr rcnt
         }
@@ -962,7 +962,7 @@ proc configmssqlstpch {option} {
         foreach item {10000 30000 100000} {
             set Name $Parent.f1.f2.ra$rcnt
             set width [string length $item]
-            ttk::radiobutton $Name -variable db2_scale_fact -text $item -value $item -width $width
+            ttk::radiobutton $Name -variable mssqls_scale_fact -text $item -value $item -width $width
             grid $Name -column $rcnt -row 1 -sticky w
             incr rcnt
         }


### PR DESCRIPTION
Bug Introduced with PR #835  “Update TPROC-H GUI Options for all Scale Factors”.
Before PR SQL Server TPROC-H used the correct variable:
-variable mssqls_scale_fact
in the scale factor radio buttons.
After the PR merge commit, the same SQL Server dialog had been changed to:
-variable db2_scale_fact
Result is that SQL Server GUI Scale Factor dialog always reverts back to 1.
Fix restores correct behaviour. 