### PR TITLE
Fix NULL Oracle Version reported for TPROC-H

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1192,6 +1192,7 @@ Version 6.0 June 2026
 
 Pull Requests & Issues
 
+Fix NULL Oracle Version reported for TPROC-H #897
 Fix SQL Server GUI Scale Factor Option #894
 Fix AWS cloud metadata detection #893
 Fix virtual user state across mixed automated, GUI and CLI runs #892

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1424,7 +1424,7 @@ proc sub_query { query_no scale_factor myposition timesten } {
 }
 proc CheckDBVersion { curn } {
 set dbversion ""
-    if {[catch {orasql $curn {select version from v$instance}}]} {
+    if {[catch {orasql $curn {SELECT version FROM PRODUCT_COMPONENT_VERSION WHERE product LIKE 'Oracle Database%'}}]} {
 	    set dbversion "DBVersion:NULL"
     } else {
         orafetch  $curn -datavariable output


### PR DESCRIPTION
The query used to select the Oracle version number for TPROC-C does not work for TPROC-H as the user does not have the correct privileges. Changed SQL for a query that works for a user without system privileges. TPROC-C can remain unmodified as it is system user running the query.