### PR TITLE
Fix MySQL and MariaDB ASH completed wait attribution (#905)

### DIFF
--- a/src/mariadb/mariamet.tcl
+++ b/src/mariadb/mariamet.tcl
@@ -1546,7 +1546,7 @@ namespace eval mariamet {
                     { #FFD700 gold }
                     { #E46800 orange }
                     { #4080F0 light_blue }
-                    { #004AE7 blue }
+                    { #00CC00 green }
                     { #00FF00 bright_green }
                     { #00CC00 green }
                     { #FFFFFF black }

--- a/src/mariadb/mariamet.tcl
+++ b/src/mariadb/mariamet.tcl
@@ -1546,7 +1546,6 @@ namespace eval mariamet {
                     { #FFD700 gold }
                     { #E46800 orange }
                     { #4080F0 light_blue }
-                    { #00CC00 green }
                     { #00FF00 bright_green }
                     { #00CC00 green }
                     { #FFFFFF black }

--- a/src/mariadb/mariamet.tcl
+++ b/src/mariadb/mariamet.tcl
@@ -2099,7 +2099,7 @@ namespace eval mariamet {
                                   s.DIGEST
                                 FROM performance_schema.threads t
                                 LEFT JOIN performance_schema.events_waits_current w
-                                  ON t.THREAD_ID = w.THREAD_ID AND w.EVENT_NAME != 'idle'
+                                  ON t.THREAD_ID = w.THREAD_ID AND w.EVENT_NAME != 'idle' AND w.END_EVENT_ID IS NULL
                                 LEFT JOIN performance_schema.events_statements_current s
                                   ON t.THREAD_ID = s.THREAD_ID
                                 WHERE t.TYPE = 'FOREGROUND'

--- a/src/mysql/mysqlmet.tcl
+++ b/src/mysql/mysqlmet.tcl
@@ -1545,7 +1545,6 @@ namespace eval mysqlmet {
                     { #FFD700 gold }
                     { #E46800 orange }
                     { #4080F0 light_blue }
-                    { #00CC00 green }
                     { #00FF00 bright_green }
                     { #00CC00 green }
                     { #FFFFFF black }

--- a/src/mysql/mysqlmet.tcl
+++ b/src/mysql/mysqlmet.tcl
@@ -2098,7 +2098,7 @@ namespace eval mysqlmet {
                                   s.DIGEST
                                 FROM performance_schema.threads t
                                 LEFT JOIN performance_schema.events_waits_current w
-                                  ON t.THREAD_ID = w.THREAD_ID AND w.EVENT_NAME != 'idle'
+                                  ON t.THREAD_ID = w.THREAD_ID AND w.EVENT_NAME != 'idle' AND w.END_EVENT_ID IS NULL
                                 LEFT JOIN performance_schema.events_statements_current s
                                   ON t.THREAD_ID = s.THREAD_ID
                                 WHERE t.TYPE = 'FOREGROUND'

--- a/src/mysql/mysqlmet.tcl
+++ b/src/mysql/mysqlmet.tcl
@@ -1545,7 +1545,7 @@ namespace eval mysqlmet {
                     { #FFD700 gold }
                     { #E46800 orange }
                     { #4080F0 light_blue }
-                    { #004AE7 blue }
+                    { #00CC00 green }
                     { #00FF00 bright_green }
                     { #00CC00 green }
                     { #FFFFFF black }


### PR DESCRIPTION
MySQL and MariaDB ASH was incorrectly sampling the last completed wait event as current. 
Pull request fixes issue so only current wait events are sampled. 

<img width="1181" height="1051" alt="mariadb_ash2" src="https://github.com/user-attachments/assets/58af756a-10d9-4eca-94c1-3497e45156ea" />
