### PR TITLE
Fix JOBTIMING upgrade and TPROC-H timing message (#916)

### DIFF
--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -63,6 +63,24 @@ namespace eval jobs {
     return [list $outerTag [list $tag $newPairs]]
 }
 
+  proc upgrade_job_timing { sqlite_db } {
+    if { [catch {
+        set timingcol_p75 [hdbjobs eval {SELECT COUNT(*) FROM pragma_table_info('JOBTIMING') WHERE name='p75_ms'}]
+        if { $timingcol_p75 eq 0 } {
+            hdbjobs eval {ALTER TABLE JOBTIMING ADD COLUMN p75_ms REAL}
+        }
+        set timingcol_p25 [hdbjobs eval {SELECT COUNT(*) FROM pragma_table_info('JOBTIMING') WHERE name='p25_ms'}]
+        if { $timingcol_p25 eq 0 } {
+            hdbjobs eval {ALTER TABLE JOBTIMING ADD COLUMN p25_ms REAL}
+        }
+        if { $timingcol_p75 eq 0 || $timingcol_p25 eq 0 } {
+            puts "Upgraded database $sqlite_db JOBTIMING table with percentile fields"
+        }
+    } message] } {
+        puts "Error upgrading JOBTIMING table with percentile fields: $message"
+    }
+  }
+
   proc init_job_tables { } {
     upvar #0 genericdict genericdict
     if {[dict exists $genericdict commandline jobs_disable ]} {
@@ -223,6 +241,7 @@ namespace eval jobs {
            } message] } {
                puts "Error upgrading JOBMETRIC table with I/O fields: $message"
            }
+           upgrade_job_timing $sqlite_db
 	   }}}}
       tsv::set commandline sqldb $sqlite_db
     }
@@ -258,6 +277,7 @@ namespace eval jobs {
           exit
 	  }
       } else {
+         upgrade_job_timing $sqlite_db
          puts "Web Service using $sqlite_db database"
        }
     }
@@ -4720,6 +4740,18 @@ proc getjob { query } {
 
         # jobid + timing  (SUMMARY across VUs)
         if {[dict exists $paramdict timing]} {
+            set jobbm [join [hdbjobs eval {SELECT bm FROM JOBMAIN WHERE JOBID=$jobid}]]
+            if {$jobbm eq "TPC-H"} {
+                set timingmessage "Percentile timing data is not applicable to TPROC-H"
+                if {[string equal -nocase $outputformat "JSON"]} {
+                    set timingresponse [dict create jobid $jobid message $timingmessage]
+                    set huddleobj [huddle compile {dict * string} $timingresponse]
+                    puts [huddle jsondump $huddleobj]
+                } else {
+                    puts $timingmessage
+                }
+                return
+            }
             set jobtiming [getjobtiming $jobid]
             set huddleobj [huddle compile {dict * dict} $jobtiming]
             if {[string equal -nocase $outputformat "JSON"]} {

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -3528,7 +3528,20 @@ if {$rawmode} {
   proc getjobtiming { jobid } {
     set jobtiming [ dict create ]
     hdbjobs eval {SELECT procname,elapsed_ms,calls,min_ms,avg_ms,max_ms,total_ms,p99_ms,p95_ms,p75_ms,p50_ms,p25_ms,sd,ratio_pct FROM JOBTIMING WHERE JOBID=$jobid and SUMMARY=1 ORDER BY RATIO_PCT DESC}  {
-    set timing "elapsed_ms $elapsed_ms calls $calls min_ms $min_ms avg_ms $avg_ms max_ms $max_ms total_ms $total_ms p99_ms $p99_ms p95_ms $p95_ms p75_ms $p75_ms p50_ms $p50_ms p25_ms $p25_ms sd $sd ratio_pct $ratio_pct"
+    set timing [list \
+    elapsed_ms $elapsed_ms \
+    calls $calls \
+    min_ms $min_ms \
+    avg_ms $avg_ms \
+    max_ms $max_ms \
+    total_ms $total_ms \
+    p99_ms $p99_ms \
+    p95_ms $p95_ms \
+    p75_ms $p75_ms \
+    p50_ms $p50_ms \
+    p25_ms $p25_ms \
+    sd $sd \
+    ratio_pct $ratio_pct]
       dict append jobtiming $procname $timing
     }
     if { [ dict size $jobtiming ] eq 0 } {
@@ -4547,7 +4560,20 @@ proc getjob { query } {
                 WHERE JOBID=$jobid AND VU=$vuid AND SUMMARY=0
                 ORDER BY RATIO_PCT DESC
             } {
-                set timing "elapsed_ms $elapsed_ms calls $calls min_ms $min_ms avg_ms $avg_ms max_ms $max_ms total_ms $total_ms p99_ms $p99_ms p95_ms $p95_ms p75_ms $p75_ms p50_ms $p50_ms p25_ms $p25_ms sd $sd ratio_pct $ratio_pct"
+                set timing [list \
+    elapsed_ms $elapsed_ms \
+    calls $calls \
+    min_ms $min_ms \
+    avg_ms $avg_ms \
+    max_ms $max_ms \
+    total_ms $total_ms \
+    p99_ms $p99_ms \
+    p95_ms $p95_ms \
+    p75_ms $p75_ms \
+    p50_ms $p50_ms \
+    p25_ms $p25_ms \
+    sd $sd \
+    ratio_pct $ratio_pct]
                 dict append jobtiming $procname $timing
             }
 


### PR DESCRIPTION
Fixes #916.

HammerDB v6.0 adds `p75_ms` and `p25_ms` to `JOBTIMING`, but an existing v5.0 jobs database was not upgraded to add these columns.

This change:

- Upgrades existing `JOBTIMING` tables by adding `p75_ms` and `p25_ms` where missing.
- Preserves existing v5.0 jobs and timing data.
- Preserves empty percentile values correctly when reading upgraded historical timing rows.
- Returns a clearer message when percentile timing is requested for TPROC-H, where percentile transaction timing is not applicable.

### Testing

Tested with the official HammerDB v5.0 Ubuntu 24 Prod package and a newly Bawt-built HammerDB v6.0 Prod package.

A genuine v5.0 on-disk `hammer.DB` was created with existing TPROC-C and TPROC-H jobs and v5.0-format `JOBTIMING` rows.

Verified after opening the same database with the updated v6.0 Prod build:

- `p75_ms` and `p25_ms` were added automatically.
- Existing jobs and timing data were preserved.
- Summary TPROC-C timing returned valid JSON with empty historical `p75_ms` and `p25_ms` values.
- Per-VU TPROC-C timing returned valid JSON with the same preserved values.
- TPROC-H timing returned `Percentile timing data is not applicable to TPROC-H`.