### PR TITLE
Update pgtcl to 2.1.1.2

### DIFF
--- a/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Linux.bawt
@@ -7,17 +7,17 @@ Setup TclS               Tcl-[GetTclVersion].7z         TclS.bawt
 Setup Tk                 Tk-[GetTkVersion].7z           Tk.bawt
 Setup TkS                Tk-[GetTkVersion].7z           TkS.bawt
 # Compiled Tcl packages.
-Setup expect             expect-5.45.4.1.7z             expect.bawt	
+Setup expect             expect-5.45.4.1.7z             expect.bawt
 Setup tkpath             tkpath-0.4.1.7z                tkpath.bawt
 Setup tkblt              tkblt-3.2.24.7z                tkblt.bawt
 Setup tclpy              tclpy-0.4.1.7z                 tclpy.bawt
 Setup tclpyS             tclpyS-0.4.1.7z                tclpyS.bawt
 # Compiled Tcl Database interface packages.
-Setup oratcl             oratcl-4.6.1.7z                oratcl.bawt	
-Setup mariatcl           mariatcl-0.1.1.7z            mariatcl.bawt	
-Setup mysqltcl           mysqltcl-3.052.1.7z            mysqltcl.bawt	
-Setup db2tcl             db2tcl-2.0.1.1.7z              db2tcl.bawt	
-Setup pgtcl              pgtcl-2.1.1.1.7z               pgtcl.bawt	
+Setup oratcl             oratcl-4.6.1.7z                oratcl.bawt
+Setup mariatcl           mariatcl-0.1.1.7z            mariatcl.bawt
+Setup mysqltcl           mysqltcl-3.052.1.7z            mysqltcl.bawt
+Setup db2tcl             db2tcl-2.0.1.1.7z              db2tcl.bawt
+Setup pgtcl              pgtcl-2.1.1.2.7z               pgtcl.bawt
 # Pure Tcl/Tk packages.
 Setup awthemes           awthemes-10.4.0.7z             awthemes.bawt
 Setup ticklecharts	     ticklecharts-3.2.8.7z	        ticklecharts.bawt

--- a/Build/Bawt-2.1.0/Setup/HammerDB-LinuxArm64.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-LinuxArm64.bawt
@@ -7,17 +7,17 @@ Setup TclS               Tcl-[GetTclVersion].7z         TclS.bawt
 Setup Tk                 Tk-[GetTkVersion].7z           Tk.bawt
 Setup TkS                Tk-[GetTkVersion].7z           TkS.bawt
 # Compiled Tcl packages.
-Setup expect             expect-5.45.4.1.7z             expect.bawt	
+Setup expect             expect-5.45.4.1.7z             expect.bawt
 Setup tkpath             tkpath-0.4.1.7z                tkpath.bawt
 Setup tkblt              tkblt-3.2.24.7z                tkblt.bawt
 Setup tclpy              tclpy-0.4.1.7z                 tclpy.bawt
 Setup tclpyS             tclpyS-0.4.1.7z                tclpyS.bawt
 # Compiled Tcl Database interface packages.
-Setup oratcl             oratcl-4.6.1.7z                oratcl.bawt	
-Setup mariatcl           mariatcl-0.1.1.7z            mariatcl.bawt	
-Setup mysqltcl           mysqltcl-3.052.1.7z            mysqltcl.bawt	
-#Setup db2tcl             db2tcl-2.0.1.1.7z              db2tcl.bawt	
-Setup pgtcl              pgtcl-2.1.1.1.7z               pgtcl.bawt	
+Setup oratcl             oratcl-4.6.1.7z                oratcl.bawt
+Setup mariatcl           mariatcl-0.1.1.7z            mariatcl.bawt
+Setup mysqltcl           mysqltcl-3.052.1.7z            mysqltcl.bawt
+#Setup db2tcl             db2tcl-2.0.1.1.7z              db2tcl.bawt
+Setup pgtcl              pgtcl-2.1.1.2.7z               pgtcl.bawt
 # Pure Tcl/Tk packages.
 Setup awthemes           awthemes-10.4.0.7z             awthemes.bawt
 Setup ticklecharts	     ticklecharts-3.2.8.7z	        ticklecharts.bawt

--- a/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
+++ b/Build/Bawt-2.1.0/Setup/HammerDB-Windows.bawt
@@ -19,10 +19,10 @@ Setup tkblt             tkblt-3.2.24.7z                tkblt.bawt
 Setup tclpy             tclpy-0.4.1.7z                 tclpy_NMake.bawt
 Setup tclpyS            tclpyS-0.4.1.7z                tclpyS_NMake.bawt
 # Compiled Tcl Database interface packages.
-Setup oratcl            oratcl-4.6.1.7z                 oratcl_NMake.bawt	
+Setup oratcl            oratcl-4.6.1.7z                 oratcl_NMake.bawt
 Setup mariatcl          mariatcl-0.1.1.7z             mariatcl_NMake.bawt
 Setup mysqltcl          mysqltcl-3.052.1.7z             mysqltcl_NMake.bawt
-Setup pgtcl             pgtcl-2.1.1.1.7z                pgtcl_NMake.bawt	
+Setup pgtcl             pgtcl-2.1.1.2.7z                pgtcl_NMake.bawt
 Setup db2tcl            db2tcl-2.0.1.1.7z               db2tcl_NMake.bawt
 # Compiled Tcl packages.
 # Pure Tcl/Tk packages.


### PR DESCRIPTION
Update the HammerDB BAWT source build to use pgtcl 2.1.1.2 on Linux, Linux ARM64 and Windows.

pgtcl 2.1.1.2 includes the fd-reuse race fix from sm-shaw/pgtclng#1 together with the additional Windows socket integration change.

The pgtcl 2.1.1.2 source package, hash and modification timestamp have been published to the HammerDB build5 repository.

Tested successfully with BAWT builds and PostgreSQL TPROC-C workloads on Windows and Linux x64. The resulting HammerDB build reports Pgtcl 2.1.1.2.